### PR TITLE
[hyper] Give spad server commands unique type

### DIFF
--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -51,8 +51,10 @@
 #include "pixmap.h"
 
 namespace OpenAxiom {
-  // Mapping of HT filepath to stream handle. 
-  using OpenHTFileTable = std::unordered_map<std::string_view, FILE*>;
+   // Mapping of HT filepath to stream handle. 
+   using OpenHTFileTable = std::unordered_map<std::string_view, FILE*>;
+
+   HyperCommand read_hyper_command(openaxiom_sio*);
 }
 
 extern void sigusr2_handler(int sig);
@@ -199,19 +201,6 @@ extern int space_width;
 
 #define NoChar   -9999
 #define db_file_name "ht.db"
-
-/* Commands from Axiom */
-
-#define EndOfPage        99
-#define SendLine         98
-#define StartPage        97          /* A normal HyperDoc page */
-#define LinkToPage       96
-#define PopUpPage        95          /* A pop-up page          */
-#define PopUpNamedPage   94
-#define KillPage         93
-#define ReplacePage      92
-#define ReplaceNamedPage 91
-#define SpadError        90
 
 /* Constants declaring size of page stacks */
 

--- a/src/hyper/node.h
+++ b/src/hyper/node.h
@@ -363,19 +363,6 @@ using ParameterList = parameter_list_type*;
 #define db_file_name "ht.db"
 
 
-/* Commands from Axiom */
-
-#define EndOfPage        99
-#define SendLine         98
-#define StartPage        97          /* A normal HyperDoc page */
-#define LinkToPage       96
-#define PopUpPage        95          /* A pop-up page          */
-#define PopUpNamedPage   94
-#define KillPage         93
-#define ReplacePage      92
-#define ReplaceNamedPage 91
-#define SpadError        90
-
 /* Constants declaring size of page stacks */
 
 #define MaxMemoDepth    25              /* max nesting level for memolinks */

--- a/src/hyper/token.h
+++ b/src/hyper/token.h
@@ -246,6 +246,22 @@ namespace OpenAxiom {
       Normal = 9998,
       UnloadedPageType = 9999,
    };
+
+   // Commands from the server.
+   // See also interp/hypertex.boot and interp/nhyper.boot
+   enum class HyperCommand : int {
+      SpadError = 90,
+      ReplaceNamedPage = 91,
+      ReplacePage = 92,
+      KillPage = 93,
+      PopUpNamedPage = 94,
+      PopUpPage = 95,          /* A pop-up page          */
+      LinkToPage = 96,
+      StartPage = 97,          /* A normal HyperDoc page */
+      SendLine = 98,
+      EndOfPage = 99,
+      PageStuff = 100,
+  };
 }
 
 /* HyperDoc parser tokens */


### PR DESCRIPTION
Distinguish them from plain integers.  Consolidate the constants designating Spad commands at a unique place in the Hyper component.