### PR TITLE
[hyper] Data member `Token::type` should not be of type `int`

### DIFF
--- a/src/hyper/lex.c
+++ b/src/hyper/lex.c
@@ -253,7 +253,7 @@ parser_init()
               (HashcodeFunction)string_hash);
     for (i = 2; i <= openaxiom_NumberUserTokens_token; i++) {
         toke = (Token *) halloc(sizeof(Token), "Token");
-        toke->type = i;
+        toke->type = openaxiom_token_kind{i};
         toke->id = token_table[i];
         hash_insert(&tokenHashTable, (char *)toke, toke->id);
     }
@@ -473,7 +473,7 @@ get_token()
     }
     switch (c) {
       case EOF:
-        token.type = -1;
+        token.type = openaxiom_token_kind{-1};
         return EOF;
       case '\\':
         keyword_fpos = fpos - 1;
@@ -765,6 +765,11 @@ begin_type()
     return 1;
 }
 
+// Return the closing matching end token type of the argument.
+static constexpr openaxiom_token_kind matching_end(openaxiom_token_kind t)
+{
+    return openaxiom_token_kind{t + 3000};
+}
 
 int
 end_type()
@@ -793,7 +798,7 @@ end_type()
     else {
         if (gWindow != NULL && !gInVerbatim) {
             check_and_pop_be_stack(token.type, token.id);
-            token.type += 3000;
+            token.type = matching_end(token.type);
             return 1;
         }
         else {
@@ -801,11 +806,11 @@ end_type()
                 && ((gInVerbatim && token.type == openaxiom_Verbatim_token)
                     || (gInSpadsrc && token.type == openaxiom_Spadsrc_token))) {
                 check_and_pop_be_stack(token.type, token.id);
-                token.type += 3000;
+                token.type = matching_end(token.type);
                 return 1;
             }
             else {
-                token.type += 3000;
+                token.type = matching_end(token.type);
                 return 1;
             }
         }

--- a/src/hyper/token.h
+++ b/src/hyper/token.h
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
    All rights reserved.
-   Copyright (C) 2007-2008, Gabriel Dos Reis.
+   Copyright (C) 2007-2023, Gabriel Dos Reis.
    All right reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -47,17 +47,10 @@
 #define FRONTSPACE 0001
 #define BACKSPACE  0002
 
-/* HyperDoc parser tokens */
-
-struct Token {
-   int type;              /* token type.  One of those listed below */
-   const char *id;                  /* string value if type == Identifier */
-};
-
 /*
     User tokens. ie, these can be found on a page
 */
-enum openaxiom_token_kind {
+enum openaxiom_token_kind : int {
   openaxiom_Word_token = 1,
   openaxiom_Page_token = 2,
   openaxiom_Lispcommandquit_token = 3,
@@ -238,6 +231,11 @@ enum openaxiom_token_kind {
   openaxiom_Endspadsrc_token = 4030
 };
 
+/* HyperDoc parser tokens */
+struct Token {
+   openaxiom_token_kind type;              /* token type.  One of those listed below */
+   const char *id;                  /* string value if type == Identifier */
+};
 
 extern const char *token_table[];
 


### PR DESCRIPTION
Make `Token::type` of type `openaxiom_token_kind` instead of plain `int`.

Fix a couple of places that exploited the ambiguous `int` type.