### PR TITLE
[hyper] Reduce uses of `sprintf`

### DIFF
--- a/src/hyper/ReadBitmap.c
+++ b/src/hyper/ReadBitmap.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@
 */
 
 #include "openaxiom-c-macros.h"
+#include <string.h>
 #include "debug.h"
 #include "halloc.h"
 #include "sockio.h"
@@ -51,9 +52,9 @@ static int read_w_and_h(FILE * fd , unsigned int * width , unsigned int * height
  * XReadBitmapFile does not seeem to work to well (whatecer that means).
  */
 
-XImage *
-HTReadBitmapFile(Display *display,int screen,char * filename, 
-                 int *width, int *height)
+XImage*
+HTReadBitmapFile(Display* display, int screen, const char* filename, 
+                 int* width, int* height)
 {
     XImage *image;
     FILE *fd;
@@ -251,7 +252,7 @@ insert_image_struct(char *filename)
 
         /* strcpy(image->filename, filename); */
 
-        sprintf(image->filename, "%s", filename);
+        strcpy(image->filename, filename);
         hash_insert(&gImageHashTable,(char *) image, image->filename);
     }
     return image;

--- a/src/hyper/event.c
+++ b/src/hyper/event.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@
 
 #define _EVENT_C
 
+#include <format>
 #include "openaxiom-c-macros.h"
 
 #include <X11/X.h>
@@ -264,10 +265,7 @@ paste_button(PasteNode * paste)
 static void
 killAxiomPage(HyperDocPage * page)
 {
-    char command[512];
-
-    sprintf(command, "(|htpDestroyPage| '%s)", page->name);
-    send_lisp_command(command);
+    send_lisp_command(std::format("(|htpDestroyPage| '{})", page->name).c_str());
 }
 
 static void

--- a/src/hyper/extent2.c
+++ b/src/hyper/extent2.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,7 @@
  ****************************************************************************/
 
 #include "openaxiom-c-macros.h"
+#include <string.h>
 #include "debug.h"
 #include "halloc.h"
 #include "sockio.h"
@@ -862,7 +863,7 @@ insert_bitmap_file(TextNode * node)
             image->height = image->image.xi->height;
             image->filename = (char *) halloc(sizeof(char) * strlen(filename) +1,"Image Filename");
             /* strcpy(image->filename, filename); */
-            sprintf(image->filename, "%s", filename);
+            strcpy(image->filename, filename);
             hash_insert(&gImageHashTable, (char *)image, image->filename);
         }
         node->width = image->width;
@@ -909,7 +910,7 @@ insert_pixmap_file(TextNode * node)
             image->filename = (char *) halloc(sizeof(char) * strlen(filename) +1,
                                               "insert_pixmap--filename");
             /* strcpy(image->filename, filename); */
-            sprintf(image->filename, "%s", filename);
+            strcpy(image->filename, filename);
             image->image.xi = xi;
             hash_insert(&gImageHashTable, (char *)image, image->filename);
         }

--- a/src/hyper/htadd.c
+++ b/src/hyper/htadd.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 /* HyperDoc database file manager */
 
-
+#include <format>
 #include "openaxiom-c-macros.h"
 
 #include <errno.h>
@@ -186,7 +186,7 @@ build_db_filename(short flag, char *db_dir, char *dbfilename)
     int ret_status;
     char *SPAD;
     struct stat buff;
-    char path[256];
+    std::string path;
 
 
     if (flag & System) {
@@ -197,15 +197,15 @@ build_db_filename(short flag, char *db_dir, char *dbfilename)
             exit(-1);
         }
         sprintf(dbfilename, "%s/share/hypertex/pages/%s", SPAD, db_file_name);
-        sprintf(path, "%s/share/hypertex/pages", SPAD);
+        path = std::format("{}/share/hypertex/pages", SPAD);
     }
     else if (flag & Named) {
         sprintf(dbfilename, "%s/%s", db_dir, db_file_name);
-        strcpy(path, db_dir);
+        path = db_dir;
     }
     else {                      /* use the current directory */
         sprintf(dbfilename, "./%s", db_file_name);
-        sprintf(path, "./");
+        path = "./";
     }
 /*    fprintf(stderr,"htadd:build_db_filename:dbfilename=%s\n",dbfilename);*/
     /* Now see if I can write to the file  */
