### PR TITLE
Sequester Hyper `StateNode`

### DIFF
--- a/src/hyper/htadd.c
+++ b/src/hyper/htadd.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2010, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -320,9 +320,11 @@ update_db(FILE *db, FILE *temp_db, FILE *new_file,
             get_token();
             mtime = atoi(token.id);
             if (strcmp(fname, addname) == 0) {
-                save_scanner_state();
-                add_new_pages(temp_db, new_file, addname, fullname);
-                restore_scanner_state();
+                // Temporarily save IO state, add the new pages, and restore.
+                {
+                    OpenAxiom::IOStateManager save_io_state { };
+                    add_new_pages(temp_db, new_file, addname, fullname);
+                }
                 file_there = 1;
                 while ((c = get_char()) != EOF) {
                     if (c == '\t')

--- a/src/hyper/lex.h
+++ b/src/hyper/lex.h
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2008, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -42,11 +42,19 @@
 #define KEYTYPE    2    /* unrecognized keyword found in lex.c */
 #define Numerrors  2
 
+namespace OpenAxiom {
+  // Type of IO state stack.  Used to automate save/restore of IO states.
+  struct IOStateManager {
+    IOStateManager();
+    IOStateManager(const IOStateManager&) = delete;
+    IOStateManager(IOStateManager&&) = delete;
+    ~IOStateManager();
+  };
+}
+
 extern void get_expected_token(int);
 extern void parser_init();
 extern void init_scanner();
-extern void save_scanner_state();
-extern void restore_scanner_state();
 extern void unget_char(int);
 extern int get_char();
 extern void unget_token();

--- a/src/hyper/macro.c
+++ b/src/hyper/macro.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2010, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -108,10 +108,9 @@ load_macro(MacroStore *macro)
     int size = 0;
     char *trace;
     char *macro_buff;
+    OpenAxiom::IOStateManager save_io_state { };
 
-    save_scanner_state();
     cfile = find_fp(macro->fpos);
-
 
     init_scanner();
 
@@ -167,7 +166,6 @@ load_macro(MacroStore *macro)
         *trace++ = getc(cfile);
     *trace = '\0';
     macro->loaded = 1;
-    restore_scanner_state();
     return macro_buff;
 }
 

--- a/src/hyper/node.h
+++ b/src/hyper/node.h
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2008, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -76,26 +76,6 @@ struct PasteNode;
 #define Header    2
 #define Footer    3
 #define Title     4
-
-
-
-/** I am implementing a state node stack, this is the structure I store **/
-
-struct StateNode {
-   int last_ch, last_token;
-   SourceInputKind input_type;
-   long fpos, keyword_fpos;
-   long page_start_fpos;
-   Token token;
-   char *input_string;
-   FILE *cfile;
-   int keyword;
-   StateNode *next;
-};
-
-/** pointer to the top of the state node graph **/
-extern StateNode *top_state_node;
-
 
 /* structure for a hyper text link */
 struct HyperLink {

--- a/src/hyper/parse-paste.c
+++ b/src/hyper/parse-paste.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2010, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -349,9 +349,8 @@ load_patch(PatchStore *patch)
     int size = 0;
     int limsize;
     char *trace;
+    OpenAxiom::IOStateManager save_io_state { };
 
-
-    save_scanner_state();
     cfile = find_fp(patch->fpos);
 
     init_scanner();
@@ -377,7 +376,6 @@ load_patch(PatchStore *patch)
         *trace++ = getc(cfile);
     *trace = '\0';
     patch->loaded = 1;
-    restore_scanner_state();
 }
 
 

--- a/src/hyper/parse.c
+++ b/src/hyper/parse.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2016, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -230,13 +230,12 @@ format_page(UnloadedPage *ulpage)
 void
 parse_from_string(char *str)
 {
-    save_scanner_state();
+    OpenAxiom::IOStateManager save_io_state { };
     last_ch = NoChar;
     last_token = 0;
     input_string = str;
     input_type = SourceInputKind::String;
     parse_HyperDoc();
-    restore_scanner_state();
 }
 
 static void


### PR DESCRIPTION
Move `StateNode` to `hyper/lex.c` as the only place where it is referenced.

Rename `StateNode` to `IOState`.  It is not a node.

Introduce `IOStateManager` as a RAII type for reliable save/restore mechanism.  Remove `save_scanner_state()` and `restore_scanner_state()`

Introduce `IOStateStack` as a non-intrusive stack datatype based on C++ standard `std::stack`.

Also save `line_number` which was forgotten as part of the IO state to save.