### PR TITLE
cmake: add Boot translator bootstrap and interpreter chain (Phase 4)

### DIFF
--- a/cmake/WriteFile.cmake
+++ b/cmake/WriteFile.cmake
@@ -1,0 +1,14 @@
+# cmake/WriteFile.cmake -- Write a string to a file.
+# This helper is invoked as a CMake script via:
+#   cmake -Dfile=<path> -Dcontent=<string> -P WriteFile.cmake
+# It is used where file(WRITE ...) cannot be used directly in a
+# custom command (e.g. inside a POST_BUILD step).
+
+if(NOT DEFINED file)
+  message(FATAL_ERROR "WriteFile.cmake: 'file' variable not set")
+endif()
+if(NOT DEFINED content)
+  message(FATAL_ERROR "WriteFile.cmake: 'content' variable not set")
+endif()
+
+file(WRITE "${file}" "${content}\n")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,8 @@
 # ===========================================================================
 # This file defines the native C/C++ libraries and executables that form
 # the foundation of the OpenAxiom build, plus the Lisp runtime compilation
-# (Phase 3).  Later PRs add:
-#   - Boot translator and interpreter chain (Phase 4)
+# (Phase 3), and the boot translator and interpreter chain (Phase 4).
+# Later PRs add:
 #   - Algebra substrate (Phase 5)
 #   - Optional subsystems and packaging (Phase 6)
 #
@@ -16,6 +16,7 @@
 #   D. Executables: hammer, open-axiom, oa-lisp
 #   E. Phase 3: Lisp runtime compilation and image linking
 #   F. Staging targets: stage-native-layout, phase1-native, phase2-native
+#   G. Phase 4: Boot translator bootstrap and interpreter chain
 # ===========================================================================
 
 
@@ -374,6 +375,589 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$
     DEPENDS stage-lisp-runtime
     COMMENT "Build and stage the Phase 3 Lisp runtime foundation"
   )