@@ -214,7 +214,7 @@ build_db_filename(short flag, char *db_dir, char *dbfilename)
     if (ret_status == -1) {
       if (errno == ENOENT) 
 	/* If the file does not exist, check the path.  */
-	ret_status = stat(path, &buff);
+	ret_status = stat(path.c_str(), &buff);
       if (ret_status == -1) {
 	perror("build_db_file");
 	exit(1);

--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -94,7 +94,7 @@ extern void change_input_focus(HyperLink * link);
 extern void next_input_focus();
 extern void prev_input_focus();
 extern int delete_item(char * name);
-extern XImage * HTReadBitmapFile(Display * display , int screen , char * filename , int * width , int * height);
+extern XImage* HTReadBitmapFile(Display* display , int screen , const char* filename , int* width , int* height);
 extern ImageStruct * insert_image_struct(char * filename);
 extern void compute_form_page(HyperDocPage * page);
 extern int window_width(int cols);

--- a/src/hyper/keyin.c
+++ b/src/hyper/keyin.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@
  *
  ****************************************************************************/
 
+#include <format>
 #include <X11/keysym.h>
 #include "openaxiom-c-macros.h"
 #include "debug.h"
@@ -132,8 +133,6 @@ handle_key(XEvent *event)
   /*char *head = "echo htadd -l ";*/
   /*char *blank1 = "                                        ";*/
   /*char *blank2 = "                                       \n";*/
-  char buffer[180];
-
   charcount = XLookupString((XKeyEvent *)event, key_buffer, key_buffer_size, &keysym ,&compstatus); /* 5 args */
 
   key_buffer[charcount] = '\0';
@@ -154,8 +153,7 @@ handle_key(XEvent *event)
     if (event->xkey.state & ShiftMask) {
       name = gWindow->page->name;
       filename = gWindow->page->filename;
-      sprintf(buffer, "htadd -l %s\n", filename);
-      system(buffer);
+      system(std::format("htadd -l {}\n", filename).c_str());
       if (auto ptr = gFileHashTable.find(filename); ptr != gFileHashTable.end()) {
           fclose(ptr->second);
           gFileHashTable.erase(ptr);

--- a/src/hyper/lex.c
+++ b/src/hyper/lex.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,7 @@
 #include <string.h>
 #include <stack>
 #include <vector>
+#include <format>
 
 #include "debug.h"
 #include "sockio.h"
@@ -876,7 +877,7 @@ token_name(TokenType type)
             strcpy(ebuffer, "~");
             break;
           case TokenType::Cond:
-            sprintf(ebuffer, "\\%s", token.id);
+            strcpy(ebuffer, std::format("\\{}", token.id).c_str());
             break;
           case TokenType::Icorrection:
             strcpy(ebuffer, "\\/");
@@ -888,7 +889,8 @@ token_name(TokenType type)
             strcpy(ebuffer, "\\begin{patch}");
             break;
           default:
-            sprintf(ebuffer, " %d ", type);
+            strcpy(ebuffer, std::format(" {} ", static_cast<int>(type)).c_str());
+            break;
         }
     }
 }
@@ -926,31 +928,27 @@ print_next_ten_tokens()
 void
 print_page_and_filename()
 {
-    char obuff[128];
-
+    std::string obuff;
     if (gPageBeingParsed->type == TokenType::Normal) {
-
         /*
          * Now try to inform the user as close to possible where the error
          * occurred
          */
-        sprintf(obuff, "(HyperDoc) While parsing %s on line %d\n\tin the file %s\n",
-                gPageBeingParsed->name, line_number,
-                gPageBeingParsed->filename);
+        obuff = std::format("(HyperDoc) While parsing {} on line {}\n\tin the file {}\n",
+                            gPageBeingParsed->name, line_number,
+                            gPageBeingParsed->filename);
     }
     else if (gPageBeingParsed->type == TokenType::SpadGen) {
-        sprintf(obuff, "While parsing %s from the Spad socket\n",
-                gPageBeingParsed->name);
+        obuff = std::format("While parsing {} from the Spad socket\n", gPageBeingParsed->name);
     }
     else if (gPageBeingParsed->type == TokenType::Unixfd) {
-        sprintf(obuff, "While parsing %s from a Unixpipe\n",
-                gPageBeingParsed->name);
+        obuff = std::format("While parsing {} from a Unixpipe\n", gPageBeingParsed->name);
     }
     else {
         /* Unknown page type */
-        sprintf(obuff, "While parsing %s\n", gPageBeingParsed->name);
+        obuff = std::format("While parsing {}\n", gPageBeingParsed->name);
     }
-    fprintf(stderr, "%s", obuff);
+    fprintf(stderr, "%s", obuff.c_str());
 }
 
 

--- a/src/hyper/mem.c
+++ b/src/hyper/mem.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reversed.
 
   Redistribution and use in source and binary forms, with or without
@@ -113,7 +113,6 @@ alloc_hd_window()
   w->fMacroHashTable = hash_copy_table(&init_macro_hash);
 
   gWindow = w;
-  /*sprintf(haslisp, "%1d\0", MenuServerOpened);*/
   make_special_pages(w->fPageHashTable);
   w->fDisplayedCursor = 0;
   return w;

--- a/src/hyper/parse-aux.c
+++ b/src/hyper/parse-aux.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reverved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
 #include <string>
 #include <unordered_set>
 #include <string_view>
+#include <format>
 
 #include "debug.h"
 #include "halloc.h"
@@ -90,15 +91,8 @@ window_code(Window *w, int size)
 char *
 window_id(Window w)
 {
-    char *ret;
-    char buff[32];
-    int length;
-
-    sprintf(buff, "%ld", w);
-    length = strlen(buff);
-    ret = (char *) halloc(length * sizeof(char) + 1, "windowid");
-    strcpy(ret, buff);
-    return (ret);
+    auto buf = std::to_string(w);
+    return alloc_string(buf.c_str());
 }
 
 // Sequence of directory pathnames.
@@ -234,10 +228,8 @@ read_ht_files(HTEnvironment& env, FILE *db_fp, const std::string& dir)
 
             ret_val = stat(fullname, &fstats);
             if (ret_val == -1) {
-                char buffer[300];
-
-                sprintf(buffer, "(HyperDoc) read_ht_db: Unable To Open %s :", fullname);
-                perror(buffer);
+                auto buffer = std::format("(HyperDoc) read_ht_db: Unable To Open {} :", fullname);
+                perror(buffer.c_str());
                 exit(-1);
             }
             get_token();

--- a/src/hyper/parse-types.c
+++ b/src/hyper/parse-types.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,8 @@
  *
  ****************************************************************************/
 
+#include <string>
+#include <format>
 #include "openaxiom-c-macros.h"
 #include "debug.h"
 #include "halloc.h"
@@ -82,18 +84,17 @@ static const char* errmess[] =  {
 static void
 htperror(const char* msg, int erno)
 {
-    char obuff[256];
-
+    std::string obuff;
     /* The first thing I do is create the error message */
 
     if (erno <= Numerrors) {
-        sprintf(obuff, "%s:%s\n", msg, errmess[erno]);
+        obuff = std::format("{}:{}\n", msg, errmess[erno]);
     }
     else {
-        sprintf(obuff, "%s:\n", msg);
+        obuff = std::format("{}:\n", msg);
         fprintf(stderr, "Unknown error type %d\n", erno);
     }
-    fprintf(stderr, "%s", obuff);
+    fprintf(stderr, "%s", obuff.c_str());
 
     print_page_and_filename();
 
@@ -190,10 +191,9 @@ parse_condnode()
         break;
       default:
         {
-            char eb[128];
             token_name(token.type);
-            sprintf(eb, "Unexpected Token %s\n", eb);
-            htperror(eb, HTCONDNODE);
+            auto eb = std::format("Unexpected Token {}\n", &ebuffer[0]); 
+            htperror(eb.c_str(), HTCONDNODE);
         }
         break;
     }

--- a/src/hyper/parse.c
+++ b/src/hyper/parse.c
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2023, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,8 @@
 
 #include <stack>
 #include <vector>
+#include <string>
+#include <format>
 #include "debug.h"
 #include "halloc.h"
 #include "sockio.h"
@@ -469,23 +471,19 @@ parse_HyperDoc()
             break;
           case TokenType::Pagename:
             {
-                char *str;
-
                 curr_node->type = TokenType::Word;
                 curr_node->space = 0;
-                str = halloc(strlen(cur_page->name) + 1, "parse");
-                sprintf(str, "%s", cur_page->name);
+                char* str = halloc(strlen(cur_page->name) + 1, "parse");
+                strcpy(str, cur_page->name);
                 curr_node->data.text = alloc_string(str);
                 break;
             }
           case TokenType::Examplenumber:
             {
-                char *str;
-
                 curr_node->type = TokenType::Word;
                 curr_node->space = 0;
-                str = halloc(5, "parse");
-                sprintf(str, "%d", example_number);
+                char* str = halloc(5, "parse");
+                strcpy(str, std::to_string(example_number).c_str());
                 curr_node->data.text = alloc_string(str);
                 break;
             }

--- a/src/hyper/titlebar.c
+++ b/src/hyper/titlebar.c
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
    All rights reserved.
-   Copyright (C) 2007-2023, Gabriel Dos Reis.
+   Copyright (C) 2007-2024, Gabriel Dos Reis.
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,8 @@
  ****************************************************************************/
 
 #include <stdlib.h>
+#include <string>
+#include <format>
 #include "openaxiom-c-macros.h"
 #include "debug.h"
 #include "halloc.h"
@@ -306,48 +308,46 @@ static void
 readTitleBarImages()
 {
     int w, h;
-    char filename[128];
-    char *axiomEnvVar = NULL;
-
-    axiomEnvVar = oa_getenv("AXIOM");
+    std::string filename;
+    auto axiomEnvVar = oa_getenv("AXIOM");
 
     if (axiomEnvVar)
-        sprintf(filename, "%s/share/hypertex/bitmaps/%s", axiomEnvVar, tw1file);
+        filename = std::format("{}/share/hypertex/bitmaps/{}", axiomEnvVar, tw1file);
     else
-        sprintf(filename, "%s", tw1file);
-    tw1image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename,
+        filename = tw1file;
+    tw1image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename.c_str(),
                                 &twwidth, &twheight);
 
     if (axiomEnvVar)
-        sprintf(filename, "%s/share/hypertex/bitmaps/%s", axiomEnvVar, tw2file);
+        filename = std::format("{}/share/hypertex/bitmaps/{}", axiomEnvVar, tw2file);
     else
-        sprintf(filename, "%s", tw2file);
-    tw2image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename,
+        filename = tw2file;
+    tw2image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename.c_str(),
                                 &w, &h);
     twwidth = ((twwidth >= w) ? (twwidth) : (w));
 
     if (axiomEnvVar)
-        sprintf(filename, "%s/share/hypertex/bitmaps/%s", axiomEnvVar, tw3file);
+        filename = std::format("{}/share/hypertex/bitmaps/{}", axiomEnvVar, tw3file);
     else
-        sprintf(filename, "%s", tw3file);
-    tw3image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename,
+        filename = tw3file;
+    tw3image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename.c_str(),
                                 &w, &h);
     twwidth = ((twwidth >= w) ? (twwidth) : (w));
 
     if (axiomEnvVar)
