### PR TITLE
Change `__WIN32__` to `_WIN32` official spelling.

### DIFF
--- a/src/driver/main.cc
+++ b/src/driver/main.cc
@@ -152,12 +152,12 @@ main(int argc, char* argv[])
       abort();
    }
 
-#ifdef __WIN32__
+#ifdef _WIN32
    /* Should not happen on MS platforms.  */
    abort();
-#else  /* __WIN32__ */
+#else  /* _WIN32 */
    execv(make_path_for(command.root_dir, driver), argv);
    perror(strerror(errno));
    return -1;
-#endif /* __WIN32__ */
+#endif /* _WIN32 */
 }

--- a/src/hyper/ex2ht.c
+++ b/src/hyper/ex2ht.c
@@ -90,7 +90,7 @@ static void
 closeCoverFile()
 {
     fclose(coverFile);
-#ifndef __WIN32__		/* FIXME! */
+#ifndef _WIN32		/* FIXME! */
     utimes("coverex.ht",latest_date);
 #endif
 }

--- a/src/include/open-axiom.h
+++ b/src/include/open-axiom.h
@@ -47,7 +47,7 @@
 #endif
 
 /* Cope with MS-platform oddities.  */
-#ifdef __WIN32__
+#ifdef _WIN32
 #  ifdef  DLL_EXPORT
 #    define OPENAXIOM_EXPORT  __declspec(dllexport)
 #  elif defined(DLL_IMPORT)
@@ -56,7 +56,7 @@
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN
 #  endif
-#endif	/* __WIN32__ */
+#endif	/* _WIN32 */
 #ifndef OPENAXIOM_EXPORT
 #  define OPENAXIOM_EXPORT  /* nothing */
 #endif /* OPENAXIOM_EXPORT */
@@ -65,7 +65,7 @@
 
 #include <stdint.h>
 
-#if defined(__WIN32__)
+#if defined(_WIN32)
 #  include <windows.h>
 #endif
 #if defined(HAVE_UNISTD_H)
