### PR TITLE
CMake: Lisp runtime detection and Phase 3 base image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,15 +202,12 @@ set(OA_STAGE_ROOT "${PROJECT_BINARY_DIR}/${OA_TARGET_TRIPLE}")
 set(OA_INSTALL_LAYOUT_ROOT "${CMAKE_INSTALL_LIBDIR}/open-axiom/${OA_TARGET_TRIPLE}/${PROJECT_VERSION}")
 
 # -- 5. External toolchain discovery --------------------------------------
-# Locate optional tools: the Lisp runtime (central to the bootstrap
-# chain, added in a later PR), Qt for the GUI, LLVM for native code
-# generation, and TeX for documentation.
+# Locate the Lisp runtime (central to the bootstrap chain), plus optional
+# tools: Qt for the GUI front-end, LLVM for native code generation, and
+# TeX for documentation.
 
 # Lisp runtime -- accepts either a bare name (looked up via find_program)
-# or an absolute path to the binary.  The full Lisp runtime detection
-# module (cmake/OpenAxiomLispRuntime.cmake) is added in a subsequent PR;
-# here we only locate the binary so that the configuration summary can
-# report its availability.
+# or an absolute path to the binary.
 if(IS_ABSOLUTE "${OA_WITH_LISP}" AND EXISTS "${OA_WITH_LISP}")
   set(OA_LISP_EXECUTABLE "${OA_WITH_LISP}")
 else()
@@ -223,12 +220,11 @@ find_program(LATEX_EXECUTABLE NAMES latex)
 find_program(MAKEINDEX_EXECUTABLE NAMES makeindex)
 find_program(LLVM_CONFIG_EXECUTABLE NAMES llvm-config llvm-config-18 llvm-config-17)
 
-# Lisp runtime configuration -- safe defaults until the detection module
-# (cmake/OpenAxiomLispRuntime.cmake) is added in a subsequent PR.
-# OPENAXIOM_BASE_RTS must be a valid C++ enumerator from the Runtime
-# enum; OPENAXIOM_HOST_LISP_PRECISION must be a numeric literal.
-set(OPENAXIOM_BASE_RTS "Runtime::unknown")
-set(OPENAXIOM_HOST_LISP_PRECISION 64)
+# Configure the Lisp runtime -- this probes the binary (if found) and sets
+# flavor-specific variables for FASL extensions, FFI types, linking model,
+# etc.  See cmake/OpenAxiomLispRuntime.cmake for full documentation.
+include(OpenAxiomLispRuntime)
+oa_configure_lisp_runtime()
 
 # -- 6. Derived feature flags ---------------------------------------------
 # Combine user options with detection results to produce the final
@@ -305,20 +301,27 @@ endif()
 # -- 7. Configuration summary ---------------------------------------------
 
 message(STATUS "OpenAxiom CMake configuration summary:")
+message(STATUS "  Lisp runtime      : ${OA_WITH_LISP} (${OA_LISP_EXECUTABLE})")
+message(STATUS "  Lisp flavor       : ${OA_LISP_FLAVOR}")
+message(STATUS "  FASL/LNK ext      : ${OA_LISP_FASL_EXT} / ${OA_LISP_LNK_EXT}")
+message(STATUS "  delayed FFI       : ${oa_delay_ffi}")
 message(STATUS "  LLVM detected     : ${OPENAXIOM_HOST_HAS_LLVM}")
 message(STATUS "  X11 detected      : ${OA_HAVE_X11}")
 message(STATUS "  Qt detected       : ${OPENAXIOM_USE_GUI} (${OA_QT_VERSION})")
 message(STATUS "  SMAN enabled      : ${OPENAXIOM_USE_SMAN}")
 message(STATUS "  regex.h available : ${HAVE_REGEX_H}")
+message(STATUS "  pdf tools         : ${PDFLATEX_EXECUTABLE};${LATEX_EXECUTABLE};${MAKEINDEX_EXECUTABLE}")
 message(STATUS "  target triple     : ${OA_TARGET_TRIPLE}")
 message(STATUS "  stage root        : ${OA_STAGE_ROOT}")
 message(STATUS "  install root      : ${OA_INSTALL_LAYOUT_ROOT}")
 
 # -- 8. Generated headers and templates -----------------------------------
-# Generate the C/C++ config header (substituting HAVE_* probes).
+# Generate the C/C++ config header (substituting HAVE_* probes) and the
+# Lisp settings file (substituting Lisp runtime variables).
 
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/config")
 file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/include/open-axiom")
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/share/open-axiom/cmake")
 
 # The C/C++ config header is generated twice:
 #   1. Under config/  -- consumed by src/CMakeLists.txt include paths.