-        sprintf(filename, "%s/share/hypertex/bitmaps/%s", axiomEnvVar, tw4file);
+        filename = std::format("{}/share/hypertex/bitmaps/{}", axiomEnvVar, tw4file);
     else
-        sprintf(filename, "%s", tw4file);
-    tw4image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename,
+        filename = tw4file;
+    tw4image = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename.c_str(),
                                 &w, &h);
     twwidth = ((twwidth >= w) ? (twwidth) : (w));
 
 
     if (axiomEnvVar)
-        sprintf(filename, "%s/share/hypertex/bitmaps/%s", axiomEnvVar, noopfile);
+        filename = std::format("{}/share/hypertex/bitmaps/{}", axiomEnvVar, noopfile);
     else
-        sprintf(filename, "%s", noopfile);
-    noopimage = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename,
+        filename = noopfile;
+    noopimage = HTReadBitmapFile(gXDisplay, gXScreenNumber, filename.c_str(),
                                  &twwidth, &twheight);
 }
 

--- a/src/include/pixmap.h
+++ b/src/include/pixmap.h
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 1991-2002, The Numerical Algorithms Group Ltd.
   All rights reserved.
-  Copyright (C) 2007-2008, Gabriel Dos Reis.
+  Copyright (C) 2007-2024, Gabriel Dos Reis.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -36,8 +36,8 @@
 #ifndef OPENAXIOM_PIXMAP_included
 #define OPENAXIOM_PIXMAP_included
 
