### PR TITLE
Use c++20 to build GUI

### DIFF
--- a/src/gui/gui.pro.in
+++ b/src/gui/gui.pro.in
@@ -60,5 +60,5 @@ LIBS += $$OA_LIB
 
 ## C++ compiler
 QMAKE_CXX = @CXX@
-QMAKE_CXXFLAGS += -std=c++11 @oa_extra_cxxflags@
+QMAKE_CXXFLAGS += -std=c++20 @oa_extra_cxxflags@
 QMAKE_LINK = @CXX@


### PR DESCRIPTION
Fixes error:

```
g++ -c -pipe -std=c++11 -Wno-mismatched-tags -Wno-string-plus-int -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I../../x86_64-pc-linux-gnu/include -I../../../src/gui -I../../../src/include -I../../config -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -o server.o ../../../src/gui/server.cc
In file included from ../../../src/include/open-axiom/Lisp:43,
                 from ../../../src/gui/server.h:38,
                 from ../../../src/gui/server.cc:33:
../../../src/include/open-axiom/vm:177:21: error: ‘std::same_as’ has not been declared
  177 |       template<std::same_as<bool> T>
```