### PR TITLE
Use C++ concepts in lieu of SFINAE.

### DIFF
--- a/src/include/open-axiom/Charset
+++ b/src/include/open-axiom/Charset
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Copyright (C) 2013, Gabriel Dos Reis.
+// Copyright (C) 2013-2022, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -34,15 +34,15 @@
 #ifndef OPENAXIOM_CHARSET_included
 #define OPENAXIOM_CHARSET_included
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace OpenAxiom {
    // Code point value of a UCS member.
-   using Codepoint = uint32_t;
+   using Codepoint = std::uint32_t;
 
    // Unicode character type.
    enum class Character : Codepoint {
-      NUL = Codepoint()         // The NUL character 
+      NUL = Codepoint{}          // The NUL character 
    };
 }
 

--- a/src/include/open-axiom/string-pool
+++ b/src/include/open-axiom/string-pool
@@ -80,7 +80,7 @@ namespace OpenAxiom {
       const Byte* make_copy(const Byte*, size_t);
    };
 
-   typedef const StringPool::EntryType* InternedString;
+   using InternedString = const StringPool::EntryType*;
 }
 
 #endif  // OPENAXIOM_STRING_POOL_INCLUDED

--- a/src/include/open-axiom/token
+++ b/src/include/open-axiom/token
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Copyright (C) 2013-2017, Gabriel Dos Reis.
+// Copyright (C) 2013-2022, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -34,7 +34,7 @@
 #ifndef OPENAXIOM_TOKEN_included
 #define OPENAXIOM_TOKEN_included
 
-#include <stdint.h>
+#include <cstdint>
 #include <stack>
 #include <iosfwd>
 #include <open-axiom/dialect>
@@ -42,7 +42,7 @@
 
 namespace OpenAxiom {
    // Categorization of Boot and Spad tokens.
-   enum class TokenCategory : uint8_t {
+   enum class TokenCategory : std::uint8_t {
       Unclassified,             // token of unknown class
       Whitespace,               // sequence of white-space characters
       Comment,                  // a description of an ignorable comment
@@ -61,7 +61,7 @@ namespace OpenAxiom {
    std::ostream& operator<<(std::ostream&, TokenCategory);
 
    // The abstract value associated with a token.
-   enum class TokenValue : uint8_t {
+   enum class TokenValue : std::uint8_t {
 #undef OPENAXIOM_DEFINE_TOKEN
 #define OPENAXIOM_DEFINE_TOKEN(T, ...)  T,
 #include <open-axiom/token-value>
@@ -73,14 +73,14 @@ namespace OpenAxiom {
    std::ostream& operator<<(std::ostream&, TokenValue);
 
 
-   enum class TokenIndex : uint32_t { };
+   enum class TokenIndex : std::uint32_t { };
 
    constexpr TokenValue value(TokenIndex t) {
-      return TokenValue((uint32_t(t) & 0xFF000000) >> 24);
+      return TokenValue((std::uint32_t(t) & 0xFF000000) >> 24);
    }
 
-   constexpr uint32_t index(TokenIndex t) {
-      return uint32_t(t) & 0x00FFFFFF;
+   constexpr std::uint32_t index(TokenIndex t) {
+      return std::uint32_t(t) & 0x00FFFFFF;
    }
 
    // Program text region, with a fragment.
@@ -146,7 +146,7 @@ namespace OpenAxiom {
       Tok finish(Tok&, Language);
    };
 
-   bool separator_or_punctuator(uint8_t);
+   bool separator_or_punctuator(std::uint8_t);
 
    template<typename T>
    inline void comment_token(T& t, TokenValue v) {
@@ -271,7 +271,7 @@ namespace OpenAxiom {
    }
 
    inline bool
-   identifier_head(uint8_t c) {
+   identifier_head(std::uint8_t c) {
       return isalpha(c) or c == '%' or c == '_';
    }
 
@@ -281,17 +281,17 @@ namespace OpenAxiom {
    }
 
    inline bool
-   identifier_suffix(uint8_t c) {
+   identifier_suffix(std::uint8_t c) {
       return c == '!' or c == '?';
    }
 
-   inline bool internal_prefix(uint8_t c) {
+   inline bool internal_prefix(std::uint8_t c) {
       return c == '%' or c == '$';
    }
 
    template<typename L>
    inline void
-   skip_prefix(L& line, ColumnIndex& idx, uint8_t c) {
+   skip_prefix(L& line, ColumnIndex& idx, std::uint8_t c) {
       while (idx < line.size() and line[idx] == c)
          ++idx;
    }

--- a/src/include/open-axiom/vm
+++ b/src/include/open-axiom/vm
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-// Copyright (C) 2011-2014, Gabriel Dos Reis.
+// Copyright (C) 2011-2022, Gabriel Dos Reis.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,12 @@
 
 #include <open-axiom/storage>
 #include <open-axiom/string-pool>
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 #include <set>
 #include <vector>
 #include <type_traits>
+#include <concepts>
 
 #define internal_type struct alignas(16)
 #define internal_data alignas(16)
@@ -157,7 +158,7 @@ namespace OpenAxiom {
       // -- Value --
       // -----------
       // All VM values fit in a universal value datatype.
-      using ValueBits = uintptr_t;
+      using ValueBits = std::uintptr_t;
       using ValueMask = ValueBits;
       enum class Value : ValueBits {
          nil = 0x00,            // distinguished NIL value
@@ -205,7 +206,7 @@ namespace OpenAxiom {
 
       // -- Arity: number of arguments or forms taken by a function
       //           or a special operator.
-      enum class Arity : intptr_t {
+      enum class Arity : std::intptr_t {
          variable = -1,         // Any number of arguments.
          zero     = 0,          // Exactly no argument.
          one      = 1,          // Exactly one argument.
@@ -242,12 +243,8 @@ namespace OpenAxiom {
          return is<Dynamic>(v) ? to_dynamic(v) : nullptr;
       }
 
-      template<typename T>
-      using IfDynamic = typename
-         std::enable_if<std::is_base_of<Dynamic, T>::value, Value>::type;
-
-      template<typename T>
-      inline IfDynamic<T> to_value(const T* o) {
+      template<std::derived_from<Dynamic> T>
+      inline Value to_value(const T* o) {
          return Value(ValueBits(o) | ValueTrait<Dynamic>::tag);
       }
 
@@ -261,7 +258,7 @@ namespace OpenAxiom {
       // VM integers are divided into classes: small numbers,
       // and large numbers.  A small number fits entirely in a register.
       // A large number is allocated and represented by its address.
-      using FixnumBits = intptr_t;
+      using FixnumBits = std::intptr_t;
       enum class Fixnum : FixnumBits {
          minimum = FixnumBits(~(~ValueBits() >> 2)),
          zero = FixnumBits(0),


### PR DESCRIPTION
With the requirement of C++20 compiler, there is no justification to continue to use SFINAE.  Fixed thusly.