-extern int file_exists(char * );
-extern FILE * zzopen(char *  , const char* );
+extern int file_exists(const char*);
+extern FILE* zzopen(const char*  , const char* );
 extern void write_pixmap_file(Display*, int, const char*, Window, int, int, int, int);
 extern int read_pixmap_file(Display *  , int  , char *  , XImage * *  , int *  , int * );
 

--- a/src/lib/pixmap.c
+++ b/src/lib/pixmap.c
@@ -1,7 +1,7 @@
 /*
     Copyright (c) 1991-2002, The Numerical ALgorithms Group Ltd.
     All rights reserved.
-    Copyright (C) 2007-2013, Gabriel Dos Reis.
+    Copyright (C) 2007-2024, Gabriel Dos Reis.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -58,7 +58,7 @@
 /* returns true if the file exists */
 
 int
-file_exists(char *file)
+file_exists(const char *file)
 {
     FILE *f;
 
@@ -69,8 +69,8 @@ file_exists(char *file)
     return 0;
 }
 
-FILE *
-zzopen(char *file, const char* mode)
+FILE*
+zzopen(const char* file, const char* mode)
 {
     char com[512], zfile[512];
 


### PR DESCRIPTION
In many cases, a better and safer alternative is provided by C++20's `std::format` functionality.