### PR TITLE
Fix minor breakage when building gui

### DIFF
--- a/src/gui/gui.pro.in
+++ b/src/gui/gui.pro.in
@@ -6,7 +6,7 @@
 oa_targetdir = @top_builddir@/@target@
 
 OA_INC = $${oa_targetdir}/include
-OA_LIB = -L@top_builddir@/@target@/lib -lOpenAxiom
+OA_LIB = -L@top_builddir@/@target@/lib -lOpenAxiom -lopen-axiom-core
 
 ## We build in release mode.
 CONFIG += release


### PR DESCRIPTION
Added -lopen-axiom-core when building open-axiom driver in src/gui.