### PR TITLE
Fix inverted arguments in call to `memset`.

### DIFF
--- a/src/utils/storage.cxx
+++ b/src/utils/storage.cxx
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2013, Gabriel Dos Reis.
+// Copyright (C) 2010-2022, Gabriel Dos Reis.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -111,7 +111,7 @@ namespace OpenAxiom {
          Pointer p = os_allocate_read_write_raw_memory(nbytes);
          if (p == nullptr)
             throw SystemError("cannot acquire more memory");
-         return memset(p, nbytes, 0);
+         return memset(p, 0, nbytes);
       }
 
       void


### PR DESCRIPTION
Mistake caught by GCC-11:

```
 /home/gdr/open-axiom.git/src/lib/../utils/storage.cxx:114:23: warning: 'memset' used with constant zero length parameter; this could be due to transposed parameters [-Wmemset-transposed-args]
  114 |          return memset(p, nbytes, 0);
      |                 ~~~~~~^~~~~~~~~~~~~~
```