### PR TITLE
Native components: Don't allow writeable literal strings

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -432,7 +432,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@

--- a/config/open-axiom.m4
+++ b/config/open-axiom.m4
@@ -372,11 +372,18 @@ dnl ---------------------------------
 dnl -- OPENAXIOM_CXX_EXTRA_OPTIONS --
 dnl ---------------------------------
 AC_DEFUN([OPENAXIOM_EXTRA_CXX_OPTIONS], [
-oa_extra_cxxflags=
-OPENAXIOM_CXX_GROK_OPTION([-Wno-mismatched-tags],[oa_extra_cxxflags])
-OPENAXIOM_CXX_GROK_OPTION([-Wno-string-plus-int],[oa_extra_cxxflags])
+# Compiler warnings that are irrevocably errors.
+oa_enabled_cxx_policies='writable-strings'
+for f in $oa_enabled_cxx_policies; do
+   OPENAXIOM_CXX_GROK_OPTION(["-Werror=$f"])
+done
 
-AC_SUBST(oa_extra_cxxflags)
+# Compiler warnings that should not be considered.
+# These flags should go after enabled policies.
+oa_disabled_cxx_policies='mismatched-tags string-plus-int'
+for f in $oa_disabled_cxx_policies; do
+   OPENAXIOM_CXX_GROK_OPTION(["-Wno-$f"])
+done
 ])
 
 dnl ---------------------------------

--- a/configure
+++ b/configure
@@ -737,7 +737,6 @@ OA_DELAYED_FFI_FALSE
 OA_DELAYED_FFI_TRUE
 OA_BUILD_GCL_FALSE
 OA_BUILD_GCL_TRUE
-oa_extra_cxxflags
 OA_USE_LLVM_FALSE
 OA_USE_LLVM_TRUE
 oa_use_llvm
@@ -6430,10 +6429,12 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
-oa_extra_cxxflags=
+# Compiler warnings that are irrevocably errors.
+oa_enabled_cxx_policies='writable-strings'
+for f in $oa_enabled_cxx_policies; do
 
-opt=-Wno-mismatched-tags				      # mandatory
-accumulator=oa_extra_cxxflags			      # optional
+opt="-Werror=$f"				      # mandatory
+accumulator=			      # optional
 if test -z $accumulator; then
    accumulator=CXXFLAGS
 fi
@@ -6466,9 +6467,15 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
+done
 
-opt=-Wno-string-plus-int				      # mandatory
-accumulator=oa_extra_cxxflags			      # optional
+# Compiler warnings that should not be considered.
+# These flags should go after enabled policies.
+oa_disabled_cxx_policies='mismatched-tags string-plus-int'
+for f in $oa_disabled_cxx_policies; do
+
+opt="-Wno-$f"				      # mandatory
+accumulator=			      # optional
 if test -z $accumulator; then
    accumulator=CXXFLAGS
 fi
@@ -6501,8 +6508,7 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
-
-
+done
 
  if test x$oa_include_gcl = xyes; then
   OA_BUILD_GCL_TRUE=

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -363,7 +363,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@

--- a/src/algebra/Makefile.in
+++ b/src/algebra/Makefile.in
@@ -550,7 +550,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@

--- a/src/boot/Makefile.in
+++ b/src/boot/Makefile.in
@@ -393,7 +393,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@

--- a/src/gui/gui.pro.in
+++ b/src/gui/gui.pro.in
@@ -60,5 +60,5 @@ LIBS += $$OA_LIB
 
 ## C++ compiler
 QMAKE_CXX = @CXX@
-QMAKE_CXXFLAGS += -std=c++20 @oa_extra_cxxflags@
+QMAKE_CXXFLAGS += -std=c++20 @CXXFLAGS@
 QMAKE_LINK = @CXX@

--- a/src/hyper/cond.c
+++ b/src/hyper/cond.c
@@ -54,7 +54,7 @@ using namespace OpenAxiom;
 static int check_memostack(TextNode * node);
 
 void
