### PR TITLE
Fix build with SBCL-2.1.0

### DIFF
--- a/src/interp/vmlisp.lisp
+++ b/src/interp/vmlisp.lisp
@@ -1,6 +1,6 @@
 ;; Copyright (c) 1991-2002, The Numerical Algorithms Group Ltd.
 ;; All rights reserved.
-;; Copyright (C) 2007-2015, Gabriel Dos Reis.
+;; Copyright (C) 2007-2022, Gabriel Dos Reis.
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -526,8 +526,8 @@
          (vector-push-extend id cvec)
          cvec)
         ((adjustable-array-p cvec)
-         (let ((l (length cvec)))
-           (adjust-array cvec (1+ l))
+         (let ((l (array-dimension cvec 0)))
+           (setf cvec (adjust-array cvec (1+ l)))
            (setf (elt cvec l) id)
            cvec))
         (t (concat cvec id))))


### PR DESCRIPTION
SBCL-2.1.0 and up have more refined type inference from array operations.  As a consequence, they caught a coding slopping in the function `SUFFIX` (defined in `src/interp/vmlisp.lisp`) - even if ``benign'' with respect to effective inputs.