### PR TITLE
[boot] Export names used in other modules

### DIFF
--- a/src/boot/includer.boot
+++ b/src/boot/includer.boot
@@ -1,6 +1,6 @@
 -- Copyright (c) 1991-2002, The Numerical ALgorithms Group Ltd.
 -- All rights reserved.
--- Copyright (C) 2007-2014, Gabriel Dos Reis.
+-- Copyright (C) 2007-2024, Gabriel Dos Reis.
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,9 @@
 
 import tokens
 namespace BOOTTRAN
-module includer
+module includer (PNAME, shoeNotFound, shoeReadLispString, shoeConsole,
+          shoeSpace, lineNo, lineString, lineCharacter, bStreamNull,
+             bNext, bRgen, bIgen, bAddLineNumber, shoeInclude)
 
 -- BOOT INCLUDER
  
@@ -120,8 +122,9 @@ lineCharacter p ==
  
 -- Lazy inclusion support.
 
+++ End of stream marker.
 $bStreamNil == ["nullstream"]
- 
+
 bStreamNull x ==
   x = nil or x is ["nullstream",:.] => true
   while x is ["nonnullstream",op,:args] repeat
@@ -163,7 +166,7 @@ bRgen s ==
 bRgen1 s ==
   a := readLine s
   a ~= %nothing => [a,:bRgen s]
-  ["nullstream"]
+  $bStreamNil
  
 bIgen n ==
   bDelay(function bIgen1,[n])
@@ -176,10 +179,8 @@ bAddLineNumber(f1,f2) ==
   bDelay(function bAddLineNumber1,[f1,f2])
  
 bAddLineNumber1(f1,f2)==
-  bStreamNull f1 =>  ["nullstream"]
-  bStreamNull f2 =>  ["nullstream"]
+  bStreamNull f1 or bStreamNull f2 => $bStreamNil
   [makeSourceLine(first f1,first f2),:bAddLineNumber(rest f1,rest f2)]
-
 
 shoePrefixLisp x == 
   strconc('")lisp",x)

--- a/src/boot/strap/includer.clisp
+++ b/src/boot/strap/includer.clisp
@@ -5,6 +5,12 @@
 
 (PROVIDE "includer")
 
+(EVAL-WHEN (:COMPILE-TOPLEVEL :LOAD-TOPLEVEL :EXECUTE)
+  (EXPORT
+   '(PNAME |shoeNotFound| |shoeReadLispString| |shoeConsole| |shoeSpace|
+           |lineNo| |lineString| |lineCharacter| |bStreamNull| |bNext| |bRgen|
+           |bIgen| |bAddLineNumber| |shoeInclude|)))
+
 (DEFUN PNAME (|x|)
   (COND ((SYMBOLP |x|) (SYMBOL-NAME |x|)) ((CHARACTERP |x|) (STRING |x|))
         (T NIL)))
