### PR TITLE
Replace `setjmp/longjmp` with `try/catch` in Hyper

### DIFF
--- a/src/hyper/event.c
+++ b/src/hyper/event.c
@@ -42,7 +42,6 @@
 #include <X11/cursorfont.h>
 #include <sys/types.h>
 #include <sys/signal.h>
-#include <setjmp.h>
 #include <sys/time.h>
 
 #include "debug.h"
@@ -60,7 +59,6 @@
 #include "lex.h"
 #include "sockio.h"
 
-jmp_buf env;
 Window gActiveWindow;
 int motion = 0;
 int gNeedIconName = 0;

--- a/src/hyper/htadd.c
+++ b/src/hyper/htadd.c
@@ -39,7 +39,6 @@
 #include "openaxiom-c-macros.h"
 
 #include <errno.h>
-#include <setjmp.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <stdlib.h>

--- a/src/hyper/htinp.c
+++ b/src/hyper/htinp.c
@@ -35,7 +35,6 @@
 
 #include <sys/stat.h>
 #include <sys/signal.h>
-#include <setjmp.h>
 
 #include "openaxiom-c-macros.h"
 #include "debug.h"
@@ -54,7 +53,6 @@ extern char **input_file_list;
 extern int input_file_count;
 extern int make_patch_files;
 extern int kill_spad;
-extern jmp_buf jmpbuf;
 
 static void make_input_file_list(void );
 static char * make_input_file_name(char * buf , char * filename);
@@ -178,12 +176,12 @@ make_the_input_file(UnloadedPage *page)
     b = make_input_file_name(buf, page->fpos.name);
     if (inListAndNewer(b, page->fpos.name)) {
         printf("parsing: %s\n", page->name);
-        if (setjmp(jmpbuf)) {
-            printf("Syntax error!\n");
-        }
-        else {
+        try {
             load_page((HyperDocPage *)page);
             make_input_file_from_page(gWindow->page);
+        }
+        catch(const HyperError&) {
+            printf("Syntax error!\n");
         }
     }
 }

--- a/src/hyper/hyper.c
+++ b/src/hyper/hyper.c
@@ -46,7 +46,6 @@
 #include <sys/types.h>
 #include <sys/signal.h>
 #include <sys/wait.h>
-#include <setjmp.h>
 #include <X11/cursorfont.h>
 #include <stdlib.h>
 #include <locale.h>
@@ -175,9 +174,6 @@ sigcld_handler(int sig)
   wait(&x);
 
 }
-
-extern jmp_buf env;
-
 
 /* Clean up spad sockets on exit */
 void

--- a/src/hyper/initx.c
+++ b/src/hyper/initx.c
@@ -47,7 +47,6 @@
 
 #include <unistd.h>
 #include <sys/signal.h>
-#include <setjmp.h>
 #include <X11/cursorfont.h>
 #include <X11/Xresource.h>
 #include <X11/Xatom.h>

--- a/src/hyper/parse-aux.c
+++ b/src/hyper/parse-aux.c
@@ -42,6 +42,8 @@
 #include "lex.h"
 #include "hyper.h"
 
+using namespace OpenAxiom;
+
 static void read_ht_file(HashTable * page_hash , HashTable * macro_hash , HashTable * patch_hash , FILE * db_fp , char * db_file);
 static HyperDocPage * make_special_page(int type , const char * name);
 
