### PR TITLE
Remove "unused but set variables" from native code

### DIFF
--- a/config/open-axiom.m4
+++ b/config/open-axiom.m4
@@ -373,7 +373,7 @@ dnl -- OPENAXIOM_CXX_EXTRA_OPTIONS --
 dnl ---------------------------------
 AC_DEFUN([OPENAXIOM_EXTRA_CXX_OPTIONS], [
 # Compiler warnings that are irrevocably errors.
-oa_enabled_cxx_policies='writable-strings'
+oa_enabled_cxx_policies='writable-strings unused-but-set-variable'
 for f in $oa_enabled_cxx_policies; do
    OPENAXIOM_CXX_GROK_OPTION(["-Werror=$f"])
 done

--- a/configure
+++ b/configure
@@ -6430,7 +6430,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 
 
 # Compiler warnings that are irrevocably errors.
-oa_enabled_cxx_policies='writable-strings'
+oa_enabled_cxx_policies='writable-strings unused-but-set-variable'
 for f in $oa_enabled_cxx_policies; do
 
 opt="-Werror=$f"				      # mandatory

--- a/src/etc/asq.c.pamphlet
+++ b/src/etc/asq.c.pamphlet
@@ -851,15 +851,14 @@ int pprintcond(int seekpt,char *path);
 /* print the object file name */
 { char stripped[256];
   int i;
-  for (i=1; object[i] != '"'; i++) stripped[i-1]=object[i];
+  for (i=1; object[i] != '"'; i++) 
+    stripped[i-1]=object[i];
   stripped[i-1]='\0';
-  printf("...loading info not available yet\n");
- /*
-    if (all == 1)
+
+  if (all == 1)
     printf("...will load from %s/algebra/%s.o\n",AXIOM,stripped);
-    else
+  else
     printf("%s/algebra/%s.o\n",AXIOM,stripped);
-    */
   return(0);
 }
  

--- a/src/graph/view2D/viewport2D.c
+++ b/src/graph/view2D/viewport2D.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2010, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -103,7 +103,6 @@ drawTheViewport(int dFlag)
   pointListStruct   *aList;
   pointStruct       *aPoint;
   XPoint            *anXPoint,*tempXpt;
-  XArc              *anXarc;
   Vertex            *anX10Point;
   float             jj,diffX, diffY, tickStart,oneTickUnit;
   int               i,j,k,ii,halfSize;
@@ -170,7 +169,6 @@ drawTheViewport(int dFlag)
 
       tempXpt   = anXPoint   = xPointsArray[i].xPoint;
       anX10Point = xPointsArray[i].x10Point;
-      anXarc     = xPointsArray[i].arc;
 
       for (j=0,aList=graphArray[i].listOfListsOfPoints;
            (j<graphArray[i].numberOfLists);
@@ -236,7 +234,6 @@ drawTheViewport(int dFlag)
 
           anXPoint++;
           anX10Point++;
-          anXarc++;
         }      /* for aPoint in pointList */
           
         aPoint--; /* make it legal, the last one*/

--- a/src/hyper/ReadBitmap.c
+++ b/src/hyper/ReadBitmap.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2010, Gabriel Dos Reis.
+  Copyright (C) 2007-2023, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,6 @@ HTReadBitmapFile(Display *display,int screen,char * filename,
     XImage *image;
     FILE *fd;
     char Line[256], Buff[256];
-    int num_chars;
     char *ptr;
     int rch;
     int version;
@@ -134,7 +133,6 @@ HTReadBitmapFile(Display *display,int screen,char * filename,
     (image)->bytes_per_line = chars_line = (*width + 7) / 8;
     file_chars_line = chars_line + padding;
 
-    num_chars = chars_line * (*height);
     file_chars = file_chars_line * (*height);
     (image)->data = (char *) halloc((image)->bytes_per_line * (image)->height,
                                     "Read Pixmap--Image data");

--- a/src/hyper/extent1.c
+++ b/src/hyper/extent1.c
@@ -1320,13 +1320,10 @@ compute_header_extent(HyperDocPage *page)
      * Hopefully we will soon be able to actually compute the needed height
      * for the header here
      */
-
-    int ty; /* UNUSED */
-
     gExtentRegion = HyperRegion::Header;
     right_margin_space = non_scroll_right_margin_space;
     init_extents();
-    ty = text_y = 3 * top_margin + line_height + max(page->title->height, twheight);
+    text_y = 3 * top_margin + line_height + max(page->title->height, twheight);
     gLineNode = page->header->next;
     compute_text_extent(page->header->next);
     page->header->height = text_height(page->header->next,

--- a/src/hyper/extent2.c
+++ b/src/hyper/extent2.c
@@ -204,9 +204,9 @@ width_of_dash(TextNode * node)
 int
 text_width(TextNode * node, TokenType Ender)
 {
-    int twidth = 0, num_words;
+    int twidth = 0;
 
-    for (num_words = 0; node != NULL; num_words++, node = node->next) {
+    for (; node != NULL; node = node->next) {
         if (Ender == TokenType::Endtokens) {
             if (node->type == TokenType::Endtokens)
                 return twidth;

--- a/src/hyper/macro.c
+++ b/src/hyper/macro.c
@@ -103,7 +103,6 @@ number(const char *str)
 static char *
 load_macro(MacroStore *macro)
 {
-    int ret_val;
     long start_fpos;
     int size = 0;
     char *trace;
@@ -159,7 +158,7 @@ load_macro(MacroStore *macro)
     }
     start_fpos = fpos;
     scan_HyperDoc();
-    ret_val = fseek(cfile, macro->fpos.pos + start_fpos, 0);
+    fseek(cfile, macro->fpos.pos + start_fpos, 0);
     size = fpos - start_fpos;
     macro_buff = (char *) halloc((size + 1) * sizeof(char), "Macro_buf");
     for (size = 0, trace = macro_buff; size < fpos - (start_fpos) - 1; size++)

--- a/src/hyper/parse-aux.c
+++ b/src/hyper/parse-aux.c
@@ -202,7 +202,7 @@ read_ht_files(HTEnvironment& env, FILE *db_fp, const std::string& dir)
     UnloadedPage *page;
     MacroStore *macro;
     PatchStore *patch;
-    int pages = 0, c, mtime, ret_val;
+    int c, mtime, ret_val;
     struct stat fstats;
     auto page_hash = env.pages;
     auto macro_hash = env.macros;
@@ -280,7 +280,6 @@ read_ht_files(HTEnvironment& env, FILE *db_fp, const std::string& dir)
                     page->fpos.line_number = atoi(token.id);
                     page->type = TokenType::UnloadedPageType;
                     hash_insert(page_hash, (char *)page, page->name);
-                    pages++;
                     break;
                   case TokenType::NewCommand:
                     get_token();
@@ -540,7 +539,6 @@ int
 get_filename()
 {
     int c, ws;
-    static int seen_white = 0; /*UNUSED */
     static char buffer[256];
     char *buf = buffer;
 
@@ -552,8 +550,6 @@ get_filename()
         keyword_fpos = fpos;
         c = get_char();
         ws = whitespace(c);
-        if (ws)
-            seen_white = 1;
     } while (ws);
     switch (c) {
       case EOF:
@@ -573,7 +569,6 @@ get_filename()
         *buf = '\0';
         token.type = TokenType::Word;
         token.id = buffer;
-        seen_white = 0;
         break;
     }
     return 1;

--- a/src/hyper/show-types.c
+++ b/src/hyper/show-types.c
@@ -465,11 +465,7 @@ show_input(TextNode *node)
     /*int twidth, boxwidth, old_color;*/
     /*Window root, child;*/
     /*int root_x, root_y, win_x, win_y, buttons;*/
-    InputItem *item;
-    char *inpbuffer;
-
-    item = node->link->reference.string;
-    inpbuffer = item->curr_line->buffer;
+    InputItem *item = node->link->reference.string;
 
     wc.border_width = 0;
     wc.x = node->x;

--- a/src/lib/wct.c
+++ b/src/lib/wct.c
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 1991-2002, The Numerical ALgorithms Group Ltd.
     All rights reserved.
-    Copyright (C) 2007-2011 Gabriel Dos Reis.
+    Copyright (C) 2007-2023 Gabriel Dos Reis.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -637,7 +637,6 @@ find_wct(void)
     char *filler = search_buff;
     int b = curr_pntr - 1;
     int e = curr_pntr;
-    int ne = 0;
     int st;
     Wix *pwix;
     int curr_len;
@@ -664,7 +663,6 @@ find_wct(void)
     /* At the same time, let me find the end of the word */
     while (e < buff_pntr && !Delimiter(buff[e])) {
         e++;
-        ne++;
     }
 
     st = b;


### PR DESCRIPTION
Enforced with C++ compiler policy `-Werror=unused-but-set-variables`