+
+
+# ===========================================================================
+# G. Phase 4: Boot translator bootstrap and interpreter chain
+# ===========================================================================
+#
+# The Boot translator (bootsys) is built through a three-stage bootstrap:
+#
+#   strap/   -- Compile cached .clisp files (checked into src/boot/strap/)
+#               with the base Lisp image from Phase 3.  This produces
+#               strap/bootsys -- the initial, trusted Boot translator.
+#
+#   stage1/  -- Use strap/bootsys to translate the .boot source files into
+#               fresh .clisp files, then compile those with the base Lisp.
+#               Produces stage1/bootsys.
+#
+#   stage2/  -- Use stage1/bootsys to translate .boot -> .clisp again and
+#               compile.  Produces stage2/bootsys -- the final bootsys.
+#
+# The three-stage process ensures the translator is self-consistent:
+# stage2/bootsys is produced by a bootsys that was itself produced from
+# the same source files (stage1/bootsys), not from the potentially-stale
+# cached .clisp files.
+#
+# The interpreter (interpsys) is then built by using bootsys to compile
+# ~100 .boot and .lisp source files in src/interp/, with a carefully
+# ordered dependency graph, and linking them into a standalone image.
+#
+# Key tools:
+#   open-axiom --execpath=<lisp> --compile ...    Compile a .boot or .lisp
+#   open-axiom --execpath=<lisp> --translate ...  Translate .boot -> .clisp
+#   open-axiom --execpath=<lisp> --make ...       Link FASLs into an image
+#
+# The open-axiom driver (built in Phase 1) is the orchestrator for all
+# Lisp-level operations -- it sets up the process environment, passes
+# flags to the underlying Lisp, and manages load paths.
+# ---------------------------------------------------------------------------
+
+# -- Paths -----------------------------------------------------------------
+
+set(oa_boot_srcdir  "${PROJECT_SOURCE_DIR}/src/boot")
+set(oa_boot_builddir "${PROJECT_BINARY_DIR}/phase4/boot")
+set(oa_interp_srcdir "${PROJECT_SOURCE_DIR}/src/interp")
+set(oa_interp_builddir "${PROJECT_BINARY_DIR}/phase4/interp")
+
+# The open-axiom driver executable -- orchestrates all Lisp operations.
+set(OA_DRIVER "$<TARGET_FILE:open-axiom>")
+
+# The base Lisp image from Phase 3 (installed into the staging tree).
+set(OA_LISPSYS "${OA_STAGE_ROOT}/bin/lisp")
+
+# -- Boot module list and dependency order ---------------------------------
+# The Boot translator is composed of these 8 modules, listed in dependency
+# order.  Each module may depend on earlier ones in this list.
+#
+# Module          Depends on
+# -------         ----------
+# utility         (none)
+# tokens          utility
+# includer        tokens
+# scanner         tokens, includer
+# pile            scanner, includer
+# ast             includer
+# parser          ast, scanner, includer
+# translator      parser, ast, pile, scanner, includer
+
+set(oa_boot_modules
+  utility tokens includer scanner pile ast parser translator
+)
+
+# Create the stage directories.
+file(MAKE_DIRECTORY
+  "${oa_boot_builddir}/strap"
+  "${oa_boot_builddir}/stage1"
+  "${oa_boot_builddir}/stage2"
+  "${oa_interp_builddir}"
+)
+
+# ---------------------------------------------------------------------------
+# Helper function: oa_boot_compile_module
+# ---------------------------------------------------------------------------
+# Compiles a single .clisp file into a FASL (and LNK for ECL) using the
+# base Lisp image.  The --load-directory flag tells the driver where to
+# find previously compiled modules that this one depends on.
+#
+# Arguments:
+#   stage       One of: strap, stage1, stage2
+#   module      Module name without extension (e.g. "utility")
+#   clisp_file  Absolute path to the .clisp source file
+#   deps        List of FASL files this module depends on
+
+function(oa_boot_compile_module stage module clisp_file deps)
+  set(outdir "${oa_boot_builddir}/${stage}")
+  set(fasl   "${outdir}/${module}.${OA_LISP_FASL_EXT}")
+  set(outputs "${fasl}")
+  if(OA_LISP_FLAVOR STREQUAL "ecl")
+    list(APPEND outputs "${outdir}/${module}.${OA_LISP_LNK_EXT}")
+  endif()
+
+  add_custom_command(
+    OUTPUT ${outputs}
+    COMMAND ${OA_DRIVER}
+      --execpath=${OA_LISPSYS}
+      --output=${fasl}
+      --compile
+      --load-directory=${outdir}
+      "${clisp_file}"
+    WORKING_DIRECTORY "${outdir}"
+    DEPENDS ${clisp_file} ${deps}
+    COMMENT "[boot/${stage}] Compile ${module}.clisp"
+    VERBATIM
+  )
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Helper function: oa_boot_translate_module
+# ---------------------------------------------------------------------------
+# Uses a bootsys image to translate a .boot source file into .clisp.
+#
+# Arguments:
+#   stage       One of: stage1, stage2
+#   module      Module name without extension
+#   bootsys     Path to the bootsys image to use for translation
+#   deps        List of files this translation depends on
+
+function(oa_boot_translate_module stage module bootsys deps)
+  set(boot_src "${oa_boot_srcdir}/${module}.boot")
+  set(outdir   "${oa_boot_builddir}/${stage}")
+  set(clisp    "${outdir}/${module}.clisp")
+
+  add_custom_command(
+    OUTPUT "${clisp}"
+    COMMAND ${OA_DRIVER}
+      --execpath=${bootsys}
+      --translate
+      --import=skip
+      --output=${clisp}
+      "${boot_src}"
+    WORKING_DIRECTORY "${outdir}"
+    DEPENDS ${bootsys} ${boot_src} ${deps}
+    COMMENT "[boot/${stage}] Translate ${module}.boot -> ${module}.clisp"
+    VERBATIM
+  )
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Helper function: oa_boot_link_image
+# ---------------------------------------------------------------------------
+# Links compiled FASL modules into a bootsys executable image.
+#
+# Arguments:
+#   stage       One of: strap, stage1, stage2
+#   fasl_list   List of FASL files to link
+
+function(oa_boot_link_image stage fasl_list)
+  set(outdir  "${oa_boot_builddir}/${stage}")
+  set(image   "${outdir}/bootsys${CMAKE_EXECUTABLE_SUFFIX}")
+
+  add_custom_command(
+    OUTPUT "${image}"
+    COMMAND ${OA_DRIVER}
+      --execpath=${OA_LISPSYS}
+      --make
+      --main="|AxiomCore|::|topLevel|"
+      --system=${OA_STAGE_ROOT}
+      --prologue=(pushnew\ :open-axiom-boot\ *features*)
+      --output=${image}
+      --load-directory=${outdir}
+      ${fasl_list}
+    WORKING_DIRECTORY "${outdir}"
+    DEPENDS ${fasl_list} stage-lisp-runtime
+    COMMENT "[boot/${stage}] Link bootsys image"
+    VERBATIM
+  )
+endfunction()
+
+
+# ---------------------------------------------------------------------------
+# Helper function: oa_boot_build_stage
+# ---------------------------------------------------------------------------
+# Builds one complete boot stage: translate (if prev_bootsys is given),
+# compile, and link into a bootsys image.  Eliminates the repetition
+# between stage1 and stage2, which are identical except for which
+# bootsys drives the translation step.
+#
+# For the strap stage, clisp_source_dir points at the cached .clisp files
+# and prev_bootsys is empty (no translation step needed).
+#
+# Arguments:
+#   stage            Directory name: strap, stage1, stage2
+#   clisp_source_dir Where to find .clisp inputs (only for strap)
+#   prev_bootsys     Path to the bootsys that translates .boot -> .clisp.
+#                    If empty, skip the translation step (strap mode).
+#
+# Sets in PARENT_SCOPE:
+#   oa_${stage}_bootsys  Path to the bootsys image produced by this stage.
+
+function(oa_boot_build_stage stage clisp_source_dir prev_bootsys)
+  set(fasls)
+  foreach(mod ${oa_boot_modules})
+    if(prev_bootsys)
+      # Translation stage: .boot -> .clisp via the previous bootsys.
+      oa_boot_translate_module(${stage} "${mod}"
+        "${prev_bootsys}" "${prev_bootsys}")
+      set(clisp_src "${oa_boot_builddir}/${stage}/${mod}.clisp")
+    else()
+      # Strap: use cached .clisp files from the source tree.
+      set(clisp_src "${clisp_source_dir}/${mod}.clisp")
+    endif()
+
+    # Compile: .clisp -> FASL with cumulative dependency chain.
+    oa_boot_compile_module(${stage} "${mod}" "${clisp_src}" "${fasls}")
+    list(APPEND fasls
+      "${oa_boot_builddir}/${stage}/${mod}.${OA_LISP_FASL_EXT}")
+  endforeach()
+
+  # Link FASLs into a bootsys image.
+  oa_boot_link_image(${stage} "${fasls}")
+  set(oa_${stage}_bootsys
+    "${oa_boot_builddir}/${stage}/bootsys${CMAKE_EXECUTABLE_SUFFIX}"
+    PARENT_SCOPE)
+endfunction()
+
+
+# ===========================================================================
+# Three-stage Boot bootstrap
+# ===========================================================================
+# Each stage is a single function call.  The strap stage compiles from
+# cached .clisp; stage1 and stage2 translate fresh .clisp from .boot
+# using the previous stage's bootsys.  The loop-over-stages pattern
+# ensures all three stages share exactly the same compile/link logic.
+
+# Stage strap: compile cached .clisp with the base Lisp image.
+oa_boot_build_stage(strap "${oa_boot_srcdir}/strap" "")
+
+# Stage 1: translate .boot with strap/bootsys, compile, link.
+oa_boot_build_stage(stage1 "" "${oa_strap_bootsys}")
+
+# Stage 2: translate .boot with stage1/bootsys, compile, link.
+# Produces the final, self-consistent Boot translator.
+oa_boot_build_stage(stage2 "" "${oa_stage1_bootsys}")
+
+
+# -- Stage the final bootsys into OA_STAGE_ROOT --
+add_custom_target(stage-bootsys
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${oa_stage2_bootsys}"
+    "${OA_STAGE_ROOT}/bin/bootsys${CMAKE_EXECUTABLE_SUFFIX}"
+  DEPENDS "${oa_stage2_bootsys}"
+  COMMENT "Stage the final Boot translator (bootsys)"
+)
+
+# ECL needs a linkset file listing the object files for bootsys.
+if(OA_LISP_FLAVOR STREQUAL "ecl")
+  set(oa_boot_lnk_list)
+  foreach(mod ${oa_boot_modules})
+    list(APPEND oa_boot_lnk_list "\"${mod}.${OA_LISP_LNK_EXT}\"")
+  endforeach()
+  string(JOIN " " oa_boot_linkset_content ${oa_boot_lnk_list})
+
+  add_custom_command(
+    TARGET stage-bootsys POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${OA_STAGE_ROOT}/boot"
+    COMMAND ${CMAKE_COMMAND}
+      -Dfile=${OA_STAGE_ROOT}/boot/linkset
+      -Dcontent=(${oa_boot_linkset_content})
+      -P "${PROJECT_SOURCE_DIR}/cmake/WriteFile.cmake"
+    COMMENT "Generate ECL linkset for bootsys"
+    VERBATIM
+  )
+  foreach(mod ${oa_boot_modules})
+    add_custom_command(
+      TARGET stage-bootsys POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${oa_boot_builddir}/stage2/${mod}.${OA_LISP_LNK_EXT}"
+        "${OA_STAGE_ROOT}/boot/"
+      VERBATIM
+    )
+  endforeach()
+endif()
+
+add_custom_target(phase4-boot
+  DEPENDS stage-bootsys
+  COMMENT "Build the Phase 4 Boot translator (three-stage bootstrap)"
+)
+
+
+# ===========================================================================
+# Phase 4b: Interpreter (interpsys)
+# ===========================================================================
+# The interpreter is built by compiling ~100 .boot and .lisp files from
+# src/interp/ using bootsys, then linking them into a standalone image
+# called interpsys.  This image is the minimal OpenAxiom system needed
+# to compile algebra in Phase 5.
+#
+# The dependency graph below is transcribed from src/interp/Makefile.in.
+# Each entry records: <module>.<ext> depends on [<dep1> <dep2> ...].
+# The generic compile rule is:
+#   open-axiom --execpath=bootsys --compile --syslib=<libdir>
+#       --output=<out> --load-directory=. <source>
+# ---------------------------------------------------------------------------
+
+set(OA_BOOTSYS "${OA_STAGE_ROOT}/bin/bootsys${CMAKE_EXECUTABLE_SUFFIX}")
+
+# ---------------------------------------------------------------------------
+# Helper: oa_interp_compile
+# ---------------------------------------------------------------------------
+# Compiles a single .boot or .lisp file from src/interp/ into a FASL.
+#
+# Arguments:
+#   module    Base name (e.g. "boot-pkg")
+#   ext       Source extension: "boot" or "lisp"
+#   ...       Names of modules this one depends on (variable-length)
+#
+# Side effect:
+#   Appends the FASL path to oa_interp_all_fasls in the PARENT scope.
+#   This eliminates the need to list every module a second time when
+#   assembling the link command -- the compile declarations themselves
+#   serve as the single source of truth for the module inventory.
+
+function(oa_interp_compile module ext)
+  set(src  "${oa_interp_srcdir}/${module}.${ext}")
+  set(fasl "${oa_interp_builddir}/${module}.${OA_LISP_FASL_EXT}")
+  set(outputs "${fasl}")
+  if(OA_LISP_FLAVOR STREQUAL "ecl")
+    list(APPEND outputs "${oa_interp_builddir}/${module}.${OA_LISP_LNK_EXT}")
+  endif()
+
+  # Build the dependency list from module names passed as extra arguments.
+  set(dep_fasls)
+  foreach(dep ${ARGN})
+    list(APPEND dep_fasls "${oa_interp_builddir}/${dep}.${OA_LISP_FASL_EXT}")
+  endforeach()
+
+  add_custom_command(
+    OUTPUT ${outputs}
+    COMMAND ${OA_DRIVER}
+      --execpath=${OA_BOOTSYS}
+      --syslib=${OA_STAGE_ROOT}/lib
+      --compile
+      --output=${fasl}
+      --load-directory=${oa_interp_builddir}
+      "${src}"
+    WORKING_DIRECTORY "${oa_interp_builddir}"
+    DEPENDS "${src}" ${OA_BOOTSYS} ${dep_fasls}
+    COMMENT "[interp] Compile ${module}.${ext}"
+    VERBATIM
+  )
+
+  # Auto-accumulate: every module that is compiled becomes part of the
+  # final link set.  The caller never needs a separate OBJS list.
+  set(tmp "${oa_interp_all_fasls}")
+  list(APPEND tmp "${fasl}")
+  set(oa_interp_all_fasls "${tmp}" PARENT_SCOPE)
+endfunction()
+
+# Accumulator for all interp FASLs -- populated by oa_interp_compile().
+set(oa_interp_all_fasls)
+
+# ---------------------------------------------------------------------------
+# Interpreter module dependency graph
+# ---------------------------------------------------------------------------
+# This is the complete dependency DAG from src/interp/Makefile.in.
+# Each call declares: oa_interp_compile(<module> <ext> [<dep1> <dep2> ...])
+# where <depN> are module names (not file paths).
+
+# -- Foundation layer: package, types, low-level runtime --
+oa_interp_compile(boot-pkg   lisp)
+oa_interp_compile(types      boot  boot-pkg)
+oa_interp_compile(hash       lisp  types)
+oa_interp_compile(sys-constants boot types)
+oa_interp_compile(sys-os     boot  sys-constants)
+oa_interp_compile(io         boot  sys-constants)
+oa_interp_compile(sys-globals boot sys-constants hash)
+oa_interp_compile(sys-driver boot  types)
+oa_interp_compile(vmlisp     lisp  types sys-globals)
+oa_interp_compile(sys-utility boot vmlisp sys-constants hash)
+
+# -- Diagnostics and core types --
+oa_interp_compile(diagnostics boot sys-globals vmlisp)
+oa_interp_compile(union       lisp vmlisp)
+oa_interp_compile(ggreater    lisp vmlisp)
+oa_interp_compile(sys-macros  lisp diagnostics union)
+oa_interp_compile(lexing      boot sys-utility sys-macros io)
+
+# -- Utility and infrastructure --
+oa_interp_compile(unlisp      lisp sys-macros)
+oa_interp_compile(daase       lisp sys-utility)
+oa_interp_compile(util        lisp lexing)
+oa_interp_compile(g-util      boot ggreater sys-macros daase)
+oa_interp_compile(g-opt       boot g-util)
+oa_interp_compile(c-util      boot g-opt)
+oa_interp_compile(g-error     boot diagnostics g-util)
+oa_interp_compile(g-timer     boot sys-macros g-util)
+oa_interp_compile(g-cndata    boot sys-macros c-util)
+oa_interp_compile(clam        boot g-timer)
+oa_interp_compile(clammed     boot g-timer)
+oa_interp_compile(slam        boot g-timer)
+oa_interp_compile(nlib        lisp sys-macros sys-utility)
+oa_interp_compile(pathname    boot nlib)
+oa_interp_compile(compat      boot pathname)
+oa_interp_compile(database    boot clam nlib cattable compat g-cndata c-util)
+oa_interp_compile(debug       lisp sys-macros lexing)
+oa_interp_compile(msgdb       boot g-util)
+oa_interp_compile(msg         boot sys-macros astr)
+oa_interp_compile(fname       lisp sys-macros)
+oa_interp_compile(word        boot g-util)
+oa_interp_compile(monitor     lisp sys-macros sys-utility)
+oa_interp_compile(sfsfun-l    lisp sys-macros)
+oa_interp_compile(sfsfun      boot sys-macros)
+oa_interp_compile(lisp-backend boot sys-macros nlib c-util)
+
+# -- Compiler support --
+oa_interp_compile(simpbool    boot sys-macros)
+oa_interp_compile(cattable    boot simpbool c-util)
+oa_interp_compile(nrunfast    boot c-util)
+oa_interp_compile(profile     boot sys-macros sys-utility c-util)
+oa_interp_compile(nruncomp    boot profile simpbool nrunfast)
+oa_interp_compile(define      boot g-error nruncomp database)
+oa_interp_compile(category    boot c-util g-cndata)
+oa_interp_compile(functor     boot category lisplib nruncomp)
+oa_interp_compile(compiler    boot msgdb pathname define)
+oa_interp_compile(lisplib     boot database debug)
+oa_interp_compile(c-doc       boot c-util)
+oa_interp_compile(htcheck     boot sys-driver sys-macros)
+
+# -- New parser (interpreter front-end) --
+oa_interp_compile(astr        boot vmlisp)
+oa_interp_compile(dq          boot types)
+oa_interp_compile(posit       boot sys-macros astr)
+oa_interp_compile(serror      boot posit)
+oa_interp_compile(cstream     boot sys-macros)
+oa_interp_compile(cformat     boot unlisp posit)
+oa_interp_compile(incl        boot cstream cformat)
+oa_interp_compile(scan        boot incl dq sys-utility)
+oa_interp_compile(pile        boot scan)
+oa_interp_compile(ptrees      boot posit serror)
+oa_interp_compile(macex       boot ptrees)
+oa_interp_compile(cparse      boot ptrees)
+oa_interp_compile(pf2sex      boot ptrees)
+oa_interp_compile(i-parser    boot cparse pf2sex)
+oa_interp_compile(postpar     boot sys-macros)
+oa_interp_compile(parse       boot postpar)
+oa_interp_compile(spad-parser boot parse lexing)
+oa_interp_compile(packtran    boot sys-macros)
+
+# -- Old parser and SPAD support --
+oa_interp_compile(spad        lisp spad-parser postpar debug)
+oa_interp_compile(record      boot nlib pathname)
+oa_interp_compile(rulesets    boot vmlisp)
+oa_interp_compile(newfort     boot sys-macros)
+oa_interp_compile(server      boot sys-macros)
+oa_interp_compile(termrw      boot sys-macros)
+oa_interp_compile(match       boot sys-macros)
+oa_interp_compile(format      boot sys-macros)
+oa_interp_compile(buildom     boot sys-macros c-util nruncomp)
+oa_interp_compile(setvars     boot sys-macros debug)
+oa_interp_compile(setvart     boot sys-macros)
+oa_interp_compile(fortcall    boot sys-macros)
+
+# -- Interpreter core --
+oa_interp_compile(i-util      boot c-util)
+oa_interp_compile(i-object    boot i-util)
+oa_interp_compile(i-intern    boot i-object ptrees)
+oa_interp_compile(i-analy     boot i-object)
+oa_interp_compile(i-resolv    boot i-object)
+oa_interp_compile(i-coerfn    boot i-analy i-resolv)
+oa_interp_compile(i-coerce    boot i-coerfn)
+oa_interp_compile(i-eval      boot i-analy)
+oa_interp_compile(i-funsel    boot i-coerfn)
+oa_interp_compile(i-map       boot i-object)
+oa_interp_compile(i-output    boot sys-utility sys-macros)
+oa_interp_compile(i-special   boot i-analy)
+oa_interp_compile(i-syscmd    boot i-object)
+oa_interp_compile(i-toplev    boot i-analy)
+oa_interp_compile(int-top     boot incl i-toplev unlisp)
+oa_interp_compile(osyscmd     boot int-top)
+oa_interp_compile(trace       boot debug)
+oa_interp_compile(hypertex    boot types)
+
+# -- HyperDoc / browser --
+oa_interp_compile(ht-util     boot sys-macros)
+oa_interp_compile(htsetvar    boot sys-macros)
+oa_interp_compile(ht-root     boot ht-util)
+oa_interp_compile(bc-util     boot ht-util c-util)
+oa_interp_compile(bc-matrix   boot bc-util)
+oa_interp_compile(bc-misc     boot bc-util)
+oa_interp_compile(bc-solve    boot bc-matrix bc-misc)
+oa_interp_compile(br-util     boot bc-util)
+oa_interp_compile(br-search   boot bc-util)
+oa_interp_compile(br-con      boot bc-util)
+oa_interp_compile(br-op1      boot bc-util)
+oa_interp_compile(br-op2      boot br-op1)
+oa_interp_compile(br-data     boot bc-util nruncomp)
+oa_interp_compile(br-prof     boot bc-util)
+oa_interp_compile(br-saturn   boot bc-util)
+oa_interp_compile(showimp     boot c-util nruncomp)
+oa_interp_compile(alql        boot br-search)
+oa_interp_compile(topics      boot sys-macros sys-utility)
+
+# -- Interpreter FASL inventory (auto-accumulated) -------------------------
+# oa_interp_all_fasls was populated by the oa_interp_compile() calls
+# above.  Every module declared above is automatically included in the
+# link set -- there is no separate OBJS list to keep in sync.
+set(oa_interp_objs ${oa_interp_all_fasls})
+
+# Handle the FFI module: delayed-FFI Lisps install sys-os separately;
+# standard-linking Lisps include it directly in the object list (already
+# covered above since sys-os is in the list).
+if(oa_delay_ffi STREQUAL "yes")
+  # Copy the FFI module to the interp staging directory so the image
+  # can find it at load time.
+  add_custom_command(
+    OUTPUT "${OA_STAGE_ROOT}/interp/sys-os.${OA_LISP_FASL_EXT}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${OA_STAGE_ROOT}/interp"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${oa_interp_builddir}/sys-os.${OA_LISP_FASL_EXT}"
+      "${OA_STAGE_ROOT}/interp/"
+    DEPENDS "${oa_interp_builddir}/sys-os.${OA_LISP_FASL_EXT}"
+    COMMENT "[interp] Stage delayed-FFI module sys-os"
+    VERBATIM
+  )
+  set(oa_interp_ffi_staged "${OA_STAGE_ROOT}/interp/sys-os.${OA_LISP_FASL_EXT}")
+else()
+  set(oa_interp_ffi_staged)
+endif()
+
+# -- Stage the messages file needed by interpsys --
+set(oa_msgs_src "${PROJECT_SOURCE_DIR}/src/doc/msgs/s2-us.msgs")
+set(oa_msgs_staged "${OA_STAGE_ROOT}/share/msgs/s2-us.msgs")
+add_custom_command(
+  OUTPUT "${oa_msgs_staged}"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${OA_STAGE_ROOT}/share/msgs"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${oa_msgs_src}" "${oa_msgs_staged}"
+  DEPENDS "${oa_msgs_src}"
+  COMMENT "[interp] Stage message catalog s2-us.msgs"
+  VERBATIM
+)
+
+# -- Link interpsys --
+# interpsys is the minimal interpreter image needed to compile algebra.
+# It is built by loading all compiled FASL modules into bootsys.
+set(oa_interpsys "${oa_interp_builddir}/interpsys${CMAKE_EXECUTABLE_SUFFIX}")
+
+add_custom_command(
+  OUTPUT "${oa_interpsys}"
+  COMMAND ${OA_DRIVER}
+    --execpath=${OA_BOOTSYS}
+    --syslib=${OA_STAGE_ROOT}/lib
+    --system=${OA_STAGE_ROOT}/
+    --prologue=(pushnew\ :open-axiom-basic-system\ *features*)
+    --make
+    --output=${oa_interpsys}
+    --main="BOOT::|systemMain|"
+    --load-directory=${oa_interp_builddir}
+    ${oa_interp_objs}
+  WORKING_DIRECTORY "${oa_interp_builddir}"
+  DEPENDS ${oa_interp_objs} ${OA_BOOTSYS} "${oa_msgs_staged}" ${oa_interp_ffi_staged}
+  COMMENT "[interp] Link interpsys image"
+  VERBATIM
+)
+
+# -- Stage interpsys --
+add_custom_target(stage-interpsys
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${oa_interpsys}"
+    "${OA_STAGE_ROOT}/bin/interpsys${CMAKE_EXECUTABLE_SUFFIX}"
+  DEPENDS "${oa_interpsys}" stage-bootsys
+  COMMENT "Stage the interpreter (interpsys)"
+)
+
+add_custom_target(phase4-interpsys
+  DEPENDS stage-interpsys
+  COMMENT "Build and stage the Phase 4 interpreter (interpsys)"
+)
+
+# -- Umbrella Phase 4 target --
+add_custom_target(phase4-boot-interp
+  DEPENDS phase4-boot phase4-interpsys
+  COMMENT "Build the complete Phase 4: Boot translator + interpreter"
+)
+
 
 endif()  # OA_LISP_EXECUTABLE guard
 