@@ -625,7 +627,7 @@ find_fp(FilePosition fp)
     ret_val = fseek(lfile, fp.pos, 0);
     if (ret_val == -1) {
         perror("fseeking to a page");
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
 
     /* now set some global values */

--- a/src/hyper/parse-input.c
+++ b/src/hyper/parse-input.c
@@ -47,6 +47,8 @@
 #include "lex.h"
 #include "hyper.h"
 
+using namespace OpenAxiom;
+
 static void insert_item(InputItem * item);
 static void add_box_to_rb_list(char * name , InputBox * box);
 static int check_others(InputBox * list);
@@ -186,7 +188,7 @@ parse_inputstring()
   size = atoi(token.id);
   if (size < 0) {
     fprintf(stderr, "Illegal size in Input string\n");
-    longjmp(jmpbuf, 1);
+    throw HyperError{};
   }
 
   /* get the default value */

--- a/src/hyper/parse-types.c
+++ b/src/hyper/parse-types.c
@@ -114,9 +114,7 @@ parse_ifcond()
     if (gInIf) {
         curr_node->type = openaxiom_Noop_token;
         fprintf(stderr, "\\if found within \\if \n");
-        longjmp(jmpbuf, 1);
-        fprintf(stderr, "Longjump failed, Exiting\n");
-        exit(-1);
+        throw HyperError{};
     }
     gInIf = true;
     curr_node->type = openaxiom_Ifcond_token;
@@ -150,9 +148,7 @@ parse_ifcond()
             token_name(token.type);
             curr_node->type = openaxiom_Noop_token;
             fprintf(stderr, "Expected a \\fi not a %s", ebuffer);
-            longjmp(jmpbuf, 1);
-            fprintf(stderr, "Longjump failed, Exiting\n");
-            exit(-1);
+            throw HyperError{};
         }
         curr_node->type = openaxiom_Fi_token;
         curr_node->next = endif;
@@ -161,9 +157,7 @@ parse_ifcond()
         curr_node->type = openaxiom_Noop_token;
         token_name(token.type);
         fprintf(stderr, "Expected a \\fi not a %s", ebuffer);
-        longjmp(jmpbuf, 1);
-        fprintf(stderr, "Longjump failed, Exiting\n");
-        exit(-1);
+        throw HyperError{};
     }
     ifnode->next = ifnode->data.ifnode->thennode;
     ifnode->width = -1;         /* A flag for compute if extents */
@@ -385,7 +379,7 @@ parse_verbatim(int type)
     }
     if (c == EOF) {
         fprintf(stderr, "parse_verbatim: Unexpected EOF found\n");
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
     resizeVbuf();
     if (*end_string == '\n')
@@ -461,7 +455,7 @@ parse_centerline()
         fprintf(stderr, "(HyperdDoc) \\centerline was expecting a }\n");
         print_page_and_filename();
         print_next_ten_tokens();
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
     curr_node->type = openaxiom_Endcenter_token;
 }
@@ -476,7 +470,7 @@ parse_command()
         curr_node->type = openaxiom_Noop_token;
         fprintf(stderr, "Parser Error token %s unexpected\n",
                 token_table[token.type]);
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
     gStringValueOk = 1;
 
@@ -513,7 +507,7 @@ parse_button()
         curr_node->type = openaxiom_Noop_token;
         fprintf(stderr, "Parser Error token %s unexpected\n",
                 token_table[token.type]);
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
     /* fill the node */
     curr_node->type = token.type;
@@ -714,7 +708,7 @@ parse_table()
         curr_node->type = openaxiom_Noop_token;
         fprintf(stderr, "Parser Error token %s unexpected\n",
                 token_table[token.type]);
-        longjmp(jmpbuf, 1);
+        throw HyperError{};
     }
     curr_node->type = openaxiom_Table_token;
     get_expected_token(openaxiom_Lbrace_token);

--- a/src/hyper/parse.h
+++ b/src/hyper/parse.h
@@ -48,8 +48,6 @@
 #include <ctype.h>
 #include "hyper.h"
 
-#include <setjmp.h>
-
 extern void display_page(HyperDocPage * page);
 extern void init_parse_patch(HyperDocPage * page);
 extern void load_page(HyperDocPage * page);
@@ -90,7 +88,6 @@ extern int pop_parameters();
 extern int parse_macro();
 extern void parse_parameters();
 
-extern jmp_buf  jmpbuf;
 extern int      vbuff;
 
 extern TextNode *cur_spadcom;   /* spad command being parsed *** */

--- a/src/hyper/token.h
+++ b/src/hyper/token.h
@@ -252,6 +252,11 @@ enum class SourceInputKind {
    UnixFD = 4
 };
 
+namespace OpenAxiom {
+  // Basic error type in the Hyper component.
+  struct HyperError { };
+}
+
 extern FILE *unixfd;
 
 #endif


### PR DESCRIPTION
Also, remove the global variable `env` of type `jmp_buf` which was never used in the Hyper component.