-insert_cond(char *label, char *cond)
+insert_cond(char *label, const char* cond)
 {
     CondNode *condnode = (CondNode *) hash_find(gWindow->fCondHashTable, label);
 

--- a/src/hyper/event.c
+++ b/src/hyper/event.c
@@ -756,8 +756,7 @@ quitHyperDoc()
 
 
 
-void
-make_window_link(char *name)
+void make_window_link(const char* name)
 {
     if (init_top_window(name) != -1)
 {}/*        gWindow->fWindowHashTable = gWindow->page->fLinkHashTable; */
@@ -867,7 +866,7 @@ get_new_window()
         val = get_int(spad_socket);
         init_scanner();
         input_type = SourceInputKind::SpadSocket;
-        input_string = "";
+        input_string = nullptr;
         gWindow->page = parse_page_from_socket();
         gWindow->fAxiomFrame = frame;
         XFlush(gXDisplay);
@@ -886,7 +885,7 @@ get_new_window()
         send_int(spad_socket, gWindow->fMainWindow);
         init_scanner();
         input_type = SourceInputKind::SpadSocket;
-        input_string = "";
+        input_string = nullptr;
         gWindow->page = parse_page_from_socket();
         compute_form_page(gWindow->page);
 
@@ -936,7 +935,7 @@ get_new_window()
         set_window(wid);
         init_scanner();
         input_type = SourceInputKind::SpadSocket;
-        input_string = "";
+        input_string = nullptr;
         gWindow->page = parse_page_from_socket();
         display_page(gWindow->page);
         gWindow->fWindowHashTable = gWindow->page->fLinkHashTable;

--- a/src/hyper/event.h
+++ b/src/hyper/event.h
@@ -46,7 +46,7 @@ extern void helpForHyperDoc();
 extern void quitHyperDoc();
 extern void exitHyperDoc();
 extern void mainEventLoop();
-extern void make_window_link(char*);
+extern void make_window_link(const char* );
 
 extern Window gActiveWindow;
 extern int    gNeedIconName;

--- a/src/hyper/htinp.c
+++ b/src/hyper/htinp.c
@@ -352,7 +352,10 @@ make_input_file_list()
 void
 print_paste_line(FILE *pfile,char *str)
 {
-    char *free = "\\free", *bound = "\\bound", *f = free, *b = bound;
+    const char* free = "\\free";
+    const char* bound = "\\bound";
+    const char* f = free;
+    const char* b = bound;
     int justSaw = 0;
 
     for (; *str; str++) {

--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -116,14 +116,14 @@ extern int issue_serverpaste(TextNode * command);
 extern void issue_unixcommand(TextNode * node);
 extern int issue_unixpaste(TextNode * node);
 extern void service_session_socket();
-extern void send_lisp_command(char * command);
+extern void send_lisp_command(const char* command);
 extern void escape_string(char * s);
 extern void unescape_string(char * s);
 extern char * print_source_to_string1(TextNode * command , int * sizeBuf);
 extern char * print_source_to_string(TextNode * command);
 extern void change_cond(char * label , char * newcond);
 extern int check_condition(TextNode * node);
-extern void insert_cond(char * label , char * cond);
+extern void insert_cond(char* label , const char* cond);
 
 
 #ifndef HTADD

--- a/src/hyper/initx.c
+++ b/src/hyper/initx.c
@@ -383,7 +383,7 @@ set_name_and_icon()
     XWMHints wmhints;
     XClassHint ch;
 
-    ch.res_name = "HyperDoc";
+    ch.res_name = const_cast<char*>("HyperDoc");            // FIXME: Use a better API.
     ch.res_class = gArgv[0];
     for (s = gArgv[0] + strlen(gArgv[0]) - 1; s != gArgv[0]; s--) {
         if (*s == '/') {

--- a/src/hyper/lex.c
+++ b/src/hyper/lex.c
@@ -91,7 +91,7 @@ struct IOState {
    long fpos, keyword_fpos;
    long page_start_fpos;
    Token token;
-   char *input_string;
+   const char* input_string;
    FILE *cfile;
    int keyword;
 };
@@ -114,7 +114,7 @@ long keyword_fpos;              /* fpos of beginning of most recent keyword */
 Token token;                    /* most recently read token */
 TokenType last_token;           /* most recently read token for unget_token */
 SourceInputKind input_type;                 /* indicates where to read input */
-char *input_string;             /* input string read when from_string is true */
+const char* input_string = nullptr;       /* input string read when from_string is true */
 int last_ch;                    /* last character read, for unget_char */
 int last_command;               /* the last socket command */
 int keyword;                    /* the last command was a keyword, or a group */
@@ -351,7 +351,7 @@ int get_char()
             line_number++;
         return c;
     case SourceInputKind::String:
-        c = (*input_string ? *input_string++ : EOF);
+        c = (input_string != nullptr and *input_string != '\0' ? *input_string++ : EOF);
         if (c == '\n')
             line_number++;
         return c;
@@ -363,7 +363,7 @@ int get_char()
         return c;
     case SourceInputKind::SpadSocket:
 AGAIN:
-        if (*input_string) {
+        if (input_string != nullptr and *input_string != '\0') {
             /* this should never happen for the first character */
             c = *input_string++;
             if (c == '\n')

--- a/src/hyper/lex.h
+++ b/src/hyper/lex.h
@@ -78,7 +78,7 @@ extern Token token;
 extern OpenAxiom::TokenType last_token;
 extern int last_ch;
 extern SourceInputKind input_type;
-extern char *input_string;
+extern const char* input_string;
 extern FILE *cfile;
 extern short int gInSpadsrc;
 extern short int gInVerbatim;

--- a/src/hyper/parse.c
+++ b/src/hyper/parse.c
@@ -92,8 +92,7 @@ reset_connection()
         close(spad_socket->socket);
         spad_socket->socket = 0;
         spad_socket = NULL;
-        if (input_string)
-            input_string[0] = '\0';
+        input_string = nullptr;
         spad_socket->nbytes_pending = 0;
         connect_spad();
     }
@@ -228,7 +227,7 @@ format_page(UnloadedPage *ulpage)
 /* parse the HyperDoc statements in the given string */
 
 void
-parse_from_string(char *str)
+parse_from_string(const char *str)
 {
     OpenAxiom::IOStateManager save_io_state { };
     last_ch = NoChar;
@@ -365,10 +364,6 @@ parse_page(HyperDocPage *page)
      */
     parse_header(page);
 }
-
-char *ExpectedBeginScroll =
-"Parser Error: Unexpected new page, expecting a begin scroll\n", *ExpectedEndScroll =
-"Parser Error: Unexpected new page, expected an end scroll\n";
 
 /*
  * The general HyperDoc parsing function.  expects to see anything. This
@@ -707,7 +702,7 @@ parse_page_from_socket()
 
     init_scanner();
     input_type = SourceInputKind::SpadSocket;
-    input_string = "";
+    input_string = nullptr;
     cur_spadcom = NULL;
     gLinkHashTable = page->fLinkHashTable;
     hash_init(

--- a/src/hyper/parse.h
+++ b/src/hyper/parse.h
@@ -52,7 +52,7 @@ extern void display_page(HyperDocPage * page);
 extern void init_parse_patch(HyperDocPage * page);
 extern void load_page(HyperDocPage * page);
 extern void parse_HyperDoc(void );
-extern void parse_from_string(char * str);
+extern void parse_from_string(const char* str);
 extern HyperDocPage * parse_page_from_socket(void );
 extern HyperDocPage * parse_page_from_unixfd(void );
 extern HyperLink * make_input_window(InputItem * item);

--- a/src/hyper/spadint.c
+++ b/src/hyper/spadint.c
@@ -829,8 +829,8 @@ switch_frames()
     send_int(session_server, SwitchFrames);
     send_int(session_server, gWindow->fAxiomFrame);
 }
-void
-send_lisp_command(char *command)
+
+void send_lisp_command(const char* command)
 {
     int ret_val;
 

--- a/src/include/pixmap.h
+++ b/src/include/pixmap.h
@@ -38,7 +38,7 @@
 
 extern int file_exists(char * );
 extern FILE * zzopen(char *  , const char* );
-extern void write_pixmap_file(Display *  , int  , char *  , Window  , int  , int  , int  , int );
+extern void write_pixmap_file(Display*, int, const char*, Window, int, int, int, int);
 extern int read_pixmap_file(Display *  , int  , char *  , XImage * *  , int *  , int * );
 
    

--- a/src/lib/pixmap.c
+++ b/src/lib/pixmap.c
@@ -109,7 +109,7 @@ zzopen(char *file, const char* mode)
 
 ********************************************************************/
 void
-write_pixmap_file(Display *dsp, int scr, char  *fn, 
+write_pixmap_file(Display* dsp, int scr, const char* fn, 
                   Window wid, int x, int y, int width,int height)
 {
     XImage *xi;
@@ -301,7 +301,7 @@ read_pixmap_file(Display *display, int screen, char *filename,
 
 
 void
-write_pixmap_file(Display *dsp, int scr, char  *fn, 
+write_pixmap_file(Display* dsp, int scr, const char* fn, 
                   Window wid, int x, int y, int width,int height)
 {
   XImage *xi;

--- a/src/rt/Makefile.in
+++ b/src/rt/Makefile.in
@@ -355,7 +355,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -58,8 +58,7 @@ AM_CXXFLAGS = \
 	-I. -I$(oa_target_includedir) \
 	-I$(top_builddir)/config \
 	-I$(top_srcdir)/src/include \
-	-DOPENAXIOM_ROOT_DIRECTORY="\"$(open_axiom_installdir)\"" \
-	@oa_extra_cxxflags@
+	-DOPENAXIOM_ROOT_DIRECTORY="\"$(open_axiom_installdir)\""
 
 oa_target_oalib = $(oa_target_libdir)/libOpenAxiom.a
 

--- a/src/utils/Makefile.in
+++ b/src/utils/Makefile.in
@@ -371,7 +371,6 @@ oa_enable_checking = @oa_enable_checking@
 oa_enable_profiling = @oa_enable_profiling@
 oa_enable_threads = @oa_enable_threads@
 oa_eval_flags = @oa_eval_flags@
-oa_extra_cxxflags = @oa_extra_cxxflags@
 oa_host_has_regex = @oa_host_has_regex@
 oa_keep_files = @oa_keep_files@
 oa_lisp_flavor = @oa_lisp_flavor@
@@ -442,8 +441,7 @@ AM_CXXFLAGS = \
 	-I. -I$(oa_target_includedir) \
 	-I$(top_builddir)/config \
 	-I$(top_srcdir)/src/include \
-	-DOPENAXIOM_ROOT_DIRECTORY="\"$(open_axiom_installdir)\"" \
-	@oa_extra_cxxflags@
+	-DOPENAXIOM_ROOT_DIRECTORY="\"$(open_axiom_installdir)\""
 
 oa_target_oalib = $(oa_target_libdir)/libOpenAxiom.a
 SUFFIXES = .cc .cxx .H .hxx


### PR DESCRIPTION
Enforce as compiler options in the native (C++) components.