### PR TITLE
Make Hyper's FilePosition::name `const char*`

### DIFF
--- a/src/hyper/addfile.c
+++ b/src/hyper/addfile.c
@@ -50,8 +50,8 @@
 using namespace OpenAxiom;
 
 
-static int build_ht_filename(char*, char*, char*);
-static int pathname(char*);
+static int build_ht_filename(char*, char*, const char*);
+static int pathname(const char*);
 
 char *gDatabasePath = NULL;
 
@@ -86,11 +86,11 @@ extend_ht(char *name)
  */
 
 static int
-build_ht_filename(char *fname, char *aname, char *name)
+build_ht_filename(char *fname, char *aname, const char* name)
 {
     char *c_dir;
     char *HTPATH;
-    char *trace;
+    const char *trace;
     char *trace2;
     int ht_file;
 
@@ -166,10 +166,11 @@ build_ht_filename(char *fname, char *aname, char *name)
         extend_ht(aname);
         for (ht_file = -1, trace2 = HTPATH;
              ht_file == -1 && *trace2 != '\0';) {
-            for (trace = fname; *trace2 != '\0' && (*trace2 != ':');)
-                *trace++ = *trace2++;
-            *trace++ = '/';
-            *trace = 0;
+            char* ptr = fname;
+            while (*trace2 != '\0' && (*trace2 != ':'))
+                *ptr++ = *trace2++;
+            *ptr++ = '/';
+            *ptr = 0;
             if (!strcmp(fname, "./")) {
                 /** The person wishes me to check the current directory too **/
                c_dir = oa_getcwd();
@@ -186,8 +187,7 @@ build_ht_filename(char *fname, char *aname, char *name)
     }
 }
 
-static int
-pathname(char *name)
+static int pathname(const char* name)
 {
     while (*name)
         if (*name++ == '/')
@@ -199,7 +199,7 @@ pathname(char *name)
 /** This procedure opens the proper HT file **/
 
 FILE *
-ht_file_open(char *fname, char *aname, char *name)
+ht_file_open(char *fname, char *aname, const char *name)
 {
     FILE *ht_fp;
     int ret_value;

--- a/src/hyper/htinp.c
+++ b/src/hyper/htinp.c
@@ -55,11 +55,11 @@ extern int make_patch_files;
 extern int kill_spad;
 
 static void make_input_file_list(void );
-static char * make_input_file_name(char * buf , char * filename);
+static char * make_input_file_name(char* buf , const char* filename);
 static char * make_paste_file_name(char * buf , char * filename);
 static void make_the_input_file(UnloadedPage * page);
 static void make_input_file_from_page(HyperDocPage * page);
-static int inListAndNewer(char * inputFile , char * htFile);
+static int inListAndNewer(const char* inputFile , const char* htFile);
 static void print_paste(FILE*, char* , char*, const char*, int);
 static void print_graph_paste(FILE*, char*, char* , const char*, int);
 static void send_command(char * command , int com_type);
@@ -139,7 +139,7 @@ ht2_input()
 }
 
 static char *
-make_input_file_name(char *buf, char *filename)
+make_input_file_name(char *buf, const char *filename)
 {
     char *b, *c;
 
@@ -273,8 +273,7 @@ make_input_file_from_page(HyperDocPage *page)
   }
 }
 
-char *
-strCopy(char *s)
+static char* strCopy(const char *s)
 {
     char *b = halloc(strlen(s) + 1,"String");
 
@@ -283,7 +282,7 @@ strCopy(char *s)
 }
 
 static int
-inListAndNewer(char *inputFile, char *htFile)
+inListAndNewer(const char* inputFile, const char* htFile)
 {
     int ret_val, found = 0, i;
     struct stat htBuf, inputBuf;

--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -93,7 +93,6 @@ extern int window_width(int cols);
 extern void ht2_input(void );
 extern void make_record(void );
 extern void verify_record(void );
-extern char * strCopy(char * s);
 extern void print_paste_line(FILE * pfile , char * str);
 extern void get_spad_output(FILE * pfile , char * command , int com_type);
 extern void get_graph_output(char*, const char*, int);

--- a/src/hyper/mem.c
+++ b/src/hyper/mem.c
@@ -679,7 +679,7 @@ free_patch(PatchStore *p)
     if (p->name)
       free(p->name);
     if (p->fpos.name)
-      free(p->fpos.name);
+      free(const_cast<char*>(p->fpos.name));
     if (p->string)
       free(p->string);
     free(p);

--- a/src/hyper/node.h
+++ b/src/hyper/node.h
@@ -170,9 +170,9 @@ struct ImageStruct {
 /* Structure for locating HyperDoc pages in a source file */
 
 struct FilePosition {
-   char *name;           /* file name */
-   long  pos;            /* position in file */
-   int   ln;             /* the line number */
+   const char* name;       // file name
+   long  pos;              // offset from the beginning of the file
+   int   line_number;      // the line number
 };
 
 /*** The structure needed for storing a macro **/

--- a/src/hyper/parse-aux.c
+++ b/src/hyper/parse-aux.c
@@ -249,7 +249,7 @@ read_ht_file(HashTable *page_hash, HashTable *macro_hash,
                     }
                     page->fpos.pos = atoi(token.id);
                     get_token();
-                    page->fpos.ln = atoi(token.id);
+                    page->fpos.line_number = atoi(token.id);
                     page->type = UnloadedPageType;
                     hash_insert(page_hash, (char *)page, page->name);
                     pages++;
@@ -274,7 +274,7 @@ read_ht_file(HashTable *page_hash, HashTable *macro_hash,
                     }
                     macro->fpos.pos = atoi(token.id);
                     get_token();
-                    macro->fpos.ln = atoi(token.id);
+                    macro->fpos.line_number = atoi(token.id);
                     macro->loaded = 0;
                     hash_insert(macro_hash, (char *)macro, macro->name);
                     break;
@@ -286,7 +286,7 @@ read_ht_file(HashTable *page_hash, HashTable *macro_hash,
                     get_token();
                     patch->fpos.pos = atoi(token.id);
                     get_token();
-                    patch->fpos.ln = atoi(token.id);
+                    patch->fpos.line_number = atoi(token.id);
                     if (hash_find(patch_hash, patch->name) != NULL) {
                         fprintf(stderr, "(HyperDoc) Patch name %s  occurred twice\n", patch->name);
                         fprintf(stderr, "(HyperDoc) The version in %s is being ignored \n",
@@ -632,6 +632,6 @@ find_fp(FilePosition fp)
 
     /* now set some global values */
     page_start_fpos = fp.pos;
-    line_number = fp.ln;
+    line_number = fp.line_number;
     return lfile;
 }

--- a/src/hyper/parse.c
+++ b/src/hyper/parse.c
@@ -156,7 +156,7 @@ load_page(HyperDocPage *page)
     }
 }
 
-HyperDocPage *formatpage;
+static HyperDocPage *formatpage;
 
 /* Display a HyperDoc page with the given name, parsing it if needed */
 

--- a/src/include/addfile.h
+++ b/src/include/addfile.h
@@ -40,7 +40,7 @@
 
 extern FILE* db_file_open(char*);
 extern void extend_ht(char*);
-extern FILE* ht_file_open(char*, char*, char*);
+extern FILE* ht_file_open(char*, char*, const char*);
 extern FILE* temp_file_open(char*);
 
 extern char* gDatabasePath;


### PR DESCRIPTION
Address cascading `const`-correctness issues.

Also make `formatpage` TU-local to `hyper/parse.c` as it is never referenced elsewhere.