### PR DESCRIPTION
Add the three-stage Boot translator bootstrap and the interpreter (interpsys) build chain to the CMake migration.

## What this PR adds

**Section G** of `src/CMakeLists.txt` -- Phase 4 of the CMake build:

### Boot translator three-stage bootstrap

The Boot translator (`bootsys`) is built through a deterministic three-stage bootstrap:

1. **strap/** -- Compile cached `.clisp` files (checked into `src/boot/strap/`) to produce the strap-stage translator.
2. **stage1/** -- Use the strap translator to recompile the Boot sources (`.boot` files) and build a stage-1 translator.
3. **stage2/** -- Use stage-1 to recompile once more, producing the final `bootsys` executable.

Each stage compiles the same set of Boot modules (`tokens`, `includer`, `scanner`, `pile`, `ast`, `parser`, `translator`) with proper inter-file dependency ordering.

### Interpreter chain (~100 modules)

Approximately 100 `.boot` and `.lisp` source files from `src/interp/` are compiled (via the stage-2 `bootsys` for `.boot` files, or directly via the Lisp runtime for `.lisp` files) and linked into the `interpsys` image.  Key umbrella targets:

- `phase4-boot` -- all three bootstrap stages
- `phase4-interpsys` -- the interpreter image
- `phase4-boot-interp` -- combined target for the full Phase 4

### New helper

- `cmake/WriteFile.cmake` -- a script-mode wrapper around `file(WRITE)` for use in `add_custom_command` steps.

### Structural note

The `OA_LISP_EXECUTABLE` guard now encompasses both Phase 3 (Lisp runtime, from PR #59) and Phase 4 (boot + interpreter).  The unconditional staging targets (`stage-native-layout`, `phase1-native`, `phase2-native`) remain outside the guard.

## Depends on

- PR #58 (merged) -- CMake scaffold and native C/C++ targets
- PR #59 (merged) -- Lisp runtime detection and Phase 3

Assisted By: Claude Opus 4.6