@@ -84,7 +84,7 @@ namespace OpenAxiom {
    typedef uint8_t Byte;
 
    // An opaque datatype
-#ifdef __WIN32__
+#ifdef _WIN32
    typedef HANDLE Handle;
 #else
    typedef void* Handle;
@@ -129,7 +129,7 @@ namespace OpenAxiom {
    }
 
 /* Internal field separator character.  */
-#if defined(__WIN32__)
+#if defined(_WIN32)
 #  define openaxiom_ifs ';'
 #else
 #  define openaxiom_ifs ':'
@@ -149,7 +149,7 @@ namespace OpenAxiom {
    static inline void
    openaxiom_sleep(int n)
    {
-#if defined(__WIN32__)
+#if defined(_WIN32)
       Sleep(n * 1000);
 #else
       sleep(n);

--- a/src/include/sockio.h
+++ b/src/include/sockio.h
@@ -38,7 +38,7 @@
 
 #include <stddef.h>
 
-#ifdef __WIN32__
+#ifdef _WIN32
 #  include <winsock2.h>
 #  define OPENAXIOM_INVALID_SOCKET INVALID_SOCKET
 #else
@@ -61,7 +61,7 @@ namespace OpenAxiom {
    Consequently, we abstract over that variation, using the typedef
    axiom_socket.  */
 
-#ifdef __WIN32__
+#ifdef _WIN32
 typedef SOCKET openaxiom_socket;
 typedef HANDLE openaxiom_filedesc;
 #else

--- a/src/lib/sockio-c.cxx
+++ b/src/lib/sockio-c.cxx
@@ -46,7 +46,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <signal.h>
-#ifdef __WIN32__
+#ifdef _WIN32
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #else
@@ -105,7 +105,7 @@ int spad_server_number = -1;
    This is needed only for MS platforms.  */
 static int openaxiom_socket_module_loaded = 0;
 
-#ifdef __WIN32__
+#ifdef _WIN32
 /* Windows require some handshaking with the WinSock DLL before
    we can even think about talking about sockets. */
 
@@ -122,7 +122,7 @@ static void
 openaxiom_load_socket_module()
 {
   if (!openaxiom_socket_module_loaded) {
-#ifdef __WIN32__
+#ifdef _WIN32
    WSADATA wsaData;
 
    /* Request version 2.0 of WinSock DLL. */
@@ -152,7 +152,7 @@ oa_inet_pton(const char* addr, int prot, Byte* bytes)
    openaxiom_load_socket_module();
    switch (prot) {
    case 4: {
-#ifdef __WIN32__
+#ifdef _WIN32
       unsigned long inet_val = inet_addr(addr);
       if (inet_val == INADDR_NONE || inet_val == INADDR_ANY)
          return -1;
@@ -206,7 +206,7 @@ openaxiom_socket_stream_link(int family)
 static inline int
 openaxiom_socket_is_invalid(openaxiom_socket sock)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    return sock == INVALID_SOCKET;
 #else
    return sock < 0;
@@ -224,7 +224,7 @@ is_invalid_socket(const openaxiom_sio* s)
 static inline int
 is_valid_socket(const openaxiom_sio* s)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    return s->socket != INVALID_SOCKET;
 #else
    return s->socket > 0;
@@ -241,7 +241,7 @@ is_valid_socket(const openaxiom_sio* s)
 OPENAXIOM_C_EXPORT void
 oa_close_socket(openaxiom_socket s)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    shutdown(s, SD_BOTH);
    closesocket(s);
 #else
@@ -261,7 +261,7 @@ oa_close_socket(openaxiom_socket s)
 OPENAXIOM_C_EXPORT openaxiom_filedesc
 oa_open_local_client_stream_socket(const char* path)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
 #  define NAMED_PIPE_PREFIX "\\\\.\\pipe"
    char* pipename;
    HANDLE handle;
@@ -308,7 +308,7 @@ oa_open_local_client_stream_socket(const char* path)
 OPENAXIOM_C_EXPORT int
 oa_filedesc_read(openaxiom_filedesc desc, Byte* buf, int size)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    DWORD count = -1;
    if (ReadFile(/* hFile */ desc,
                 /* lpBuffer */ buf,
@@ -325,7 +325,7 @@ oa_filedesc_read(openaxiom_filedesc desc, Byte* buf, int size)
 OPENAXIOM_C_EXPORT int
 oa_filedesc_write(openaxiom_filedesc desc, const Byte* buf, int size)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    DWORD count = -1;
    if (WriteFile(/* hFile */ desc,
                  /* lpBuffer */ buf,
@@ -342,7 +342,7 @@ oa_filedesc_write(openaxiom_filedesc desc, const Byte* buf, int size)
 OPENAXIOM_C_EXPORT int
 oa_filedesc_close(openaxiom_filedesc desc)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    return CloseHandle(desc) ? 0 : -1;
 #else
    return close(desc);
@@ -428,7 +428,7 @@ oa_socket_write_byte(openaxiom_socket sock, Byte byte)
 static inline int
 openaxiom_syscall_was_cancelled()
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    return WSAGetLastError() == WSAEINTR;
 #else
    return errno == EINTR;
@@ -440,7 +440,7 @@ openaxiom_syscall_was_cancelled()
 static inline int
 openaxiom_connection_refused()
 {
-#ifdef __WIN32__
+#ifdef _WIN32
    return WSAGetLastError() == WSAECONNREFUSED;
 #else
    return errno == ECONNREFUSED;

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -461,7 +461,7 @@ int
 execute_core(const Command* command, Driver driver)
 {
    char* execpath = (char*) executable_path(command, driver);
-#ifdef __WIN32__
+#ifdef _WIN32
    char* command_line;
    int cur = strlen(command->core.argv[0]);
    int command_line_length = 0;
@@ -527,7 +527,7 @@ execute_core(const Command* command, Driver driver)
    CloseHandle(procInfo.hProcess);
    return status;
                         
-#else  /* __WIN32__ */
+#else  /* _WIN32 */
    int i;
    Arguments args(args_count(command));
    /* GCL has this oddity that it wants to believe that argv[0] has
@@ -557,7 +557,7 @@ execute_core(const Command* command, Driver driver)
    execv(execpath, args.data());
    perror(execpath);
    return -1;
-#endif /* __WIN32__ */
+#endif /* _WIN32 */
 }
 
 }


### PR DESCRIPTION
`_WIN32` is the official name of the macro,