@@ -333,6 +336,15 @@ configure_file(
 configure_file(
   "${PROJECT_SOURCE_DIR}/cmake/openaxiom-c-macros.h.in"
   "${PROJECT_BINARY_DIR}/include/open-axiom/config"
+  @ONLY
+)
+
+# Lisp settings file -- captures the full Lisp runtime configuration so
+# that later CMake-based build phases (algebra, databases) can simply
+# include() this file instead of re-running detection.
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/openaxiom-lisp-settings.cmake.in"
+  "${PROJECT_BINARY_DIR}/config/openaxiom-lisp-settings.cmake"
   @ONLY
 )
 

--- a/cmake/OpenAxiomLispRuntime.cmake
+++ b/cmake/OpenAxiomLispRuntime.cmake
@@ -1,0 +1,382 @@
+# OpenAxiomLispRuntime.cmake -- Lisp runtime detection and configuration
+#
+# This module probes the host Lisp system at CMake configure time and sets
+# the full matrix of flavor-specific variables that later build stages need
+# to compile Lisp sources, link base images, and generate FFI type tables.
+#
+# Public entry point:
+#   oa_configure_lisp_runtime()
+#     Reads OA_WITH_LISP and OA_LISP_EXECUTABLE from the calling scope,
+#     queries the runtime, and exports ~25 variables into the parent scope.
+#
+# Supported Lisp flavors: SBCL, ECL, CLisp, GCL, Clozure.
+#
+# Internal helpers (not intended for external use):
+#   oa_parse_lisp_flavor(OUTVAR RAW_TEXT)
+#   oa_list_to_string(OUTVAR ...)
+#   oa_query_lisp(OUTPUT_VAR EXPRESSION <expr>)
+#   oa_set_ffi_type_table(flavor precision)
+
+
+# ---------------------------------------------------------------------------
+# oa_parse_lisp_flavor -- classify a Lisp implementation from free-form text
+# ---------------------------------------------------------------------------
+# Examines the output of (lisp-implementation-type) or similar and returns a
+# canonical flavor tag: sbcl, ecl, clisp, clozure, gcl, or "unknown".
+function(oa_parse_lisp_flavor OUTVAR RAW_TEXT)
+  string(TOLOWER "${RAW_TEXT}" _lisp_text)
+  set(_flavor "unknown")
+
+  if(_lisp_text MATCHES "sbcl")
+    set(_flavor "sbcl")
+  elseif(_lisp_text MATCHES "extensible common lisp|(^|[^a-z])ecl([^a-z]|$)")
+    set(_flavor "ecl")
+  elseif(_lisp_text MATCHES "clisp")
+    set(_flavor "clisp")
+  elseif(_lisp_text MATCHES "clozure|ccl")
+    set(_flavor "clozure")
+  elseif(_lisp_text MATCHES "gcl")
+    set(_flavor "gcl")
+  endif()
+
+  set(${OUTVAR} "${_flavor}" PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# oa_list_to_string -- join a CMake list into a space-separated string
+# ---------------------------------------------------------------------------
+function(oa_list_to_string OUTVAR)
+  string(REPLACE ";" " " _value "${ARGN}")
+  set(${OUTVAR} "${_value}" PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# oa_query_lisp -- evaluate a Lisp expression at configure time
+# ---------------------------------------------------------------------------
+# Runs OA_LISP_EXECUTABLE in batch mode, evaluating EXPRESSION.  Both stdout
+# and stderr are captured and returned (some Lisps print useful diagnostics
+# to stderr).  The caller must set OA_LISP_QUIET_ARGS, OA_LISP_BATCH_ARGS,
+# OA_LISP_EVAL_FLAG, and optionally OA_LISP_ENV_VARS before calling.
+#
+# Any environment variables in OA_LISP_ENV_VARS (e.g. GCL_ANSI=t) are
+# injected via "cmake -E env".
+function(oa_query_lisp OUTPUT_VAR)
+  set(options)
+  set(oneValueArgs EXPRESSION)
+  cmake_parse_arguments(OA_QUERY "${options}" "${oneValueArgs}" "" ${ARGN})
+
+  if(NOT OA_LISP_EXECUTABLE)
+    set(${OUTPUT_VAR} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  # Build the optional environment-variable prefix.
+  set(_env_args)
+  if(OA_LISP_ENV_VARS)
+    set(_env_args ${OA_LISP_ENV_VARS})
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env ${_env_args}
+      "${OA_LISP_EXECUTABLE}" ${OA_LISP_QUIET_ARGS} ${OA_LISP_BATCH_ARGS}
+      ${OA_LISP_EVAL_FLAG} "${OA_QUERY_EXPRESSION}"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _output
+    ERROR_VARIABLE _error
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+
+  # Merge stdout and stderr -- some Lisps emit results on either stream.
+  set(${OUTPUT_VAR} "${_output}\n${_error}" PARENT_SCOPE)
+endfunction()
+
+
+# ---------------------------------------------------------------------------
+# oa_set_ffi_type_table -- populate flavor-specific FFI type names
+# ---------------------------------------------------------------------------
+# Each Lisp spells the fundamental C types differently in its FFI layer.
+# This macro sets _void_type ... _pointer_type in the *caller's* scope.
+# The tables below are transcribed from config/open-axiom.m4.
+#
+# Uses a macro (not a function) so that the variables are set directly in
+# the enclosing scope without needing PARENT_SCOPE on every line.
+macro(oa_set_ffi_type_table _flavor _precision)
+  if("${_flavor}" STREQUAL "gcl")
+    set(_void_type   "void")
+    set(_char_type   "char")
+    set(_int_type    "int")
+    set(_float_type  "float")
+    set(_double_type "double")
+    set(_string_type "string")
+    if(${_precision} EQUAL 64)
+      set(_pointer_type "(signed-integer 64)")
+    else()
+      set(_pointer_type "fixnum")
+    endif()
+
+  elseif("${_flavor}" STREQUAL "sbcl")
+    set(_void_type   "void")
+    set(_char_type   "char")
+    set(_int_type    "int")
+    set(_float_type  "float")
+    set(_double_type "double")
+    set(_string_type "c-string")
+    set(_pointer_type "(* t)")
+
+  elseif("${_flavor}" STREQUAL "clisp")
+    set(_void_type   "nil")
+    set(_char_type   "character")
+    set(_int_type    "int")
+    set(_float_type  "single-float")
+    set(_double_type "double-float")
+    set(_string_type "c-string")
+    set(_pointer_type "c-pointer")
+
+  elseif("${_flavor}" STREQUAL "ecl")
+    set(_void_type   ":void")
+    set(_char_type   ":char")
+    set(_int_type    ":int")
+    set(_float_type  ":float")
+    set(_double_type ":double")
+    set(_string_type ":cstring")
+    set(_pointer_type ":pointer-void")
+
+  elseif("${_flavor}" STREQUAL "clozure")
+    set(_void_type   ":void")
+    set(_char_type   ":unsigned-byte")
+    set(_int_type    ":signed-fullword")
+    set(_float_type  ":single-float")
+    set(_double_type ":double-float")
+    set(_string_type ":address")
+    set(_pointer_type ":address")
+
+  else()
+    # Fallback -- use SBCL-compatible names as a reasonable default.
+    set(_void_type   "void")
+    set(_char_type   "char")
+    set(_int_type    "int")
+    set(_float_type  "float")
+    set(_double_type "double")
+    set(_string_type "c-string")
+    set(_pointer_type "(* t)")
+  endif()
+endmacro()
+
+
+# ===========================================================================
+# oa_configure_lisp_runtime -- master configuration entry point
+# ===========================================================================
+# Reads:
+#   OA_WITH_LISP         -- user-requested flavor name (e.g. "sbcl", "gcl")
+#   OA_LISP_EXECUTABLE   -- absolute path to the Lisp binary (may be empty)
+#
+# Exports into the parent scope (see end of function for the full list):
+#   OA_LISP_FLAVOR, OA_LISP_FASL_EXT, OA_LISP_LNK_EXT,
+#   OA_LISP_QUIET_ARGS, OA_LISP_BATCH_ARGS, OA_LISP_EVAL_FLAG,
+#   OA_LISP_ENV_VARS, OPENAXIOM_BASE_RTS, OPENAXIOM_HOST_LISP_PRECISION,
+#   oa_lisp_flavor, oa_standard_linking, oa_delay_ffi, oa_use_dynamic_lib,
+#   oa_quiet_flags, oa_eval_flags, oa_optimize_options,
+#   void_type ... pointer_type  (FFI type names for core.lisp.in substitution)
+function(oa_configure_lisp_runtime)
+  string(TOLOWER "${OA_WITH_LISP}" _requested_flavor)
+
+  # -------------------------------------------------------------------
+  # 1. Set up the command-line protocol for each Lisp flavor.
+  #    Each Lisp has its own way of being invoked non-interactively:
+  #      quiet args   -- suppress banners and prompts
+  #      batch args   -- skip user/site init files
+  #      eval flag    -- the flag that precedes a Lisp expression
+  #      env vars     -- environment variables needed (e.g. GCL_ANSI=t)
+  # -------------------------------------------------------------------
+  set(_quiet_args)
+  set(_batch_args)
+  set(_eval_flag --eval)
+  set(_env_vars)
+
+  if(_requested_flavor STREQUAL "gcl")
+    set(_quiet_args -batch)
+    set(_eval_flag -eval)
+    # GCL 2.7 defaults to CLtL1 mode where DEFPACKAGE is unavailable.
+    # Setting GCL_ANSI=t selects the ANSI image instead.
+    set(_env_vars "GCL_ANSI=t")
+  elseif(_requested_flavor STREQUAL "ecl")
+    set(_batch_args -norc)
+    set(_eval_flag -eval)
+  elseif(_requested_flavor STREQUAL "sbcl")
+    set(_quiet_args --noinform --noprint)
+    set(_batch_args --no-sysinit --no-userinit --disable-debugger)
+    set(_eval_flag --eval)
+  elseif(_requested_flavor STREQUAL "clisp")
+    set(_quiet_args --quiet)
+    set(_batch_args -norc)
+    set(_eval_flag -x)
+  elseif(_requested_flavor STREQUAL "clozure")
+    set(_quiet_args --quiet --no-init)
+    set(_eval_flag --eval)
+  endif()
+
+  # Publish invocation protocol for both local use and parent scope.
+  set(OA_LISP_QUIET_ARGS ${_quiet_args} PARENT_SCOPE)
+  set(OA_LISP_BATCH_ARGS ${_batch_args} PARENT_SCOPE)
+  set(OA_LISP_EVAL_FLAG  ${_eval_flag}  PARENT_SCOPE)
+  set(OA_LISP_ENV_VARS   ${_env_vars}   PARENT_SCOPE)
+  # Local copies so oa_query_lisp can read them within this function.
+  set(OA_LISP_QUIET_ARGS ${_quiet_args})
+  set(OA_LISP_BATCH_ARGS ${_batch_args})
+  set(OA_LISP_EVAL_FLAG  ${_eval_flag})
+  set(OA_LISP_ENV_VARS   ${_env_vars})
+
+  # -------------------------------------------------------------------
+  # 2. Establish default FASL extension and host-precision fallbacks.
+  #    These are overridden below if the Lisp is actually queryable.
+  # -------------------------------------------------------------------
+  set(_detected_flavor "${_requested_flavor}")
+  set(_fasl_ext "fasl")
+  set(_precision "${CMAKE_SIZEOF_VOID_P}")
+  math(EXPR _precision "${_precision} * 8")
+
+  # Static per-flavor defaults for when the binary is not available.
+  if(_requested_flavor STREQUAL "gcl")
+    set(_fasl_ext "o")
+  elseif(_requested_flavor STREQUAL "clisp"
+      OR _requested_flavor STREQUAL "ecl")
+    set(_fasl_ext "fas")
+  endif()
+
+  # -------------------------------------------------------------------
+  # 3. Query the actual Lisp runtime, if available.
+  #    Three queries: implementation type, *features*, FASL extension.
+  # -------------------------------------------------------------------
+  if(OA_LISP_EXECUTABLE)
+    # 3a. Identify the implementation type to confirm the flavor.
+    oa_query_lisp(_impl_dump
+      EXPRESSION "(progn (format t \"oa_lisp_implementation=~a\" (lisp-implementation-type)) (quit))")
+    oa_parse_lisp_flavor(_parsed_flavor "${_impl_dump}")
+    if(NOT _parsed_flavor STREQUAL "unknown")
+      set(_detected_flavor "${_parsed_flavor}")
+    endif()
+
+    # 3b. Dump *features* for precision detection and capability checks.
+    oa_query_lisp(_feature_dump
+      EXPRESSION "(progn (dolist (feature *features*) (format t \"~a \" feature)) (quit))")
+    string(TOUPPER "${_feature_dump}" _feature_dump_upper)
+
+    # 3c. Ask the compiler for the actual FASL file extension.
+    oa_query_lisp(_fasl_dump
+      EXPRESSION "(progn (format t \"oa_fasl_type=~a\" (pathname-type (compile-file-pathname \"foo.lisp\"))) (quit))")
+    string(REGEX MATCH "oa_fasl_type=([^ \r\n]+)" _fasl_match "${_fasl_dump}")
+    if(CMAKE_MATCH_1)
+      set(_fasl_ext "${CMAKE_MATCH_1}")
+    endif()
+
+    # Determine host word size from feature flags.
+    if(_feature_dump_upper MATCHES "X86-64|X86_64|WORD-SIZE=64|64-BIT")
+      set(_precision 64)
+    else()
+      set(_precision 32)
+    endif()
+
+    # CLisp without FFI support cannot build OpenAxiom.
+    if(_detected_flavor STREQUAL "clisp" AND NOT _feature_dump_upper MATCHES "FFI")
+      message(FATAL_ERROR
+        "The selected CLISP runtime does not report FFI support, which OpenAxiom requires")
+    endif()
+  endif()
+
+  # -------------------------------------------------------------------
+  # 4. Derive the linking model from the detected flavor.
+  #
+  #    ECL uses "standard linking" -- it compiles Lisp to C, producing
+  #    native object files (.o) that are linked by the C toolchain.
+  #    All other flavors produce their own linkable FASL format.
+  #
+  #    Delayed FFI means FFI stubs are resolved at image-load time
+  #    rather than at compile time (SBCL, CLisp, Clozure).
+  # -------------------------------------------------------------------
+  string(REGEX REPLACE "^\\." "" _objext "${CMAKE_C_OUTPUT_EXTENSION}")
+  if(NOT _objext)
+    set(_objext "o")
+  endif()
+
+  set(_standard_linking "no")
+  set(_delay_ffi        "no")
+  set(_use_dynamic_lib  "yes")
+  set(_lnkext           "${_fasl_ext}")
+
+  if(_detected_flavor STREQUAL "ecl")
+    set(_standard_linking "yes")
+    set(_use_dynamic_lib  "no")
+    set(_lnkext           "${_objext}")
+  elseif(_detected_flavor STREQUAL "gcl")
+    set(_use_dynamic_lib  "no")
+  endif()
+
+  if(_detected_flavor STREQUAL "sbcl"
+      OR _detected_flavor STREQUAL "clozure"
+      OR _detected_flavor STREQUAL "clisp")
+    set(_delay_ffi "yes")
+  endif()
+
+  # -------------------------------------------------------------------
+  # 5. Populate the FFI type table (delegated to the macro above).
+  # -------------------------------------------------------------------
+  oa_set_ffi_type_table("${_detected_flavor}" "${_precision}")
+
+  # -------------------------------------------------------------------
+  # 6. Choose Lisp compiler optimisation options.
+  #    When runtime checking or profiling is requested we add safety
+  #    (and debug, where supported) so the Lisp compiler preserves
+  #    enough metadata for useful diagnostics.
+  # -------------------------------------------------------------------
+  set(_optimize_options "speed")
+  if(OA_ENABLE_RUNTIME_CHECKING OR OA_ENABLE_PROFILING)
+    if(_detected_flavor STREQUAL "gcl")
+      # GCL does not support (optimize ... (debug N)).
+      set(_optimize_options "speed safety")
+    else()
+      set(_optimize_options "speed safety debug")
+    endif()
+  endif()
+
+  # Convert list-form flags into the space-separated strings that
+  # core.lisp.in expects.
+  oa_list_to_string(_quiet_flags ${_quiet_args})
+  oa_list_to_string(_eval_flags  ${_batch_args} ${_eval_flag})
+
+  # -------------------------------------------------------------------
+  # 7. Export everything into the parent scope.
+  # -------------------------------------------------------------------
+
+  # Variables used by CMake build rules (src/CMakeLists.txt).
+  set(OA_LISP_FLAVOR    "${_detected_flavor}"            PARENT_SCOPE)
+  set(OA_LISP_FASL_EXT  "${_fasl_ext}"                   PARENT_SCOPE)
+  set(OA_LISP_LNK_EXT   "${_lnkext}"                     PARENT_SCOPE)
+  # Map the detected flavor to the C++ Runtime:: enum.  If the flavor
+  # does not match any known enumerator, fall back to Runtime::unknown
+  # so that the generated header is always valid C++.
+  if(_detected_flavor MATCHES "^(gcl|ecl|sbcl|clisp|clozure|bemol|polyml)$")
+    set(OPENAXIOM_BASE_RTS "Runtime::${_detected_flavor}" PARENT_SCOPE)
+  else()
+    set(OPENAXIOM_BASE_RTS "Runtime::unknown"             PARENT_SCOPE)
+  endif()
+  set(OPENAXIOM_HOST_LISP_PRECISION "${_precision}"       PARENT_SCOPE)
+
+  # Variables substituted into core.lisp.in via @VAR@.
+  set(oa_lisp_flavor      "${_detected_flavor}"  PARENT_SCOPE)
+  set(oa_standard_linking  "${_standard_linking}" PARENT_SCOPE)
+  set(oa_delay_ffi         "${_delay_ffi}"        PARENT_SCOPE)
+  set(oa_use_dynamic_lib   "${_use_dynamic_lib}"  PARENT_SCOPE)
+  set(oa_quiet_flags       "${_quiet_flags}"      PARENT_SCOPE)
+  set(oa_eval_flags        "${_eval_flags}"       PARENT_SCOPE)
+  set(oa_optimize_options  "${_optimize_options}"  PARENT_SCOPE)
+
+  # FFI type names (substituted into core.lisp.in).
+  set(void_type    "${_void_type}"    PARENT_SCOPE)
+  set(char_type    "${_char_type}"    PARENT_SCOPE)
+  set(int_type     "${_int_type}"     PARENT_SCOPE)
+  set(float_type   "${_float_type}"   PARENT_SCOPE)
+  set(double_type  "${_double_type}"  PARENT_SCOPE)
+  set(string_type  "${_string_type}"  PARENT_SCOPE)
+  set(pointer_type "${_pointer_type}" PARENT_SCOPE)
+endfunction()

--- a/cmake/openaxiom-lisp-settings.cmake.in
+++ b/cmake/openaxiom-lisp-settings.cmake.in
@@ -1,0 +1,53 @@
+# ===========================================================================
+# openaxiom-lisp-settings.cmake -- generated Lisp runtime configuration
+# ===========================================================================
+# This file is produced by configure_file() from the .in template.  It
+# captures every Lisp runtime variable that was detected at configure time
+# so that later CMake-based build phases (algebra compilation, database
+# generation, etc.) can simply include() it instead of re-running the
+# detection logic.
+#
+# Variables with @VAR@ placeholders are substituted by CMake at configure
+# time from values set in cmake/OpenAxiomLispRuntime.cmake.
+# ===========================================================================
+
+# -- Lisp binary and flavor identification --
+set(OA_LISP_EXECUTABLE "@OA_LISP_EXECUTABLE@")
+set(OA_LISP_FLAVOR "@OA_LISP_FLAVOR@")
+
+# -- File extensions --
+# FASL: compiled Lisp file extension (e.g. fasl, fas, o).
+# LNK:  linkable object extension -- same as FASL except for ECL where
+#       standard-linking produces native .o files.
+set(OA_LISP_FASL_EXT "@OA_LISP_FASL_EXT@")
+set(OA_LISP_LNK_EXT "@OA_LISP_LNK_EXT@")
+
+# -- Linking model flags --
+# OA_STANDARD_LINKING:  "yes" for ECL (Lisp -> C -> .o -> link).
+# OA_DELAY_FFI:         "yes" when FFI stubs resolve at image-load time
+#                       (SBCL, CLisp, Clozure).
+# OA_USE_DYNAMIC_LIB:   "yes" when the runtime supports shared libraries.
+set(OA_STANDARD_LINKING "@oa_standard_linking@")
+set(OA_DELAY_FFI "@oa_delay_ffi@")
+set(OA_USE_DYNAMIC_LIB "@oa_use_dynamic_lib@")
+
+# -- Invocation flags (space-separated) --
+set(OA_QUIET_FLAGS "@oa_quiet_flags@")
+set(OA_EVAL_FLAGS "@oa_eval_flags@")
+
+# -- Host precision (32 or 64) --
+set(OA_HOST_LISP_PRECISION "@OPENAXIOM_HOST_LISP_PRECISION@")
+
+# -- FFI type names --
+# Each Lisp spells fundamental C types differently in its FFI layer.
+# These are substituted into algebra / compiler Lisp sources.
+set(OA_FFI_VOID_TYPE "@void_type@")
+set(OA_FFI_CHAR_TYPE "@char_type@")
+set(OA_FFI_INT_TYPE "@int_type@")
+set(OA_FFI_FLOAT_TYPE "@float_type@")
+set(OA_FFI_DOUBLE_TYPE "@double_type@")
+set(OA_FFI_STRING_TYPE "@string_type@")
+set(OA_FFI_POINTER_TYPE "@pointer_type@")
+
+# -- Compiler optimisation options --
+set(OA_OPTIMIZE_OPTIONS "@oa_optimize_options@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,8 +2,8 @@
 # src/CMakeLists.txt -- OpenAxiom source-tree targets
 # ===========================================================================
 # This file defines the native C/C++ libraries and executables that form
-# the foundation of the OpenAxiom build.  Later PRs add:
-#   - Lisp runtime compilation (Phase 3)
+# the foundation of the OpenAxiom build, plus the Lisp runtime compilation
+# (Phase 3).  Later PRs add:
 #   - Boot translator and interpreter chain (Phase 4)
 #   - Algebra substrate (Phase 5)
 #   - Optional subsystems and packaging (Phase 6)
@@ -14,7 +14,8 @@
 #   B. Helper: oa_apply_build_flags -- shared warning / profiling / debug opts
 #   C. Static libraries: open-axiom-core, OpenAxiom, spad
 #   D. Executables: hammer, open-axiom, oa-lisp
-#   E. Staging targets: stage-native-layout, phase1-native, phase2-native
+#   E. Phase 3: Lisp runtime compilation and image linking
+#   F. Staging targets: stage-native-layout, phase1-native, phase2-native
 # ===========================================================================
 
 
@@ -231,7 +232,152 @@ add_executable(oa-lisp rt/driver.cc)
 set_target_properties(oa-lisp PROPERTIES OUTPUT_NAME lisp)
 target_link_libraries(oa-lisp PRIVATE OpenAxiom open-axiom-core)
 
-# -- E. Staging targets ----------------------------------------------------
+# -- E. Phase 3: Lisp compilation and base-image linking ------------------
+# The Phase 3 chain:
+#   1. Generate core.lisp from the .in template (configure_file)
+#   2. Compile core.lisp -> core.FASL  (+ core.o for ECL)
+#   3. Link the FASL into a standalone image: oa-base-lisp
+#   4. Stage everything under OA_STAGE_ROOT for later phases
+#
+# The LISP_CMD variable below avoids repeating the multi-part
+# `cmake -E env ...EXECUTABLE ...QUIET ...BATCH` invocation prefix.
+
+set(oa_lisp_build_dir "${PROJECT_BINARY_DIR}/phase3/lisp")
+set(oa_lisp_generated_core "${oa_lisp_build_dir}/core.lisp")
+set(oa_lisp_generated_fasl "${oa_lisp_build_dir}/core.${OA_LISP_FASL_EXT}")
+set(oa_lisp_generated_linkable "${oa_lisp_build_dir}/core.${OA_LISP_LNK_EXT}")
+set(oa_lisp_generated_image "${oa_lisp_build_dir}/oa-base-lisp${CMAKE_EXECUTABLE_SUFFIX}")
+
+file(MAKE_DIRECTORY "${oa_lisp_build_dir}")
+
+# Variables substituted into core.lisp.in by configure_file.
+# They bridge CMake-side knowledge (install paths, compiler identity,
+# target triple, optional features) into the Lisp source so that the
+# Lisp bootstrap code can locate native tools and honour build options.
+#
+# The variable names must match the @VAR@ placeholders in core.lisp.in
+# exactly -- some are inherited from the Autotools era (e.g. CXX, LDFLAGS,
+# SHREXT, LIBEXT) and cannot be renamed without updating the template.
+set(host "${OA_TARGET_TRIPLE}")
+set(build "${OA_TARGET_TRIPLE}")
+set(target "${OA_TARGET_TRIPLE}")
+set(CXX "${CMAKE_CXX_COMPILER}")
+set(LDFLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+set(open_axiom_installdir "${CMAKE_INSTALL_PREFIX}/${OA_INSTALL_LAYOUT_ROOT}")
+set(oa_keep_files "")
+set(oa_enable_profiling nil)
+if(OA_ENABLE_PROFILING)
+  set(oa_enable_profiling t)
+endif()
+set(oa_use_llvm no)
+if(OPENAXIOM_HOST_HAS_LLVM)
+  set(oa_use_llvm yes)
+endif()
+set(oa_editor "$ENV{EDITOR}")
+if(NOT oa_editor)
+  set(oa_editor "vi")
+endif()
+set(oa_shrlib_prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
+# SHREXT / LIBEXT: library extension with and without the leading dot.
+# Consumed by the Lisp loader when building shared objects at algebra time.
+set(SHREXT "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+string(REGEX REPLACE "^\\." "" LIBEXT "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+# Extra C runtime libraries needed on Windows (Winsock for sockio).
+set(oa_c_runtime_extra "")
+if(WIN32)
+  set(oa_c_runtime_extra "\"-lwsock32\"")
+endif()
+
+# -- Step 1: Generate core.lisp from the template --
+configure_file(
+  "${PROJECT_SOURCE_DIR}/src/lisp/core.lisp.in"
+  "${oa_lisp_generated_core}"
+  @ONLY
+)
+
+# Guard: only emit the Lisp build rules when a supported runtime was found.
+if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$")
+  # Common Lisp invocation prefix -- used by every custom command below.
+  # Wraps the binary in `cmake -E env` for flavor-specific environment
+  # variables (e.g. GCL_ANSI=t), followed by quiet/batch flags.
+  set(OA_LISP_CMD
+    ${CMAKE_COMMAND} -E env ${OA_LISP_ENV_VARS}
+    "${OA_LISP_EXECUTABLE}" ${OA_LISP_QUIET_ARGS} ${OA_LISP_BATCH_ARGS}
+  )
+
+  # -- Step 2: Compile core.lisp -> FASL (+ .o for ECL) --
+  if(OA_LISP_FLAVOR STREQUAL "ecl")
+    # ECL uses the "system-p" flag to produce a relocatable .o alongside
+    # the FASL; both are needed at the linking step.
+    add_custom_command(
+      OUTPUT "${oa_lisp_generated_fasl}" "${oa_lisp_generated_linkable}"
+      COMMAND ${OA_LISP_CMD}
+              ${OA_LISP_EVAL_FLAG} "(require (quote cmp))"
+              ${OA_LISP_EVAL_FLAG} "(compile-file \"core.lisp\" :system-p t)"
+              ${OA_LISP_EVAL_FLAG} "(c::build-fasl \"core.${OA_LISP_FASL_EXT}\" :lisp-files (quote (\"core.${OA_LISP_LNK_EXT}\")))"
+              ${OA_LISP_EVAL_FLAG} "(quit)"
+      WORKING_DIRECTORY "${oa_lisp_build_dir}"
+      DEPENDS "${oa_lisp_generated_core}" stage-native-layout
+      COMMENT "Compile the OpenAxiom core Lisp runtime with ECL"
+      VERBATIM
+    )
+    set(oa_base_lisp_objects "(\"core.${OA_LISP_LNK_EXT}\")")
+  else()
+    # Non-ECL flavors: standard compile-file -> single FASL output.
+    add_custom_command(
+      OUTPUT "${oa_lisp_generated_fasl}"
+      COMMAND ${OA_LISP_CMD}
+              ${OA_LISP_EVAL_FLAG} "(progn (compile-file \"core.lisp\") (quit))"
+      WORKING_DIRECTORY "${oa_lisp_build_dir}"
+      DEPENDS "${oa_lisp_generated_core}" stage-native-layout
+      COMMENT "Compile the OpenAxiom core Lisp runtime"
+      VERBATIM
+    )
+    set(oa_base_lisp_objects "nil")
+  endif()
+
+  # -- Step 3: Link the FASL into a standalone executable image --
+  add_custom_command(
+    OUTPUT "${oa_lisp_generated_image}"
+    COMMAND ${OA_LISP_CMD}
+            ${OA_LISP_EVAL_FLAG} "(load \"core\")"
+            ${OA_LISP_EVAL_FLAG} "(|AxiomCore|::|link| \"oa-base-lisp${CMAKE_EXECUTABLE_SUFFIX}\" (quote ${oa_base_lisp_objects}) \"|AxiomCore|::|topLevel|\")"
+    WORKING_DIRECTORY "${oa_lisp_build_dir}"
+    DEPENDS "${oa_lisp_generated_fasl}"
+    COMMENT "Link the Phase 3 OpenAxiom base Lisp image"
+    VERBATIM
+  )
+
+  # -- Step 4: Stage Lisp artifacts into the runtime layout --
+  add_custom_target(stage-lisp-runtime
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+      "${OA_STAGE_ROOT}/lisp"
+      "${OA_STAGE_ROOT}/share/open-axiom/cmake"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${oa_lisp_generated_core}"
+      "${OA_STAGE_ROOT}/lisp/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${oa_lisp_generated_fasl}"
+      "${OA_STAGE_ROOT}/lisp/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${oa_lisp_generated_image}"
+      "${OA_STAGE_ROOT}/bin/"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${PROJECT_BINARY_DIR}/config/openaxiom-lisp-settings.cmake"
+      "${OA_STAGE_ROOT}/share/open-axiom/cmake/"
+    DEPENDS stage-native-layout "${oa_lisp_generated_image}"
+    COMMENT "Stage the Phase 3 Lisp runtime artifacts"
+  )
+
+  # Umbrella target -- the single name that CI and developers invoke.
+  add_custom_target(phase3-lisp-runtime
+    DEPENDS stage-lisp-runtime
+    COMMENT "Build and stage the Phase 3 Lisp runtime foundation"
+  )
+
+endif()  # OA_LISP_EXECUTABLE guard
+
+# -- F. Staging targets ----------------------------------------------------
 # stage-native-layout copies all Phase 1-2 artifacts (binaries, libraries,
 # headers) into OA_STAGE_ROOT -- an in-tree directory that mirrors the
 # final installation layout.  Later phases read from this staging tree.


### PR DESCRIPTION
## Summary

This PR adds **Lisp runtime detection** and the **Phase 3 base-image build chain** to the CMake migration, building on the native scaffold merged in PR #58.

## What's new

### `cmake/OpenAxiomLispRuntime.cmake` (new)
A self-contained CMake module that probes the host Lisp system at configure time and exports ~25 variables consumed by later build phases:

- **Flavor identification** -- classifies SBCL, ECL, CLisp, Clozure, and GCL from `(lisp-implementation-type)` output.
- **FASL / link extensions** -- queries `compile-file-pathname` for the actual compiled-file suffix.
- **FFI type table** -- maps C fundamental types to each Lisp's FFI spelling (e.g. SBCL `(* t)` vs ECL `:pointer-void`).
- **Linking model** -- detects ECL's standard-linking (Lisp -> C -> .o) vs the FASL-linking used by all other flavors.
- **Delayed FFI** -- flags SBCL / CLisp / Clozure as resolving FFI stubs at image-load time.
- **Invocation protocol** -- records quiet/batch/eval flags and environment variables (e.g. `GCL_ANSI=t`) per flavor.

Public entry point: `oa_configure_lisp_runtime()`.

### `cmake/openaxiom-lisp-settings.cmake.in` (new)
A `configure_file()` template that snapshots the detected Lisp configuration so that later build phases can `include()` it without re-running detection.

### `CMakeLists.txt` (updated)
- Section 5 replaces the Phase-1 `Runtime::unknown` stubs with `include(OpenAxiomLispRuntime)` + `oa_configure_lisp_runtime()`.
- Section 7 adds Lisp flavor, FASL/LNK extension, and delayed-FFI summary lines.
- Section 8 generates the Lisp settings cache file.

### `src/CMakeLists.txt` (updated -- Section E added)
Phase 3 targets, guarded by `if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR ...)`:

1. **`configure_file(core.lisp.in ...)`** -- stamps Lisp runtime variables into the boot loader.
2. **Compile core.lisp** -- invokes the host Lisp compiler to produce a FASL.
3. **Link base image** -- builds `interpsys`, the foundation Lisp image, from the FASL plus native libraries.
4. **`stage-lisp-runtime`** -- copies the image into the staging layout.
5. **`phase3-lisp-runtime`** -- umbrella target.

The staging targets in Section F remain unconditional (outside the Lisp guard) so the native layout is always available.

## Design notes

- Detection gracefully degrades: if no Lisp binary is found, a warning is emitted and Phase 3 targets are simply absent.
- All 5 supported Lisps (SBCL, ECL, CLisp, GCL, Clozure) use the same target graph -- only the invocation flags and extensions differ.
- The FFI type table is transcribed from the Autotools `config/open-axiom.m4`; no runtime behavior has changed.