@@ -110,7 +116,7 @@
     (PROGN
      (SETQ |a| (|readLine| |s|))
      (COND ((NOT (EQ |a| |%nothing|)) (CONS |a| (|bRgen| |s|)))
-           (T (LIST '|nullstream|))))))
+           (T |$bStreamNil|)))))
 
 (DEFUN |bIgen| (|n|) (|bDelay| #'|bIgen1| (LIST |n|)))
 
@@ -120,8 +126,7 @@
   (|bDelay| #'|bAddLineNumber1| (LIST |f1| |f2|)))
 
 (DEFUN |bAddLineNumber1| (|f1| |f2|)
-  (COND ((|bStreamNull| |f1|) (LIST '|nullstream|))
-        ((|bStreamNull| |f2|) (LIST '|nullstream|))
+  (COND ((OR (|bStreamNull| |f1|) (|bStreamNull| |f2|)) |$bStreamNil|)
         (T
          (CONS (|makeSourceLine| (CAR |f1|) (CAR |f2|))
                (|bAddLineNumber| (CDR |f1|) (CDR |f2|))))))

--- a/src/boot/strap/parser.clisp
+++ b/src/boot/strap/parser.clisp
@@ -387,7 +387,7 @@
       (COND (|done| (RETURN NIL))
             (T
              (SETQ |found|
-                     (LET ((#1=#:G370
+                     (LET ((#1=#:G107
                             (CATCH :OPEN-AXIOM-CATCH-POINT (FUNCALL |f| |ps|))))
                        (COND
                         ((AND (CONSP #1#)
@@ -1411,7 +1411,7 @@
      (SETQ |op| (|enclosingFunction| (|parserLoadUnit| |ps|)))
      (SETQ |varno| (|parserGensymSequenceNumber| |ps|))
      (UNWIND-PROTECT
-         (LET ((#1=#:G371
+         (LET ((#1=#:G108
                 (CATCH :OPEN-AXIOM-CATCH-POINT
                   (PROGN
                    (SETF (|enclosingFunction| (|parserLoadUnit| |ps|)) NIL)

--- a/src/boot/strap/tokens.clisp
+++ b/src/boot/strap/tokens.clisp
@@ -84,10 +84,10 @@
   (LET* (|s|)
     (COND
      ((SETQ |s|
-              (WITH-HASH-TABLE-ITERATOR (#1=#:G369 |shoeKeyTable|)
+              (WITH-HASH-TABLE-ITERATOR (#1=#:G106 |shoeKeyTable|)
                 (LET ((|bfVar#1| NIL))
                   (LOOP
-                   (MULTIPLE-VALUE-BIND (#2=#:G370 |k| |v|)
+                   (MULTIPLE-VALUE-BIND (#2=#:G107 |k| |v|)
                        (#1#)
                      (COND ((NOT #2#) (RETURN |bfVar#1|))
                            (T
@@ -138,9 +138,9 @@
                  (COND ((> |i| 255) (RETURN NIL)) (T (SETF (ELT |a| |i|) |b|)))
                  (SETQ |i| (+ |i| 1))))
               |a|))
-     (WITH-HASH-TABLE-ITERATOR (#1=#:G371 |shoeKeyTable|)
+     (WITH-HASH-TABLE-ITERATOR (#1=#:G108 |shoeKeyTable|)
        (LOOP
-        (MULTIPLE-VALUE-BIND (#2=#:G372 |s| #:G373)
+        (MULTIPLE-VALUE-BIND (#2=#:G109 |s| #:G110)
             (#1#)
           (COND ((NOT #2#) (RETURN NIL)) (T (|shoeInsert| |s| |d|))))))
      |d|)))
@@ -154,9 +154,9 @@
      (LET ((|i| 0))
        (LOOP (COND ((> |i| 255) (RETURN NIL)) (T (SETF (SBIT |a| |i|) 0)))
              (SETQ |i| (+ |i| 1))))
-     (WITH-HASH-TABLE-ITERATOR (#1=#:G374 |shoeKeyTable|)
+     (WITH-HASH-TABLE-ITERATOR (#1=#:G111 |shoeKeyTable|)
        (LOOP
-        (MULTIPLE-VALUE-BIND (#2=#:G375 |k| #:G376)
+        (MULTIPLE-VALUE-BIND (#2=#:G112 |k| #:G113)
             (#1#)
           (COND ((NOT #2#) (RETURN NIL)) ((|shoeStartsId| (SCHAR |k| 0)) NIL)
                 (T (SETF (SBIT |a| (CHAR-CODE (SCHAR |k| 0))) 1))))))

--- a/src/boot/strap/translator.clisp
+++ b/src/boot/strap/translator.clisp
@@ -443,7 +443,7 @@
      (SETQ |ps| (|makeParserState| |toks|))
      (|bpFirstTok| |ps|)
      (SETQ |found|
-             (LET ((#1=#:G379
+             (LET ((#1=#:G116
                     (CATCH :OPEN-AXIOM-CATCH-POINT (|bpOutItem| |ps|))))
                (COND
                 ((AND (CONSP #1#) (EQUAL (CAR #1#) :OPEN-AXIOM-CATCH-POINT))


### PR DESCRIPTION
Export names from `includer` that are used in other modules of bootsys.