### PR TITLE
Systematically use `_WIN32` as Windows indicator.

### DIFF
--- a/src/clef/edible.c
+++ b/src/clef/edible.c
@@ -34,13 +34,17 @@
 */
 
 #include <stdlib.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
-#include <termios.h>
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/time.h>
+#if defined(_WIN32)
+#  include <Windows.h>
+#else
+#  include <unistd.h>
+#  include <sys/stat.h>
+#  include <sys/time.h>
+#  include <termios.h>
+#endif
 #include <errno.h>
 #include <signal.h>
 #include <locale.h>

--- a/src/driver/main.cc
+++ b/src/driver/main.cc
@@ -88,7 +88,7 @@ namespace OpenAxiom {
       const char* ldd_path = option_value(command, "--syslib");
       if (ldd_path == nullptr)
          ldd_path = oa_concatenate_string(sysdir, "/lib");
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
       augment_variable("PATH", ldd_path);
 #else      
       augment_variable("LD_LIBRARY_PATH", ldd_path);

--- a/src/lib/cfuns-c.cxx
+++ b/src/lib/cfuns-c.cxx
@@ -45,12 +45,12 @@
 #include <stdio.h>
 #include <assert.h>
 #include <math.h>
-#include <unistd.h>
 
 
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
 #  include <windows.h>
 #else
+#  include <unistd.h>
 #  include <dirent.h>
 #  include <fcntl.h>
 #endif
@@ -101,7 +101,7 @@ addtopath(char *dir)
 static inline int
 openaxiom_is_path_separator(char c)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return c == '\\' || c == '/';
 #else
    return c == '/';
@@ -254,7 +254,7 @@ writeablep(const char *path)
             the MinGW/MSYS port appears to use MS' StrDup as the real
             worker.  Consequently, the guarantee that the the string can
             free'd no longer holds.  We have to use MS's LocalFree.  */
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
        LocalFree(dir);
 #else
        free(dir);
@@ -336,7 +336,7 @@ OPENAXIOM_C_EXPORT int
 std_stream_is_terminal(int fd)
 {
    assert(fd > -1 && fd < 3);
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    DWORD handle;
    switch (fd) {
    case 0: handle = STD_INPUT_HANDLE; break;
@@ -367,11 +367,11 @@ std_stream_is_terminal(int fd)
 OPENAXIOM_C_EXPORT int
 oa_chdir(const char* path)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return SetCurrentDirectory(path) ? 0 : -1;
 #else
    return chdir(path);
-#endif /* OPENAXIOM_MS_WINDOWS_HOST */
+#endif /* _WIN32 */
 }
 
 
@@ -392,7 +392,7 @@ oa_unlink(const char* path)
 {
    const char* curdir;
    int status = -1;
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    WIN32_FIND_DATA findData;
    HANDLE walkHandle;
 
@@ -476,7 +476,7 @@ oa_unlink(const char* path)
       status = -1;
    else
       status = 0;
-#endif /* OPENAXIOM_MS_WINDOWS_HOST */
+#endif /*_WIN32 */
 
   sortie:
    oa_chdir(curdir);
@@ -486,11 +486,11 @@ oa_unlink(const char* path)
 
 OPENAXIOM_C_EXPORT const char*
 oa_acquire_temporary_pathname() {
-#if OPENAXIOM_MS_WINDOWS_HOST
+#if _WIN32
    char buf[MAX_PATH];
    const char* tmpdir = oa_get_tmpdir();
    auto n = GetTempFileName(tmpdir, "oa-", random() % SHRT_MAX, buf);
-   /* tmpdir was malloc()ed when OPENAXIOM_MS_WINDOWS_HOST.  */
+   /* tmpdir was malloc()ed when _WIN32.  */
    free(const_cast<char*>(tmpdir));
    if (n == 0) {
       perror("oa_acquire_temporary_pathname");
@@ -516,7 +516,7 @@ oa_release_temporary_pathname(const char* s)
 OPENAXIOM_C_EXPORT int
 oa_rename(const char* old_path, const char* new_path)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return MoveFile(old_path, new_path) ? 0 : -1;
 #else
    return rename(old_path, new_path);
@@ -528,7 +528,7 @@ oa_rename(const char* old_path, const char* new_path)
 OPENAXIOM_C_EXPORT int
 oa_mkdir(const char* path)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return CreateDirectory(path, NULL) ? 0 : -1;
 #else
 #  define DIRECTORY_PERM ((S_IRWXU|S_IRWXG|S_IRWXO) & ~(S_IWGRP|S_IWOTH))
@@ -547,7 +547,7 @@ oa_system(const char* cmd)
 OPENAXIOM_C_EXPORT int 
 oa_getpid(void) 
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return GetCurrentProcessId();
 #else
    return getpid();
@@ -592,7 +592,7 @@ oa_strcat(const char* left, const char* right)
 OPENAXIOM_C_EXPORT char*
 oa_getenv(const char* var)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST   
+#ifdef _WIN32
 #define BUFSIZE 128
    char* buf = (char*) malloc(BUFSIZE);
    int len = GetEnvironmentVariable(var, buf, BUFSIZE);
@@ -619,7 +619,7 @@ oa_getenv(const char* var)
 OPENAXIOM_C_EXPORT int
 oa_setenv(const char* var, const char* val)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return SetEnvironmentVariable(var, val);
 #elif HAVE_DECL_SETENV
    return !setenv(var, val, true);
@@ -641,7 +641,7 @@ oa_getcwd(void)
 {
    size_t bufsz = 256;
    char* buf = (char*) malloc(bufsz);
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    DWORD n = GetCurrentDirectory(bufsz, buf);
    if (n == 0) {
       perror("oa_getcwd");
@@ -655,7 +655,7 @@ oa_getcwd(void)
       }
    }
    return buf;
-#else /* OPENAXIOM_MS_WINDOWS_HOST */
+#else /* _WIN32 */
    errno = 0;
    while (getcwd(buf,bufsz) == 0) {
       if (errno == ERANGE) {
@@ -675,7 +675,7 @@ oa_getcwd(void)
 OPENAXIOM_C_EXPORT int
 oa_access_file_for_read(const char* path)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
   return GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES ? -1 : 1;
 #else
    return access(path, R_OK);
@@ -686,7 +686,7 @@ oa_access_file_for_read(const char* path)
 OPENAXIOM_C_EXPORT const char*
 oa_get_tmpdir(void)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    char* buf;
    /* First, probe.  */
    int bufsz = GetTempPath(0, NULL);
@@ -715,7 +715,7 @@ oa_get_tmpdir(void)
 OPENAXIOM_C_EXPORT int
 oa_copy_file(const char* src, const char* dst)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    return CopyFile(src,dst, /* bFailIfExists = */ 0) ? 0 : -1;
 #else
 #define OA_BUFSZ 512
@@ -793,7 +793,7 @@ oa_allocate_process_argv(Process* proc, int argc)
 OPENAXIOM_C_EXPORT int
 oa_spawn(Process* proc, SpawnFlags flags)
 {
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
    const char* path = NULL;
    char* cmd_line = NULL;
    int curpos = strlen(proc->argv[0]);

--- a/src/lib/edin.c
+++ b/src/lib/edin.c
@@ -37,7 +37,11 @@
 
 #include <stdlib.h>
 #include "openaxiom-c-macros.h"
-#include <unistd.h>
+#if defined(_WIN32)
+#  include <Windows.h>
+#else
+#  include <unistd.h>
+#endif
 #include <string.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/src/lib/fnct_key.c
+++ b/src/lib/fnct_key.c
@@ -34,14 +34,18 @@
 */
 
 #include "openaxiom-c-macros.h"
-#include <unistd.h>
+#if defined(_WIN32)
+#  include <Windows.h>
+#else
+#  include <unistd.h>
+#  include <sys/stat.h>
+#  include <sys/types.h>
+#  include <sys/wait.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "cfuns.h"
 #include "edible.h"

--- a/src/lib/openpty.c
+++ b/src/lib/openpty.c
@@ -35,7 +35,11 @@
 
 #include "openaxiom-c-macros.h"
 #include <stdlib.h>
-#include <unistd.h>
+#if defined(_WIN32)
+#  include <Windows.h>
+#else
+#  include <unistd.h>
+#endif
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>

--- a/src/lib/sockio-c.cxx
+++ b/src/lib/sockio-c.cxx
@@ -41,15 +41,15 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
-#include <sys/time.h>
 #include <string.h>
 #include <signal.h>
 #ifdef _WIN32
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #else
+#  include <unistd.h>
+#  include <sys/time.h>
 #  include <arpa/inet.h>
 #  include <netdb.h>
 #endif

--- a/src/lib/wct.c
+++ b/src/lib/wct.c
@@ -45,7 +45,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#if defined(_WIN32)
+#  include <Windows.h>
+#else
+#  include <unistd.h>
+#endif
 #include <string.h>
 #include <fcntl.h>
 #include <time.h>

--- a/src/rt/Lisp.cc
+++ b/src/rt/Lisp.cc
@@ -305,6 +305,7 @@ namespace OpenAxiom {
       // -- special operators
       using SpecialOperator = Value (*)(Evaluator*, const Sexpr::Syntax&);
       const NamedConstant<SpecialOperator> special_ops[] = {
+         { },
       };      
 
       static SpecialOperator

--- a/src/utils/storage.cxx
+++ b/src/utils/storage.cxx
@@ -49,7 +49,7 @@
 #ifdef HAVE_SYS_MMAN_H
 #  include <sys/mman.h>
 #endif
-#ifdef OPENAXIOM_MS_WINDOWS_HOST
+#ifdef _WIN32
 #  include <windows.h>
 #endif
 #include <errno.h>
@@ -77,7 +77,7 @@ namespace OpenAxiom {
    namespace Memory {
       // Return storage page allocation unit in byte count.
       size_t page_size() {
-#if defined(OPENAXIOM_MS_WINDOWS_HOST)
+#if defined(_WIN32)
          SYSTEM_INFO si = { };
          GetSystemInfo(&si);
          return si.dwPageSize;
@@ -93,7 +93,7 @@ namespace OpenAxiom {
       // storage from the host OS.  Return null on failure.
       static inline Pointer
       os_allocate_read_write_raw_memory(size_t nbytes) {
-#if defined(OPENAXIOM_MS_WINDOWS_HOST)
+#if defined(_WIN32)
          return VirtualAlloc(Pointer(), nbytes,
                              MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 #elif defined(HAVE_SYS_MMAN_H)
@@ -116,7 +116,7 @@ namespace OpenAxiom {
 
       void
       os_release_raw_memory(Pointer p, size_t n) {
-#if defined(OPENAXIOM_MS_WINDOWS_HOST)
+#if defined(_WIN32)
          VirtualFree(p, 0, MEM_RELEASE);
 #elif defined(HAVE_SYS_MMAN_H)
          munmap(p, n);
@@ -258,7 +258,7 @@ namespace OpenAxiom {
       // -----------------
       FileMapping::FileMapping(std::string path)
             : start(), extent() {
-#if defined(OPENAXIOM_MS_WINDOWS_HOST)
+#if defined(_WIN32)
          HANDLE file = CreateFile(path.c_str(), GENERIC_READ, 0, 0,
                                   OPEN_EXISTING,
                                   FILE_ATTRIBUTE_NORMAL, 0);
@@ -290,7 +290,7 @@ namespace OpenAxiom {
          extent = s.st_size;
 #else
 #  error "Don't know how to map a file on this platform"         
-#endif  // OPENAXIOM_MS_WINDOWS_HOST
+#endif  // _WIN32
       }
 
       FileMapping::FileMapping(FileMapping&& f)
@@ -301,7 +301,7 @@ namespace OpenAxiom {
 
       FileMapping::~FileMapping() {
          if (start != nullptr) {
-#if defined(OPENAXIOM_MS_WINDOWS_HOST)
+#if defined(_WIN32)
             UnmapViewOfFile(start);
 #elif defined(HAVE_SYS_MMAN_H)
             munmap(start, extent);


### PR DESCRIPTION
The macro `_WIN32` is compiler-supplied.