### PR TITLE
char8_t migration, tagged-pointer Lisp values, Boot/Spad parser and translator

### DIFF
--- a/.github/workflows/ci-linux-gcc-ccl.yml
+++ b/.github/workflows/ci-linux-gcc-ccl.yml
@@ -1,10 +1,9 @@
 # Linux: GCC 15 + Clozure CL (standard FASL path)
 name: 'CI: Linux GCC+CCL'
 on:
-  push:
-    branches: [master, cmake-migration-proposal]
-  pull_request:
-    branches: [master]
+  schedule:
+    - cron: '0 3 * * *'  # nightly at 03:00 UTC
+  workflow_dispatch:
 jobs:
   build:
     uses: ./.github/workflows/ci-linux-build.yml

--- a/.github/workflows/ci-linux-gcc-ccl.yml
+++ b/.github/workflows/ci-linux-gcc-ccl.yml
@@ -13,3 +13,4 @@ jobs:
       cxx: g++-15
       lisp: clozure
       lisp_executable: ccl
+      build_algstrap: true

--- a/.github/workflows/ci-linux-gcc-clisp.yml
+++ b/.github/workflows/ci-linux-gcc-clisp.yml
@@ -12,3 +12,4 @@ jobs:
       cc: gcc-15
       cxx: g++-15
       lisp: clisp
+      build_algstrap: true

--- a/.github/workflows/ci-windows-msvc-sbcl.yml
+++ b/.github/workflows/ci-windows-msvc-sbcl.yml
@@ -20,14 +20,17 @@ jobs:
 
       - name: Install Visual Studio 2026 Insiders (C++ workload)
         run: |
-          winget install --id Microsoft.VisualStudio.Community.Insiders -e `
-            --accept-source-agreements --accept-package-agreements `
-            --override "--quiet --wait --add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended"
+          $bootstrapper = "${{ runner.temp }}\vs_community.exe"
+          Invoke-WebRequest -Uri "https://aka.ms/vs/18/insiders/vs_community.exe" `
+            -OutFile $bootstrapper
+          Start-Process -Wait -FilePath $bootstrapper -ArgumentList `
+            "--quiet", "--wait", "--norestart", `
+            "--add", "Microsoft.VisualStudio.Workload.NativeDesktop", `
+            "--includeRecommended"
 
-      - name: Install SBCL via winget
+      - name: Install SBCL
         run: |
-          winget install --id SBCL.SBCL -e `
-            --accept-source-agreements --accept-package-agreements
+          choco install sbcl -y --no-progress
           $sbclDir = "C:\Program Files\Steel Bank Common Lisp"
           if (-not (Test-Path $sbclDir)) {
             # Fallback: search Program Files for sbcl.exe
@@ -50,7 +53,7 @@ jobs:
           $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $installPath = & $vsWhere -prerelease -latest -property installationPath
           if (-not $installPath) {
-            Write-Error "VS Insiders installation not found"
+            Write-Error "No Visual Studio installation found"
             exit 1
           }
           $devShell = Join-Path $installPath "Common7\Tools\Launch-VsDevShell.ps1"
@@ -59,7 +62,7 @@ jobs:
             exit 1
           }
           "VSDEVSHELL=$devShell" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          Write-Host "VS Insiders at: $installPath"
+          Write-Host "VS found at: $installPath"
 
       - name: Verify tools
         run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,9 +64,15 @@ add_library(open-axiom-core STATIC
   lib/sockio-c.cxx
   utils/storage.cxx
   io/std-streams.cxx
+  io/charset.cxx
   io/InputFragment.cxx
   syntax/token.cxx
   syntax/sexpr.cxx
+  syntax/syntax-tree.cxx
+  syntax/syntax-print.cxx
+  syntax/lisp-value.cxx
+  syntax/boot-ast.cxx
+  syntax/boot-translator.cxx
   syntax/Parser.cxx
 )
 
@@ -88,7 +94,11 @@ target_sources(open-axiom-core
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/Lisp"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/Parser"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/SourceFile"
+      "${PROJECT_SOURCE_DIR}/src/include/open-axiom/SyntaxPrint"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/SyntaxTree"
+      "${PROJECT_SOURCE_DIR}/src/include/open-axiom/LispValue"
+      "${PROJECT_SOURCE_DIR}/src/include/open-axiom/BootAst"
+      "${PROJECT_SOURCE_DIR}/src/include/open-axiom/BootTranslator"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/defaults"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/diagnostics"
       "${PROJECT_SOURCE_DIR}/src/include/open-axiom/dialect"
@@ -166,9 +176,15 @@ if(oa_use_dynamic_lib STREQUAL "yes")
     lib/sockio-c.cxx
     utils/storage.cxx
     io/std-streams.cxx
+    io/charset.cxx
     io/InputFragment.cxx
     syntax/token.cxx
     syntax/sexpr.cxx
+    syntax/syntax-tree.cxx
+    syntax/syntax-print.cxx
+    syntax/lisp-value.cxx
+    syntax/boot-ast.cxx
+    syntax/boot-translator.cxx
     syntax/Parser.cxx
   )
   set_target_properties(open-axiom-core-shared PROPERTIES
@@ -295,6 +311,11 @@ target_link_libraries(open-axiom PRIVATE OpenAxiom open-axiom-core)
 add_executable(oa-lisp rt/driver.cc)
 set_target_properties(oa-lisp PROPERTIES OUTPUT_NAME lisp)
 target_link_libraries(oa-lisp PRIVATE OpenAxiom open-axiom-core)
+
+# bemol -- parser test driver.
+# Reads .boot and .spad files, tokenizes and parses them, reports statistics.
+add_executable(boot-parser-test boot/bemol.cxx)
+target_link_libraries(boot-parser-test PRIVATE OpenAxiom open-axiom-core)
 
 # -- E. Lisp compilation and base-image linking ------------------------------
 # The Lisp chain:

--- a/src/algebra/oct.spad.pamphlet
+++ b/src/algebra/oct.spad.pamphlet
@@ -284,15 +284,15 @@ OctonionCategory(R: CommutativeRing): Category ==
 ++  imaginary part, the k imaginary part, (as with quaternions)
 ++  and in addition the imaginary parts E, I, J, K.
 -- Examples: octonion.input
-Octonion(R:CommutativeRing): export == impl where
+Octonion(R:CommutativeRing): Export == Impl where
  
   QR ==> Quaternion R
  
-  export ==> Join(OctonionCategory R, FullyRetractableTo QR)  with
+  Export ==> Join(OctonionCategory R, FullyRetractableTo QR)  with
     octon: (QR,QR) -> %
       ++ octon(qe,qE) constructs an octonion from two quaternions
       ++ using the relation {\em O = Q + QE}.
-  impl ==> add
+  Impl ==> add
     Rep := Record(e: QR,E: QR)
  
     0 == [0,0]

--- a/src/boot/Makefile.am
+++ b/src/boot/Makefile.am
@@ -71,7 +71,7 @@ bootsys_SOURCES = \
 	translator.boot
 
 bemol_SOURCES = \
-	bemol.cc
+	bemol.cxx
 
 bemol_LDADD = \
 	$(oa_target_libdir)/libOpenAxiom.a \

--- a/src/boot/Makefile.in
+++ b/src/boot/Makefile.in
@@ -462,7 +462,7 @@ bootsys_SOURCES = \
 	translator.boot
 
 bemol_SOURCES = \
-	bemol.cc
+	bemol.cxx
 
 bemol_LDADD = \
 	$(oa_target_libdir)/libOpenAxiom.a \

--- a/src/boot/Makefile.in
+++ b/src/boot/Makefile.in
@@ -516,7 +516,7 @@ LISP_COMPILE = \
 all: all-am
 
 .SUFFIXES:
-.SUFFIXES: .cc .lo .o .obj
+.SUFFIXES: .cc .cxx .lo .o .obj
 $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
@@ -587,6 +587,22 @@ am--depfiles: $(am__depfiles_remade)
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ $<
 
 .cc.obj:
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.obj$$||'`;\
+@am__fastdepCXX_TRUE@	$(CXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ `$(CYGPATH_W) '$<'` &&\
+@am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ `$(CYGPATH_W) '$<'`
+
+.cxx.o:
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
+@am__fastdepCXX_TRUE@	$(CXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ $< &&\
+@am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXXCOMPILE) -c -o $@ $<
+
+.cxx.obj:
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.obj$$||'`;\
 @am__fastdepCXX_TRUE@	$(CXXCOMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ `$(CYGPATH_W) '$<'` &&\
 @am__fastdepCXX_TRUE@	$(am__mv) $$depbase.Tpo $$depbase.Po

--- a/src/boot/bemol.cxx
+++ b/src/boot/bemol.cxx
@@ -1,0 +1,693 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Test driver for the Boot language parser.  Reads each
+// --%   input .boot file, tokenizes every fragment, runs the
+// --%   recursive-descent parser, and reports statistics or errors.
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <open-axiom/Charset>
+#include <open-axiom/InputFragment>
+#include <open-axiom/token>
+#include <open-axiom/SyntaxTree>
+#include <open-axiom/SyntaxPrint>
+#include <open-axiom/Parser>
+#include <open-axiom/LispValue>
+#include <open-axiom/BootAst>
+#include <open-axiom/BootTranslator>
+#include <open-axiom/diagnostics>
+#include <open-axiom/FileMapping>
+
+namespace {
+    using namespace OpenAxiom;
+
+    // -- Processing options for a Boot source file.
+    //    Each flag selects an output phase.
+    enum class ProcessingMode : unsigned {
+        None      = 0,
+        Verbose   = 1 << 0,   // Print AST node kinds.
+        Dump      = 1 << 1,   // Print CST as S-expressions.
+        Lower     = 1 << 2,   // Lower CST to old-style AST.
+        Translate = 1 << 3,   // Full Boot-to-Lisp translation.
+    };
+
+    constexpr ProcessingMode operator|(ProcessingMode a, ProcessingMode b)
+    {
+        return static_cast<ProcessingMode>(
+            static_cast<unsigned>(a) | static_cast<unsigned>(b));
+    }
+    constexpr ProcessingMode operator&(ProcessingMode a, ProcessingMode b)
+    {
+        return static_cast<ProcessingMode>(
+            static_cast<unsigned>(a) & static_cast<unsigned>(b));
+    }
+    constexpr bool has(ProcessingMode flags, ProcessingMode bit)
+    {
+        return (flags & bit) != ProcessingMode::None;
+    }
+
+    // -- Parsed command-line options.
+    struct CommandLine {
+        ProcessingMode mode = ProcessingMode::None;
+        Language dialect = Language::Boot;
+        const char* output_path = nullptr;      // -o file: exact output file (single input only)
+        const char* output_dir = nullptr;        // --output-dir: directory for derived names
+        bool use_stdout = false;                 // -o -: write to stdout
+        std::vector<const char*> input_files;
+    };
+
+    // -- Summary statistics for a single input file.
+    struct FileStats {
+        const char* path;           // input file path
+        int fragments;              // number of fragments processed
+        int tokens;                 // total tokens across all fragments
+        int top_level_forms;        // successful top-level parses
+        int errors;                 // number of parse errors
+        int unconsumed;             // tokens left after parsing
+
+        FileStats& operator+=(const FileStats& rhs)
+        {
+            fragments += rhs.fragments;
+            tokens += rhs.tokens;
+            top_level_forms += rhs.top_level_forms;
+            errors += rhs.errors;
+            unconsumed += rhs.unconsumed;
+            return *this;
+        }
+    };
+
+    // -- Format a Kind as a readable string.
+    const char* kind_name(Syntax::Kind k)
+    {
+        switch (k)
+        {
+        case Syntax::Kind::Literal:
+            return "Literal";
+        case Syntax::Kind::Name:
+            return "Name";
+        case Syntax::Kind::QualifiedName:
+            return "QualifiedName";
+        case Syntax::Kind::Module:
+            return "Module";
+        case Syntax::Kind::Namespace:
+            return "Namespace";
+        case Syntax::Kind::Import:
+            return "Import";
+        case Syntax::Kind::ImportSignature:
+            return "ImportSignature";
+        case Syntax::Kind::ConstantDef:
+            return "ConstantDef";
+        case Syntax::Kind::FunctionDef:
+            return "FunctionDef";
+        case Syntax::Kind::MacroDef:
+            return "MacroDef";
+        case Syntax::Kind::TypeAlias:
+            return "TypeAlias";
+        case Syntax::Kind::Signature:
+            return "Signature";
+        case Syntax::Kind::Apply:
+            return "Apply";
+        case Syntax::Kind::InfixExpr:
+            return "InfixExpr";
+        case Syntax::Kind::PrefixExpr:
+            return "PrefixExpr";
+        case Syntax::Kind::SuffixDot:
+            return "SuffixDot";
+        case Syntax::Kind::Restrict:
+            return "Restrict";
+        case Syntax::Kind::Coerce:
+            return "Coerce";
+        case Syntax::Kind::Quote:
+            return "Quote";
+        case Syntax::Kind::Bracket:
+            return "Bracket";
+        case Syntax::Kind::Tuple:
+            return "Tuple";
+        case Syntax::Kind::Sequence:
+            return "Sequence";
+        case Syntax::Kind::Pile:
+            return "Pile";
+        case Syntax::Kind::Mapping:
+            return "Mapping";
+        case Syntax::Kind::Forall:
+            return "Forall";
+        case Syntax::Kind::IfExpr:
+            return "IfExpr";
+        case Syntax::Kind::Return:
+            return "Return";
+        case Syntax::Kind::Leave:
+            return "Leave";
+        case Syntax::Kind::Implies:
+            return "Implies";
+        case Syntax::Kind::While:
+            return "While";
+        case Syntax::Kind::Until:
+            return "Until";
+        case Syntax::Kind::ForIn:
+            return "ForIn";
+        case Syntax::Kind::SuchThat:
+            return "SuchThat";
+        case Syntax::Kind::Iterators:
+            return "Iterators";
+        case Syntax::Kind::Cross:
+            return "Cross";
+        case Syntax::Kind::Repeat:
+            return "Repeat";
+        case Syntax::Kind::Is:
+            return "Is";
+        case Syntax::Kind::Isnt:
+            return "Isnt";
+        case Syntax::Kind::EqualPattern:
+            return "EqualPattern";
+        case Syntax::Kind::ColonAppend:
+            return "ColonAppend";
+        case Syntax::Kind::Assignment:
+            return "Assignment";
+        case Syntax::Kind::Lambda:
+            return "Lambda";
+        case Syntax::Kind::DefaultValue:
+            return "DefaultValue";
+        case Syntax::Kind::KeyArg:
+            return "KeyArg";
+        case Syntax::Kind::BoundedSegment:
+            return "BoundedSegment";
+        case Syntax::Kind::UnboundedSegment:
+            return "UnboundedSegment";
+        case Syntax::Kind::Reduce:
+            return "Reduce";
+        case Syntax::Kind::Structure:
+            return "Structure";
+        case Syntax::Kind::Record:
+            return "Record";
+        case Syntax::Kind::AccessorDef:
+            return "AccessorDef";
+        case Syntax::Kind::Case:
+            return "Case";
+        case Syntax::Kind::Throw:
+            return "Throw";
+        case Syntax::Kind::Catch:
+            return "Catch";
+        case Syntax::Kind::Finally:
+            return "Finally";
+        case Syntax::Kind::Try:
+            return "Try";
+        case Syntax::Kind::Where:
+            return "Where";
+        case Syntax::Kind::Dynamic:
+            return "Dynamic";
+        case Syntax::Kind::With:
+            return "With";
+        case Syntax::Kind::Add:
+            return "Add";
+        case Syntax::Kind::Capsule:
+            return "Capsule";
+        case Syntax::Kind::Pretend:
+            return "Pretend";
+        case Syntax::Kind::Has:
+            return "Has";
+        case Syntax::Kind::Collect:
+            return "Collect";
+        case Syntax::Kind::Join:
+            return "Join";
+        case Syntax::Kind::FreeDecl:
+            return "FreeDecl";
+        case Syntax::Kind::ExportDecl:
+            return "ExportDecl";
+        case Syntax::Kind::LispExpr:
+            return "LispExpr";
+        case Syntax::Kind::Unparsed:
+            return "Unparsed";
+        default:
+            return "???";
+        }
+    }
+
+    // -- Check whether a filename has the given suffix (case-insensitive).
+    bool has_suffix(std::string_view path, std::string_view suffix)
+    {
+        if (path.size() < suffix.size())
+            return false;
+        auto tail = path.substr(path.size() - suffix.size());
+        for (std::size_t i = 0; i < suffix.size(); ++i)
+            if (ascii_lower(char8_t(tail[i])) != ascii_lower(char8_t(suffix[i])))
+                return false;
+        return true;
+    }
+
+    // -- Determine the language dialect for a file.
+    //    If an explicit dialect was requested (via --spad), use it.
+    //    Otherwise, infer from the file extension.
+    Language dialect_for(const char* path, Language explicit_dialect)
+    {
+        if (explicit_dialect != Language::Boot)
+            return explicit_dialect;
+        if (has_suffix(path, ".spad"))
+            return Language::Spad;
+        return Language::Boot;
+    }
+
+    // -- Parse command-line arguments into a CommandLine structure.
+    //    Returns false if a fatal error occurred (e.g. missing argument).
+    bool parse_command_line(int argc, char* argv[], CommandLine& cl)
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            std::string_view arg = argv[i];
+            if (arg == "-v" or arg == "--verbose")
+                cl.mode = cl.mode | ProcessingMode::Verbose;
+            else if (arg == "--dump")
+                cl.mode = cl.mode | ProcessingMode::Dump;
+            else if (arg == "--lower")
+                cl.mode = cl.mode | ProcessingMode::Lower;
+            else if (arg == "--translate")
+                cl.mode = cl.mode | ProcessingMode::Lower
+                                  | ProcessingMode::Translate;
+            else if (arg == "--spad")
+                cl.dialect = Language::Spad;
+            else if (arg == "-o" or arg == "--output")
+            {
+                if (i + 1 < argc)
+                {
+                    ++i;
+                    if (std::string_view{argv[i]} == "-")
+                        cl.use_stdout = true;
+                    else
+                        cl.output_path = argv[i];
+                }
+                else
+                {
+                    std::cerr << "error: " << arg
+                              << " requires an argument\n";
+                    return false;
+                }
+            }
+            else if (arg == "--output-dir")
+            {
+                if (i + 1 < argc)
+                    cl.output_dir = argv[++i];
+                else
+                {
+                    std::cerr << "error: " << arg
+                              << " requires an argument\n";
+                    return false;
+                }
+            }
+            else
+                cl.input_files.push_back(argv[i]);
+        }
+        // -- Validate: -o (file) is only valid with a single input file.
+        if (cl.output_path != nullptr and cl.input_files.size() > 1)
+        {
+            std::cerr << "error: -o/--output cannot be used with "
+                         "multiple input files\n";
+            return false;
+        }
+        // -- Validate: -o and --output-dir are mutually exclusive.
+        if ((cl.output_path != nullptr or cl.use_stdout)
+            and cl.output_dir != nullptr)
+        {
+            std::cerr << "error: -o/--output and --output-dir "
+                         "are mutually exclusive\n";
+            return false;
+        }
+        return true;
+    }
+
+    // -- Derive an output file path from an input file path.
+    //    Replaces the extension with ".out".
+    //    If output_dir is given, places the file there; otherwise
+    //    the output is alongside the input.
+    // -- Choose a file extension based on the processing mode and dialect.
+    const char* output_extension(ProcessingMode mode, Language dialect)
+    {
+        if (dialect == Language::Boot
+            and has(mode, ProcessingMode::Translate))
+            return ".clisp";
+        return ".out";
+    }
+
+    std::string derive_output_path(const char* input_path,
+                                   const char* output_dir,
+                                   ProcessingMode mode,
+                                   Language dialect)
+    {
+        std::string_view in = input_path;
+        // -- Find the basename (after last separator).
+        auto sep = in.find_last_of("/\\");
+        auto base = (sep != std::string_view::npos)
+            ? in.substr(sep + 1) : in;
+        // -- Strip the extension.
+        auto dot = base.find_last_of('.');
+        auto stem = (dot != std::string_view::npos)
+            ? base.substr(0, dot) : base;
+
+        std::string result;
+        if (output_dir != nullptr)
+        {
+            result = output_dir;
+            if (not result.empty() and result.back() != '/'
+                and result.back() != '\\')
+                result += '/';
+            result += stem;
+        }
+        else
+        {
+            // -- Same directory as input.
+            auto dir = (sep != std::string_view::npos)
+                ? in.substr(0, sep + 1) : std::string_view{};
+            result = dir;
+            result += stem;
+        }
+        result += output_extension(mode, dialect);
+        return result;
+    }
+
+    // -- Process a single source file.
+    //    Returns the file statistics (fragments, tokens, forms, errors).
+    //    If os is null, output phases are skipped (stats-only mode).
+    //    When dialect is Language::Spad, only tokenization is performed.
+    FileStats process_file(const char* path, std::ostream* os,
+                           ProcessingMode mode,
+                           Language dialect = Language::Boot)
+    {
+        FileStats stats { path, 0, 0, 0, 0, 0 };
+        Memory::FileMapping file { path };
+        if (file.empty())
+        {
+            std::cerr << "error: cannot open " << path << '\n';
+            stats.errors = 1;
+            return stats;
+        }
+        // -- Read source with reader directive evaluation.
+        // *FEATURES* is nil -- no host Lisp features.
+        Utf8SourceView source { file.begin(), file.size() };
+        auto prose = read_source(source.view(), Lisp::nil);
+
+        // -- Spad mode: tokenize and parse.
+        if (dialect == Language::Spad)
+        {
+            Syntax::SyntaxForest forest;
+            for (auto& frag : prose)
+            {
+                ++stats.fragments;
+                try
+                {
+                    auto toks = pile(words(frag, Language::Spad));
+                    stats.tokens += static_cast<int>(toks.size());
+                    std::size_t consumed = 0;
+                    auto forms = Boot::parse_spad(toks, forest, &consumed);
+                    stats.top_level_forms += static_cast<int>(forms.size());
+                    // -- Count significant (non-whitespace/comment/formatting)
+                    // tokens left unconsumed after parsing.
+                    for (std::size_t i = consumed; i < toks.size(); ++i)
+                    {
+                        switch (toks[i].category)
+                        {
+                        case TokenCategory::Whitespace:
+                        case TokenCategory::Comment:
+                        case TokenCategory::Formatting:
+                            break;
+                        default:
+                            ++stats.unconsumed;
+                            break;
+                        }
+                    }
+
+                    if (os != nullptr and has(mode, ProcessingMode::Verbose))
+                    {
+                        for (auto node : forms)
+                        {
+                            auto k = Syntax::kind(node);
+                            auto idx = Syntax::index(node);
+                            *os << "  " << kind_name(k)
+                                << "[" << idx << "]\n";
+                        }
+                    }
+                    if (os != nullptr and has(mode, ProcessingMode::Dump))
+                    {
+                        for (auto node : forms)
+                        {
+                            Syntax::print_sexpr(*os, node,
+                                                forest, toks, frag);
+                            *os << '\n';
+                        }
+                    }
+                }
+                catch (const EndOfStringUnseen& e)
+                {
+                    ++stats.errors;
+                    std::cerr << path << ": lexer error: "
+                              << "unterminated string at line " << e.line
+                              << ", column " << e.column << '\n';
+                }
+                catch (const MissingExponent& e)
+                {
+                    ++stats.errors;
+                    std::cerr << path << ": lexer error: "
+                              << "missing exponent at line " << e.line
+                              << ", column " << e.column << '\n';
+                }
+                catch (const Diagnostics::BasicError& e)
+                {
+                    ++stats.errors;
+                    std::cerr << path << ": parse error: "
+                              << e.message() << '\n';
+                }
+            }
+            return stats;
+        }
+
+        // -- Boot mode: full processing.
+        Syntax::SyntaxForest forest;
+        Lisp::Arena arena;
+        Boot::TranslationUnit tu(arena);
+
+        // -- Check if this file enables clamming via )eval directive.
+        for (auto& frag : prose)
+        {
+            for (auto& line : frag)
+            {
+                if (line.find(u8")eval") != std::u8string::npos
+                    and line.find(u8"$bfClamming") != std::u8string::npos
+                    and line.find(u8"true") != std::u8string::npos)
+                {
+                    tu.clamming = true;
+                    break;
+                }
+            }
+            if (tu.clamming)
+                break;
+        }
+
+        // -- Collect all top-level AST nodes for translation.
+        std::vector<Lisp::Value> all_ast_nodes;
+
+        for (auto& frag : prose)
+        {
+            ++stats.fragments;
+            try
+            {
+                auto toks = pile(words(frag, Language::Boot));
+                stats.tokens += static_cast<int>(toks.size());
+                auto forms = Boot::parse_boot(toks, forest);
+                stats.top_level_forms += static_cast<int>(forms.size());
+
+                if (os != nullptr and has(mode, ProcessingMode::Verbose))
+                {
+                    for (auto node : forms)
+                    {
+                        auto k = Syntax::kind(node);
+                        auto idx = Syntax::index(node);
+                        *os << "  " << kind_name(k)
+                            << "[" << idx << "]\n";
+                    }
+                }
+                if (os != nullptr and has(mode, ProcessingMode::Dump))
+                {
+                    for (auto node : forms)
+                    {
+                        Syntax::print_sexpr(*os, node,
+                                            forest, toks, frag);
+                        *os << '\n';
+                    }
+                }
+                if (has(mode, ProcessingMode::Lower))
+                {
+                    Boot::LoweringContext ctx{ forest, toks, frag, arena };
+                    for (auto node : forms)
+                    {
+                        auto val = Boot::lower(node, ctx);
+                        if (has(mode, ProcessingMode::Translate))
+                            all_ast_nodes.push_back(val);
+                        else if (os != nullptr)
+                        {
+                            Lisp::print(*os, val);
+                            *os << '\n';
+                        }
+                    }
+                }
+            }
+            catch (const Diagnostics::BasicError& e)
+            {
+                ++stats.errors;
+                std::cerr << path << ": parse error: "
+                          << e.message() << '\n';
+            }
+            catch (const EndOfStringUnseen& e)
+            {
+                ++stats.errors;
+                std::cerr << path << ": lexer error: "
+                          << "unterminated string at line " << e.line
+                          << ", column " << e.column << '\n';
+            }
+            catch (const MissingExponent& e)
+            {
+                ++stats.errors;
+                std::cerr << path << ": lexer error: "
+                          << "missing exponent at line " << e.line
+                          << ", column " << e.column << '\n';
+            }
+        }
+
+        // -- Output full translation if requested.
+        if (os != nullptr and has(mode, ProcessingMode::Translate)
+            and not all_ast_nodes.empty())
+        {
+            auto translated = Boot::translate_file(tu, all_ast_nodes);
+            for (auto form : translated)
+            {
+                Lisp::print(*os, form);
+                *os << "\n\n";
+            }
+        }
+
+        return stats;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace OpenAxiom;
+
+    CommandLine cl;
+    if (not parse_command_line(argc, argv, cl))
+        return 1;
+
+    bool has_output = cl.output_path != nullptr
+                   or cl.output_dir != nullptr
+                   or cl.use_stdout
+                   or cl.input_files.size() == 1;
+    FileStats totals { "total", 0, 0, 0, 0, 0 };
+    int file_count = 0;
+
+    for (auto input : cl.input_files)
+    {
+        auto file_dialect = dialect_for(input, cl.dialect);
+
+        // -- Determine the output stream for this file.
+        std::ofstream file_out;
+        std::ostream* os = nullptr;
+        if (cl.use_stdout)
+        {
+            os = &std::cout;
+        }
+        else if (cl.output_path != nullptr)
+        {
+            file_out.open(cl.output_path, std::ios_base::binary);
+            if (not file_out)
+            {
+                std::cerr << "error: cannot open output file "
+                          << cl.output_path << '\n';
+                return 1;
+            }
+            os = &file_out;
+        }
+        else if (cl.output_dir != nullptr)
+        {
+            auto path = derive_output_path(input, cl.output_dir,
+                                            cl.mode, file_dialect);
+            file_out.open(path, std::ios_base::binary);
+            if (not file_out)
+            {
+                std::cerr << "error: cannot open output file "
+                          << path << '\n';
+                return 1;
+            }
+            os = &file_out;
+        }
+        else if (cl.input_files.size() == 1)
+        {
+            auto path = derive_output_path(input, nullptr,
+                                            cl.mode, file_dialect);
+            file_out.open(path, std::ios_base::binary);
+            if (not file_out)
+            {
+                std::cerr << "error: cannot open output file "
+                          << path << '\n';
+                return 1;
+            }
+            os = &file_out;
+        }
+
+        auto stats = process_file(input, os, cl.mode, file_dialect);
+        totals += stats;
+        ++file_count;
+
+        if (stats.errors > 0)
+            std::cerr << stats.path << ": "
+                      << stats.errors << " error(s)\n";
+        if (stats.unconsumed > 0)
+            std::cerr << stats.path << ": "
+                      << stats.unconsumed << " unconsumed token(s)\n";
+    }
+
+    // -- Summary goes to stderr when output is directed elsewhere,
+    // otherwise to stdout.
+    auto& summary = has_output ? std::cerr : std::cout;
+    summary << "\n=== Parser Summary ===\n"
+            << "  Files:      " << file_count << '\n'
+            << "  Fragments:  " << totals.fragments << '\n'
+            << "  Tokens:     " << totals.tokens << '\n'
+            << "  Top-levels: " << totals.top_level_forms << '\n'
+            << "  Unconsumed: " << totals.unconsumed << '\n'
+            << "  Errors:     " << totals.errors << '\n';
+
+    return totals.errors > 0 ? 1 : 0;
+}

--- a/src/driver/main.cc
+++ b/src/driver/main.cc
@@ -50,7 +50,7 @@
 
 namespace OpenAxiom {
 
-   // Publish the system exec prefix for use by sub-processes.
+   // -- Publish the system exec prefix for use by sub-processes.
    static void
    publish_systemdir(const char* dir)
    {
@@ -96,7 +96,7 @@ namespace OpenAxiom {
       publish_systemdir(sysdir);
    }
 
-   // Print configuration info.
+   // -- Print configuration info.
    static int
    print_configuration_info(Command* command) {
       int i;

--- a/src/gui/conversation.cc
+++ b/src/gui/conversation.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -41,7 +41,7 @@
 #include "debate.h"
 
 namespace OpenAxiom {
-   // Largest width and line spacing, in pixel, of the font metrics
+   // -- Largest width and line spacing, in pixel, of the font metrics
    // associated with `w'.
    static QSize font_units(const QWidget* w) {
       const QFontMetrics fm = w->fontMetrics();
@@ -51,7 +51,7 @@ namespace OpenAxiom {
       return { fm.width('W'), h };
    }
 
-   // Return true if the QString `s' is morally an empty string.
+   // -- Return true if the QString `s' is morally an empty string.
    // QT makes a difference between a null string and an empty string.
    // That distinction is largely pedantic and without difference
    // for most of our practical purposes.
@@ -60,14 +60,12 @@ namespace OpenAxiom {
       return s.isNull() or s.isEmpty();
    }
    
-   // Return a resonable margin for this frame.
+   // -- Return a resonable margin for this frame.
    static int our_margin(const QFrame* f) {
       return 2 + f->frameWidth();
    }
 
-   // --------------------
    // -- OutputTextArea --
-   // --------------------
    OutputTextArea::OutputTextArea(QWidget* p)
          : Base(p), cur(document()) {
       get_cursor().movePosition(QTextCursor::End);
@@ -76,14 +74,14 @@ namespace OpenAxiom {
       setFont(p->font());
       setViewportMargins(0, 0, 0, 0);
       setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
-      // We do not want to see scroll bars.  Usually disallowing vertical
+      // -- We do not want to see scroll bars.  Usually disallowing vertical
       // scroll bars and allocating enough horizontal space is sufficient
       // to ensure that we don't see any horizontal scrollbar.
       setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
       setLineWidth(1);
    }
 
-   // This overriding implementation is so that we can control the
+   // -- This overriding implementation is so that we can control the
    // amount of vertical space in the read-only editor viewport allocated
    // for the display of output text.  In particular we do not want
    // scrollbars.
@@ -125,9 +123,7 @@ namespace OpenAxiom {
       return *this;
    }
 
-   // --------------
    // -- Question --
-   // --------------
    Question::Question(Exchange* e) : QLineEdit(e) {
       setBackgroundRole(QPalette::AlternateBase);
       setFrame(true);
@@ -145,27 +141,23 @@ namespace OpenAxiom {
       QLineEdit::enterEvent(e);
    }
 
-   // ------------
    // -- Answer --
-   // ------------
    Answer::Answer(Exchange* e) : OutputTextArea(e) {
       setFrameStyle(StyledPanel | Raised);
    }
 
-   // --------------
    // -- Exchange --
-   // --------------
    // Amount of pixel spacing between the query and reply areas.
    const int spacing = 2;
 
-   // Return a monospace font
+   // -- Return a monospace font
    static QFont monospace_font() {
       QFont f("Monaco", 11);
       f.setStyleHint(QFont::TypeWriter);
       return f;
    }
 
-   // The layout within an exchange is as follows:
+   // -- The layout within an exchange is as follows:
    //   -- input area (an editor) with its own decoation accounted for.
    //   -- an optional spacing
    //   -- an output area with its own decoration accounted for.
@@ -181,7 +173,7 @@ namespace OpenAxiom {
       return win->debate()->server();
    }
 
-   // Dress the query area with initial properties.
+   // -- Dress the query area with initial properties.
    static void
    prepare_query_widget(Conversation* conv, Exchange* e) {
       Question* q = e->question();
@@ -191,7 +183,7 @@ namespace OpenAxiom {
       q->setGeometry(m, m, conv->width() - 2 * m, q->height());
    }
 
-   // Dress the reply aread with initial properties.
+   // -- Dress the reply aread with initial properties.
    // Place the reply widget right below the frame containing
    // the query widget; make both of the same width, of course.
    static void
@@ -256,19 +248,15 @@ namespace OpenAxiom {
       }
    }
 
-   // ------------
    // -- Banner --
-   // ------------
    Banner::Banner(Conversation* conv) :  Base(conv) {
       setFrameStyle(StyledPanel | Raised);
       setBackgroundRole(QPalette::Base);
    }
 
-   // ------------------
    // -- Conversation --
-   // -------------------
    
-   // Default number of characters per question line.
+   // -- Default number of characters per question line.
    const int columns = 80;
    const int lines = 40;
 
@@ -278,7 +266,7 @@ namespace OpenAxiom {
       return QSize(columns * s.width(), lines * s.height());
    }
 
-   // Set a minimum preferred widget size, so no layout manager
+   // -- Set a minimum preferred widget size, so no layout manager
    // messes with it.  Indicate we can make use of more space.
    Conversation::Conversation(Debate* d)
          : QWidget(d),

--- a/src/gui/conversation.h
+++ b/src/gui/conversation.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -45,7 +45,7 @@
 #include "server.h"
 
 namespace OpenAxiom {
-   // A conversation is a set of exchanges.  An exchange is a question
+   // -- A conversation is a set of exchanges.  An exchange is a question
    // followed by an answer.  A conversation that takes place in a
    // a certain frame is a debate.
    class Debate;
@@ -56,32 +56,28 @@ namespace OpenAxiom {
 
    class MainWindow;
 
-   // --------------------
-   // -- OutputTextArea --
-   // --------------------
+   // -- -- OutputTextArea --
    // An output text area is a widget where we output text.
    // The texts are accumulated, as opposed to overwritten.
    class OutputTextArea : public QTextEdit {
       typedef QTextEdit Base;
    public:
       explicit OutputTextArea(QWidget*);
-      // the metrics of this output area
+      // -- the metrics of this output area
       QSize sizeHint() const;
-      // Add a new paragraph to existing texts.  Paragraghs are
+      // -- Add a new paragraph to existing texts.  Paragraghs are
       // separated by the newline character.
       void add_paragraph(const QString&);
-      // Add accumulate new text.
+      // -- Add accumulate new text.
       void add_text(const QString&);
-      // Current cursor
+      // -- Current cursor
       QTextCursor& get_cursor() { return cur; }
       OutputTextArea& insert_block(const QString&);
    protected:
       QTextCursor cur;
    };
 
-   // ---------------
-   // -- Question --
-   // ---------------
+   // -- -- Question --
    // A question is just a one-liner query area.
    struct Question : QLineEdit {
       explicit Question(Exchange*);
@@ -91,34 +87,30 @@ namespace OpenAxiom {
       void focusInEvent(QFocusEvent*);
    };
 
-   // ------------
-   // -- Answer --
-   // ------------
+   // -- -- Answer --
    struct Answer : OutputTextArea {
       explicit Answer(Exchange*);
    };
 
-   // --------------
-   // -- Exchange --
-   // --------------
+   // -- -- Exchange --
    class Exchange : public QFrame {
       Q_OBJECT;
    public:
       Exchange(Conversation*, int);
 
-      // The widget holding the query area
+      // -- The widget holding the query area
       Question* question() { return &query; }
       const Question* question() const { return &query; }
       Server* server() const;
 
-      // The widget holding the reply area.
+      // -- The widget holding the reply area.
       Answer* answer() { return &reply; }
       const Answer* answer() const { return &reply; }
 
-      // Conversion number
+      // -- Conversion number
       int number() const { return no; }
 
-      // Reimplement position management.
+      // -- Reimplement position management.
       QSize sizeHint() const;
 
    protected:
@@ -134,7 +126,7 @@ namespace OpenAxiom {
       void reply_to_query();
    };
 
-   // Conversation banner, welcome greatings.
+   // -- Conversation banner, welcome greatings.
    class Banner : public OutputTextArea {
       typedef OutputTextArea Base;
    public:
@@ -153,31 +145,31 @@ namespace OpenAxiom {
 
       Debate* debate() const { return win; }
 
-      // Holds if this conversation just started.
+      // -- Holds if this conversation just started.
       bool fresh() const { return children.empty(); }
 
-      // Number of exchanges in this conversation
+      // -- Number of exchanges in this conversation
       int length() const { return children.size(); }
 
-      // Return the `i'-th conversation in this set, if any.
+      // -- Return the `i'-th conversation in this set, if any.
       Exchange* operator[](int) const;
 
-      // Return the bottom left corner of the rectangle enclosing the
+      // -- Return the bottom left corner of the rectangle enclosing the
       // the set of exchanges in this conversation.
       QPoint bottom_left() const;
       
-      // Start a new conversation topic.
+      // -- Start a new conversation topic.
       Exchange* new_topic();
       
-      // Override QWidegt::sizeHint.  Return the cumulative sizes
+      // -- Override QWidegt::sizeHint.  Return the cumulative sizes
       // of all conversations so far.
       QSize sizeHint() const;
 
-      // Return a pointer to the current exchange, if any.
+      // -- Return a pointer to the current exchange, if any.
       Exchange* exchange() { return cur_ex; }
 
    public slots:
-      // Return the topic following a given topic in this set of conversations
+      // -- Return the topic following a given topic in this set of conversations
       Exchange* next(Exchange*);
       
    protected:
@@ -202,6 +194,6 @@ namespace OpenAxiom {
 #endif  // OPENAXIOM_CONVERSATION_INCLUDED
 
 
-// Local Variables:
+// -- Local Variables:
 // mode: c++
 // End:

--- a/src/gui/debate.cc
+++ b/src/gui/debate.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //

--- a/src/gui/debate.h
+++ b/src/gui/debate.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -59,6 +59,6 @@ namespace OpenAxiom {
 
 #endif  // OPENAXIOM_DEBATE_INCLUDED
 
-// Local Variables:
+// -- Local Variables:
 // mode: c++
 // End:

--- a/src/gui/main-window.cc
+++ b/src/gui/main-window.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -76,7 +76,7 @@ namespace OpenAxiom {
 
       connect_server_io(this, debate);
       server()->launch();
-      // When invoked in a --role=server mode, OpenAxiom would
+      // -- When invoked in a --role=server mode, OpenAxiom would
       // wait to be pinged before displaying a prompt.  This is
       // an unfortunate result of a rather awkward hack.
       server()->input("");
@@ -87,7 +87,7 @@ namespace OpenAxiom {
    }
 
    void MainWindow::done(int s, QProcess::ExitStatus) {
-      // For the time being, shut done the whole application
+      // -- For the time being, shut done the whole application
       // if the interpreter quits.  FIXME.
       QApplication::exit(s);
    }

--- a/src/gui/main-window.h
+++ b/src/gui/main-window.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -66,6 +66,6 @@ namespace OpenAxiom {
 #endif  // OPENAXIOM_GUI_MAIN_WINDOW_INCLUDED
 
 
-// Local Variables:
+// -- Local Variables:
 // mode: c++
 // End:

--- a/src/gui/main.cc
+++ b/src/gui/main.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //

--- a/src/gui/server.cc
+++ b/src/gui/server.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014, Gabriel Dos Reis.
+// -- Copyright (C) 2013-2014, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //

--- a/src/gui/server.h
+++ b/src/gui/server.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -60,7 +60,7 @@ namespace OpenAxiom {
    };   
 }
 
-// Local Variables:
+// -- Local Variables:
 // mode: c++
 // End:
 

--- a/src/hyper/htsearch.cc
+++ b/src/hyper/htsearch.cc
@@ -50,16 +50,16 @@
 #include <iostream>
 #include "cfuns.h"
 
-// FIXME: Remove kludge
+// -- FIXME: Remove kludge
 using namespace OpenAxiom;
 
- // Path to the directory containing the hyperdoc pages.
+ // -- Path to the directory containing the hyperdoc pages.
 static std::string htpagedir;
 
-// Path to the  hthits program.
+// -- Path to the  hthits program.
 static std::string hthitscmd;
 
-// Path to the database file of the hyperdoc pages.
+// -- Path to the database file of the hyperdoc pages.
 static std::string htdbfile;
 
 /*
@@ -176,7 +176,7 @@ htsearch(const char* pattern)
         presea(NULL,size,1,pattern);
     else {
 
-        // hthits requires to change directory
+        // -- hthits requires to change directory
         // to where the HyperDoc pages reside.
        if (oa_chdir(htpagedir.c_str()) == -1) {
           std::cerr << "Cannot change the page directory: "
@@ -184,7 +184,7 @@ htsearch(const char* pattern)
             exit(-1);
         }
         
-        // Call hthits with: hthits pattern ht.db
+        // -- Call hthits with: hthits pattern ht.db
         hthitscmd = hthitscmd + " " + pattern + " " + htdbfile;
         if ((hits = popen(hthitscmd.c_str(), "r")) != NULL) {
             while (fgets(buf, 1024, hits) != NULL)

--- a/src/hyper/hyper.h
+++ b/src/hyper/hyper.h
@@ -51,7 +51,7 @@
 #include "pixmap.h"
 
 namespace OpenAxiom {
-   // Mapping of HT filepath to stream handle. 
+   // -- Mapping of HT filepath to stream handle. 
    using OpenHTFileTable = std::unordered_map<std::string_view, FILE*>;
 
    HyperCommand read_hyper_command(openaxiom_sio*);
@@ -272,7 +272,7 @@ extern GroupItem   *gTopOfGroupStack;
 extern HyperDocPage *gPageBeingParsed;
 
 
-// Kludge between the more correct 'array of unsigned char' incoming data,
+// -- Kludge between the more correct 'array of unsigned char' incoming data,
 // and the unprincipled 'pointer to char' parameters of several X11
 // functions below.
 template<int N>

--- a/src/hyper/lex.h
+++ b/src/hyper/lex.h
@@ -43,7 +43,7 @@
 #define Numerrors  2
 
 namespace OpenAxiom {
-  // Type of IO state stack.  Used to automate save/restore of IO states.
+  // -- Type of IO state stack.  Used to automate save/restore of IO states.
   struct IOStateManager {
     IOStateManager();
     IOStateManager(const IOStateManager&) = delete;

--- a/src/hyper/node.h
+++ b/src/hyper/node.h
@@ -78,7 +78,7 @@ namespace OpenAxiom {
       Title = 4
    };
 
-   // Definition for connection status to the OpenAxiom server
+   // -- Definition for connection status to the OpenAxiom server
    enum class SpadStatus {
       Connected = 0,
       NotConnected = 1,

--- a/src/hyper/token.h
+++ b/src/hyper/token.h
@@ -48,18 +48,18 @@
 #define BACKSPACE  0002
 
 namespace OpenAxiom {
-  // The category of enumeration types.
+  // -- The category of enumeration types.
   template<typename T>
   concept EnumType = std::is_enum_v<T>;
 
-  // Return the underlying integer value of an enumeration value.
+  // -- Return the underlying integer value of an enumeration value.
   template<EnumType T>
   constexpr auto rep(T t)
   {
      return static_cast<std::underlying_type_t<T>>(t);
   }
 
-   // User tokens. ie, these can be found on a page
+   // -- User tokens. ie, these can be found on a page
    enum class TokenType : int {
       Word = 1,
       Page = 2,
@@ -161,7 +161,7 @@ namespace OpenAxiom {
       Controlbitmap = 98,
       NumberUserTokens = 98,
       
-      // Here are the system tokens. These are used internally to help
+      // -- Here are the system tokens. These are used internally to help
       // with parsing and displaying of text
       SystemTokens = 1001,
       Lbrace = 1001,
@@ -199,7 +199,7 @@ namespace OpenAxiom {
       Scrollupbutton = 1033,
       Scrolldownbutton = 1034,
 
-      // Here are the tokens used to mark the end to some sort of group of
+      // -- Here are the tokens used to mark the end to some sort of group of
       // tokens. ie, the tokens found in a centerline command
       Endtokens = 2000,
       End1 = 2001,
@@ -237,7 +237,7 @@ namespace OpenAxiom {
       Endpaste = 4029,
       Endspadsrc = 4030,
 
-      // Types of HyperDoc pages
+      // -- Types of HyperDoc pages
       UlUnknownPage = 9993, /*I hate this hack, but I have to know whether*/
       UnknownPage = 9994, /*this page has been loaded or not.           */
       ErrorPage = 9995,
@@ -247,7 +247,7 @@ namespace OpenAxiom {
       UnloadedPageType = 9999,
    };
 
-   // Commands from the server.
+   // -- Commands from the server.
    // See also interp/hypertex.boot and interp/nhyper.boot
    enum class HyperCommand : int {
       SpadError = 90,
@@ -283,7 +283,7 @@ enum class SourceInputKind {
 };
 
 namespace OpenAxiom {
-  // Basic error type in the Hyper component.
+  // -- Basic error type in the Hyper component.
   struct HyperError { };
 }
 

--- a/src/include/open-axiom/BootAst
+++ b/src/include/open-axiom/BootAst
@@ -1,5 +1,5 @@
 // -- -*- C++ -*-
-// Copyright (C) 2013, Gabriel Dos Reis.
+// Copyright (C) 2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -31,25 +31,46 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <open-axiom/Input>
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   CST-to-AST lowering: converts SyntaxForest nodes into
+// --%   Lisp values matching the old Boot translator's %Ast
+// --%   representation.
 
-namespace OpenAxiom {
-   // -- Input::NonEmptyText --
-   Input::NonEmptyLine::NonEmptyLine(Ordinal n, const Text& t)
-         : structure::binary<Ordinal, Text>(n, t)
-   { }
+#ifndef OPENAXIOM_BOOT_AST_included
+#define OPENAXIOM_BOOT_AST_included
 
-   // -- Input::Line --
-   const Input::NonEmptyLine&
-   Input::Line::get() const {
-      return source()->at(index());
-   }
+#include <string>
+#include <string_view>
+#include <vector>
 
-   // -- Input::Source --
-   Input::Line
-   Input::Source::line(LineNumber n, const Text& t) {
-      Index idx = size();
-      emplace_back(n, t);
-      return { this, idx };
-   }
+#include <open-axiom/SyntaxTree>
+#include <open-axiom/LispValue>
+#include <open-axiom/token>
+
+namespace OpenAxiom::Boot {
+
+    // -- Strip Boot underscore-escape sequences from an identifier.
+    //    '_' followed by whitespace is a line continuation (removed).
+    //    '_' followed by a non-whitespace character escapes it.
+    std::u8string unescape_boot_id(std::u8string_view text);
+
+    // -- Bundled context for CST-to-Lisp lowering.
+    struct LoweringContext {
+        const Syntax::SyntaxForest& forest;
+        const std::vector<Token>& tokens;
+        const Fragment& fragment;
+        Lisp::Arena& arena;
+    };
+
+    // -- Lower a single CST node to a Lisp AST value.
+    Lisp::Value lower(Syntax::NodeIndex node,
+                                   LoweringContext& ctx);
+
+    // -- Lower a span of CST children to a Lisp list.
+    Lisp::Value lower_span(Syntax::NodeSpan span,
+                                        LoweringContext& ctx);
+
 }
+
+#endif  // OPENAXIOM_BOOT_AST_included

--- a/src/include/open-axiom/BootTranslator
+++ b/src/include/open-axiom/BootTranslator
@@ -1,0 +1,109 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Boot-to-Lisp translator.  Converts the intermediate AST
+// --%   (Lisp values produced by CST lowering) into Common Lisp
+// --%   S-expressions ready for pretty-printing as .clisp output.
+
+#ifndef OPENAXIOM_BOOT_TRANSLATOR_included
+#define OPENAXIOM_BOOT_TRANSLATOR_included
+
+#include <string>
+#include <vector>
+#include <iosfwd>
+
+#include <open-axiom/LispValue>
+
+namespace OpenAxiom::Boot {
+
+    // -- Translation unit state (mirrors old %LoadUnit).
+    struct TranslationUnit {
+        Lisp::Arena& arena;
+        int gensym_counter = 0;
+        int let_var_counter = 0;
+        int is_var_counter = 0;
+
+        // -- When true, function definitions are "clammed" (cached).
+        // Each f(args)==body generates two DEFUNs: f; (impl) and
+        // f (caching wrapper).
+        bool clamming = false;
+
+        // -- Side conditions accumulated during where-clause processing.
+        std::vector<Lisp::Value> side_conditions;
+
+        // -- Name of the enclosing function (for where-clause renaming).
+        std::u8string enclosing_function;
+
+        explicit TranslationUnit(Lisp::Arena& a) : arena(a) {}
+
+        // -- Generate a fresh symbol: bfVar#N, LETTMP#N, ISTMP#N.
+        Lisp::Value gensym();
+        Lisp::Value let_var();
+        Lisp::Value is_var();
+
+    private:
+        Lisp::Value fresh_symbol(
+            std::u8string_view prefix, int& counter);
+    };
+
+    // -- Apply translateForm to a Lisp S-expression.
+    //    Handles: QUOTE passthrough, apply->FUNCALL/APPLY,
+    //    LET bindings, L%T init, PROGN/LOOP/RETURN recursion.
+    Lisp::Value translate_form(
+        Lisp::Arena& arena,
+        Lisp::Value x);
+
+    // -- Translate a top-level AST node to a list of Lisp forms.
+    //    Returns a list of forms (DEFUN, DEFPARAMETER, etc.).
+    std::vector<Lisp::Value> translate_toplevel(
+        TranslationUnit& tu,
+        Lisp::Value ast);
+
+    // -- Generate the file preamble for a Boot module.
+    //    Takes the sequence of top-level AST nodes and extracts
+    //    module/namespace/import info to produce the preamble.
+    std::vector<Lisp::Value> translate_file(
+        TranslationUnit& tu,
+        const std::vector<Lisp::Value>& top_levels);
+
+    // -- Pretty-print a Lisp form with proper indentation.
+    //    Uses the Common Lisp pretty-printer style.
+    void pretty_print(std::ostream& os,
+                      Lisp::Value form,
+                      int indent = 0);
+
+}
+
+#endif  // OPENAXIOM_BOOT_TRANSLATOR_included

--- a/src/include/open-axiom/Charset
+++ b/src/include/open-axiom/Charset
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013-2022, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -34,15 +34,151 @@
 #ifndef OPENAXIOM_CHARSET_included
 #define OPENAXIOM_CHARSET_included
 
+#include <cstddef>
 #include <cstdint>
+#include <iosfwd>
+#include <string>
+#include <string_view>
 
 namespace OpenAxiom {
-   // Code point value of a UCS member.
+   // -- Code point value of a UCS member.
    using Codepoint = std::uint32_t;
 
-   // Unicode character type.
+   // -- Unicode character type.
    enum class Character : Codepoint {
       NUL = Codepoint{}          // The NUL character 
+   };
+
+   // -- Locale-independent ASCII character classification.
+   //    These operate on char8_t (UTF-8 code units) and do not
+   //    depend on LC_CTYPE.
+
+   constexpr bool ascii_blank(char8_t c)
+   {
+      return c == u8' ' or c == u8'\t';
+   }
+
+   constexpr bool ascii_space(char8_t c)
+   {
+      return c == u8' ' or c == u8'\t' or c == u8'\n' or c == u8'\r'
+         or c == u8'\f' or c == u8'\v';
+   }
+
+   constexpr bool ascii_digit(char8_t c)
+   {
+      return c >= u8'0' and c <= u8'9';
+   }
+
+   constexpr bool ascii_xdigit(char8_t c)
+   {
+      return ascii_digit(c)
+         or (c >= u8'a' and c <= u8'f')
+         or (c >= u8'A' and c <= u8'F');
+   }
+
+   constexpr bool ascii_alpha(char8_t c)
+   {
+      return (c >= u8'a' and c <= u8'z') or (c >= u8'A' and c <= u8'Z');
+   }
+
+   constexpr bool ascii_alnum(char8_t c)
+   {
+      return ascii_alpha(c) or ascii_digit(c);
+   }
+
+   constexpr bool ascii_lowercase(char8_t c)
+   {
+      return c >= u8'a' and c <= u8'z';
+   }
+
+   constexpr bool ascii_printable(char8_t c)
+   {
+      return c >= u8' ' and c <= u8'~';
+   }
+
+   // -- Common Lisp reader macro / syntax characters that require
+   // |bar| quoting in symbol output.
+   constexpr bool cl_special_char(char8_t c)
+   {
+      switch (c)
+      {
+      case u8'|': case u8' ': case u8'(': case u8')':
+      case u8'#': case u8'\'': case u8'"': case u8',':
+      case u8'`': case u8'\\': case u8';':
+         return true;
+      default:
+         return false;
+      }
+   }
+
+   // -- Common Lisp bar-quoting utilities.
+   //    Used when printing symbol names in CL S-expression format.
+
+   // -- Does a symbol name need |bar| quoting?
+   constexpr bool needs_bar_quoting(std::u8string_view name)
+   {
+      if (name.empty())
+         return true;
+      for (char8_t c : name)
+      {
+         if (ascii_lowercase(c) or cl_special_char(c))
+            return true;
+      }
+      return false;
+   }
+
+   // -- Print a symbol name inside |bars|, escaping | and \.
+   void print_bar_quoted(std::ostream& os, std::u8string_view name);
+
+   constexpr char8_t ascii_lower(char8_t c)
+   {
+      return (c >= u8'A' and c <= u8'Z')
+         ? static_cast<char8_t>(c + (u8'a' - u8'A'))
+         : c;
+   }
+
+   // -- Conversion helpers between char8_t and char domains.
+   //    UTF-8 code units have the same bit pattern as char on
+   //    all platforms OpenAxiom targets.
+   inline std::string_view as_chars(std::u8string_view s)
+   {
+      return { reinterpret_cast<const char*>(s.data()), s.size() };
+   }
+
+   inline std::u8string_view as_utf8(std::string_view s)
+   {
+      return { reinterpret_cast<const char8_t*>(s.data()), s.size() };
+   }
+
+   // -- Stream a UTF-8 string to a char-based ostream.
+   std::ostream& operator<<(std::ostream&, std::u8string_view);
+
+   // -- Non-owning view of a UTF-8 encoded byte buffer.
+   //    Strips an optional BOM and provides a std::u8string_view
+   //    for text processing.
+   struct Utf8SourceView {
+      explicit Utf8SourceView(const std::byte* data, std::size_t size)
+         : text { skip_bom(data, size),
+                  size - (skip_bom(data, size)
+                          - reinterpret_cast<const char8_t*>(data)) }
+      { }
+
+      std::u8string_view view() const { return text; }
+
+   private:
+      std::u8string_view text;
+
+      static const char8_t* skip_bom(const std::byte* data,
+                                     std::size_t size)
+      {
+         auto p = reinterpret_cast<const char8_t*>(data);
+         if (size >= 3
+             and p[0] == char8_t(0xEF)
+             and p[1] == char8_t(0xBB)
+             and p[2] == char8_t(0xBF))
+            return p + 3;
+         return p;
+      }
    };
 }
 

--- a/src/include/open-axiom/Constructor
+++ b/src/include/open-axiom/Constructor
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/Database
+++ b/src/include/open-axiom/Database
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/FileMapping
+++ b/src/include/open-axiom/FileMapping
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2010-2014, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -38,24 +38,24 @@
 #ifndef OPENAXIOM_FILEMAPPING_included
 #define OPENAXIOM_FILEMAPPING_included
 
-#include <open-axiom/storage>
+#include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace OpenAxiom {
    namespace Memory {
-      // -----------------
       // -- FileMapping --
-      // -----------------
       struct FileMapping {
-         explicit FileMapping(std::string);
+         explicit FileMapping(const std::string&);
          FileMapping(FileMapping&&);
          ~FileMapping();
-         const Byte* begin() const { return start; }
-         const Byte* end() const { return begin() + extent; }
+         const std::byte* begin() const { return start; }
+         const std::byte* end() const { return start + extent; }
          std::size_t size() const { return extent; }
          bool empty() const { return size() == 0; }
       protected:
-         Byte* start { };           // address at the mapped storage
-         size_t extent { };         // length (in bytes) of the storage
+         std::byte* start { };      // address of the mapped storage
+         std::size_t extent { };    // length (in bytes) of the storage
       private:
          FileMapping(const FileMapping&) = delete;
          FileMapping& operator=(const FileMapping&) = delete;

--- a/src/include/open-axiom/Input
+++ b/src/include/open-axiom/Input
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/InputFragment
+++ b/src/include/open-axiom/InputFragment
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2014-2024, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -36,41 +36,43 @@
 #ifndef OPENAXIOM_INPUTFRAGMENT_included
 #define OPENAXIOM_INPUTFRAGMENT_included
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <stack>
 
 namespace OpenAxiom {
-   // Datatypes for locating lines and columns.
+   namespace Lisp { enum class Value : std::uint64_t; }
+   // -- Datatypes for locating lines and columns.
    using LineNumber = std::size_t;
-   using ColumnIndex = uint16_t;
+   using ColumnIndex = std::uint16_t;
 
-   enum class LineKind : uint8_t {
+   enum class LineKind : std::uint8_t {
       Ordinary,                 // Ordinary input line
       Description,              // Documentation commentary lines.
       Meta,                     // Input to the attention of the reader
       Ignorable,                // Ignorable commentary line
    };
    
-   // A physical line is just raw text, coupled with location
+   // -- A physical line is just raw UTF-8 text, coupled with location
    // information such as line and indentation column.
-   struct Line : std::string {
+   struct Line : std::u8string {
       LineNumber number { };
       ColumnIndex indent { };
       LineKind kind { LineKind::Ordinary };
       
-      std::string sub_string(ColumnIndex s, ColumnIndex e) const {
-         return substr(s, e - s);
+      std::u8string sub_string(ColumnIndex s, ColumnIndex e) const {
+         return std::u8string(substr(s, e - s));
       }
    };
 
-   // Cursor into a fragment.
+   // -- Cursor into a fragment.
    // Note: We don't expect people to write large fragements
    //       either in length or in width.
    struct FragmentCursor {
-      uint16_t line;            // index of a line in a fragment
-      uint16_t column;          // column number at line.
+      std::uint16_t line;       // index of a line in a fragment
+      std::uint16_t column;     // column number at line.
 
       inline FragmentCursor& operator++() {
          ++column;
@@ -97,30 +99,30 @@ namespace OpenAxiom {
 
    std::ostream& operator<<(std::ostream&, FragmentCursor);
 
-   // A program fragment is a logical line, composed of possibly
+   // -- A program fragment is a logical line, composed of possibly
    // several physical lines subject to the off-side rule.  As a
    // special case, a line ending with the underbar character
    // continues to the next line with disregard to the off-side rule.
    struct Fragment : std::vector<Line> {
       explicit operator bool() const { return not empty(); }
-      // Holds if the last physical line ends with line continuation marker.
+      // -- Holds if the last physical line ends with line continuation marker.
       bool line_continuation() const {
-         return not empty() and back().back() == '_';
+         return not empty() and back().back() == u8'_';
       }
       using std::vector<Line>::operator[];
-      // Reference a line given by a position into this fragment.
+      // -- Reference a line given by a position into this fragment.
       const Line& operator()(const FragmentCursor& pos) const {
          return (*this)[pos.line];
       }
-      // Reference a character code unit at the position into this fragment.
-      uint8_t operator[](const FragmentCursor& pos) const {
+      // -- Reference a character at the position into this fragment.
+      char8_t operator[](const FragmentCursor& pos) const {
          return (*this)[pos.line][pos.column];
       }
-      // Advance the cursor position to the next character code unit.
-      uint8_t advance(FragmentCursor& pos) const {
+      // -- Advance the cursor position to the next character.
+      char8_t advance(FragmentCursor& pos) const {
          return (*this)[pos.line][pos.column++];
       }
-      // This predicate holds if this fragment covers the cursor position.
+      // -- This predicate holds if this fragment covers the cursor position.
       bool covering(const FragmentCursor& pos) const {
          return pos.column < (*this)[pos.line].size();
       }
@@ -128,7 +130,7 @@ namespace OpenAxiom {
 
    std::ostream& operator<<(std::ostream&, const Fragment&);
 
-   // A prose is the contents of an input source file organized as a
+   // -- A prose is the contents of an input source file organized as a
    // sequence of fragments.
    // Note: a prose is defined as movable, but not a copyable type.
    struct Prose : std::vector<Fragment> {
@@ -136,7 +138,15 @@ namespace OpenAxiom {
       Prose(Prose&&) = default;
    };
 
-   Prose read_source(std::istream&);
+   Prose read_source(std::u8string_view);
+
+   // -- Read source with reader directive evaluation.
+   //    Processes )if / )elseif / )else / )endif conditionals
+   //    by evaluating the condition as a Boot expression and
+   //    including/excluding lines accordingly.
+   //    The features parameter is a Lisp-style list of keyword
+   //    symbols (e.g. (:SBCL :COMMON-LISP ...)).
+   Prose read_source(std::u8string_view, Lisp::Value features);
 }
 
 #endif  // OPENAXIOM_INPUTFRAGMENT_included

--- a/src/include/open-axiom/Lisp
+++ b/src/include/open-axiom/Lisp
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013-2014, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/LispValue
+++ b/src/include/open-axiom/LispValue
@@ -1,0 +1,266 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   A lightweight, arena-allocated Lisp value representation for
+// --%   use as an intermediate representation in the Boot-to-Lisp
+// --%   translator.  Values are dynamically typed and immutable
+// --%   once constructed (with the exception of cons cell mutation
+// --%   for list construction).
+
+#ifndef OPENAXIOM_LISP_VALUE_included
+#define OPENAXIOM_LISP_VALUE_included
+
+#include <cstdint>
+#include <forward_list>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <unordered_map>
+#include <iosfwd>
+
+namespace OpenAxiom::Lisp {
+
+    // -- Value: a dynamically-typed Lisp value
+    // Represented as a tagged pointer packed into an enum with
+    // std::uint64_t as base type.  The low 3 bits encode the
+    // ValueKind discriminator; the upper 61 bits are the address
+    // of a heap-allocated data node (always 8-byte aligned, so
+    // the low bits are structurally zero).  nil is the zero
+    // enumerator — both address and tag are zero.
+
+    // -- Discriminator for value nodes.
+    enum class ValueKind : std::uint8_t {
+        Symbol,
+        Integer,
+        Float,
+        String,
+        Cons,
+    };
+
+    // -- Tagged pointer to a Lisp value node.
+    enum class Value : std::uint64_t { nil = 0 };
+
+    // -- Extract the raw bits from a Value.
+    constexpr std::uint64_t to_bits(Value v)
+    {
+        return static_cast<std::uint64_t>(v);
+    }
+
+    // -- Tag manipulation constants.
+    inline constexpr unsigned tag_width = 3;
+    inline constexpr std::uint64_t tag_mask = 0b111;
+
+    // -- Extract the kind discriminator.
+    constexpr ValueKind kind(Value v)
+    {
+        return ValueKind(to_bits(v) & tag_mask);
+    }
+
+    // -- Recover the data pointer (mask off the tag bits).
+    template<typename T>
+    const T* as(Value v)
+    {
+        return reinterpret_cast<const T*>(to_bits(v) & ~tag_mask);
+    }
+
+    // -- Forge a tagged Value from a data pointer and kind.
+    inline Value tag(const void* p, ValueKind k)
+    {
+        return Value{ reinterpret_cast<std::uint64_t>(p)
+                    | std::uint64_t(k) };
+    }
+
+    // -- Data nodes (headerless — no padding holes)
+    // Each node must be at least 8-byte aligned so that the
+    // low 3 bits of its address are structurally zero, available
+    // for the ValueKind tag.
+
+    struct alignas(8) SymbolData {
+        std::u8string_view name;        // interned in the Arena
+    };
+
+    struct alignas(8) IntegerData {
+        std::int64_t value;
+    };
+
+    struct alignas(8) FloatData {
+        double value;
+    };
+
+    struct alignas(8) StringData {
+        std::u8string_view text;        // interned in the Arena
+    };
+
+    struct alignas(8) ConsData {
+        Value car;
+        Value cdr;
+    };
+
+    // -- The canonical nil value.
+    inline constexpr Value nil = Value::nil;
+
+    // -- Predicates.
+    constexpr bool null(Value v)    { return v == nil; }
+    constexpr bool consp(Value v)   { return not null(v) and kind(v) == ValueKind::Cons; }
+    constexpr bool symbolp(Value v) { return not null(v) and kind(v) == ValueKind::Symbol; }
+    constexpr bool integerp(Value v){ return not null(v) and kind(v) == ValueKind::Integer; }
+    constexpr bool floatp(Value v)  { return not null(v) and kind(v) == ValueKind::Float; }
+    constexpr bool stringp(Value v) { return not null(v) and kind(v) == ValueKind::String; }
+    constexpr bool atomp(Value v)   { return not consp(v); }
+
+    // -- Car and cdr.
+    inline Value car(Value v) { return as<ConsData>(v)->car; }
+    inline Value cdr(Value v) { return as<ConsData>(v)->cdr; }
+
+    // -- Convenience: cadr, caddr, etc.
+    inline Value cadr(Value v)  { return car(cdr(v)); }
+    inline Value cddr(Value v)  { return cdr(cdr(v)); }
+    inline Value caddr(Value v) { return car(cddr(v)); }
+    inline Value caar(Value v)  { return car(car(v)); }
+    inline Value cdar(Value v)  { return cdr(car(v)); }
+
+    // -- Get the symbol name.
+    inline std::u8string_view symbol_name(Value v)
+    {
+        return as<SymbolData>(v)->name;
+    }
+
+    // -- Get the integer value.
+    inline std::int64_t integer_value(Value v)
+    {
+        return as<IntegerData>(v)->value;
+    }
+
+    // -- Get the string text.
+    inline std::u8string_view string_text(Value v)
+    {
+        return as<StringData>(v)->text;
+    }
+
+    // -- Test if a value is a symbol with the given name.
+    inline bool is_symbol(Value v, std::u8string_view name)
+    {
+        return symbolp(v) and symbol_name(v) == name;
+    }
+
+    // -- Test if a cons cell's car is a symbol with the given name.
+    inline bool is_tagged(Value v, std::u8string_view tag)
+    {
+        return consp(v) and is_symbol(car(v), tag);
+    }
+
+    // -- Length of a proper list.
+    std::uint32_t length(Value v);
+
+    // -- Iterate over the elements of a proper list.
+    template<typename Fn>
+    void for_each(Value lst, Fn fn)
+    {
+        while (consp(lst))
+        {
+            fn(car(lst));
+            lst = cdr(lst);
+        }
+    }
+
+    // -- Arena: factory for Lisp values
+    // All values are owned by an Arena.  Symbols and strings
+    // are interned so that equality can be tested by pointer
+    // comparison on the string_view data.
+    struct Arena {
+        Arena();
+
+        // -- Value constructors.
+        Value make_symbol(std::u8string_view name);
+        Value make_integer(std::int64_t value);
+        Value make_float(double value);
+        Value make_string(std::u8string_view text);
+        Value cons(Value car, Value cdr);
+
+        // -- List construction from a vector of elements.
+        Value list(std::initializer_list<Value> elems);
+        Value list(const std::vector<Value>& elems);
+
+        // -- Frequently used symbols (cached for efficiency).
+        Value T;                // T (true)
+        Value quote_sym;        // QUOTE
+        Value nil_sym;          // NIL (the symbol, not the value)
+
+    private:
+        // -- Interning tables.
+        std::unordered_map<std::u8string_view, Value> symbols;
+        std::forward_list<std::u8string> owned_strings;
+
+        // -- Storage pools.  forward_list gives stable addresses
+        // and automatic lifetime management.
+        std::forward_list<SymbolData> sym_pool;
+        std::forward_list<IntegerData> int_pool;
+        std::forward_list<FloatData> float_pool;
+        std::forward_list<StringData> str_pool;
+        std::forward_list<ConsData> cons_pool;
+
+        // -- Intern a string: return a stable u8string_view.
+        std::u8string_view intern_string(std::u8string_view s);
+    };
+
+    // -- Output: pretty-print a Lisp value
+
+    // -- Print a Lisp value as a Common Lisp S-expression.
+    // Symbols with lowercase or special characters are |bar|-quoted.
+    void print(std::ostream& os, Value v);
+
+    inline std::ostream& operator<<(std::ostream& os, Value v)
+    {
+        print(os, v);
+        return os;
+    }
+
+    // -- Condition evaluator for reader directives
+    // Evaluate a lowered Boot condition AST (from Boot::lower)
+    // in the context of a features list.  Used by the reader
+    // to process )if / )elseif conditions.
+    //
+    // Handles:
+    //   (%Call |%hasFeature| (kw-expr))  -- feature check
+    //   (%InfixExpr |and| lhs rhs)       -- logical and
+    //   (%InfixExpr |or| lhs rhs)        -- logical or
+    //   (%PrefixExpr |not| operand)       -- negation
+    //   NIL                               -- false
+    //   anything else                     -- true (non-nil)
+    bool eval_condition(Value v, Value features);
+
+}
+
+#endif  // OPENAXIOM_LISP_VALUE_included

--- a/src/include/open-axiom/Parser
+++ b/src/include/open-axiom/Parser
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2016-2017, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -35,15 +35,33 @@
 #define OPENAXIOM_PARSER_included
 
 #include <string>
+#include <vector>
+
+#include <open-axiom/token>
+#include <open-axiom/SyntaxTree>
 
 namespace OpenAxiom {
-   // Translate a Boot input source code to a Lisp source code.
+   // -- Translate a Boot input source code to a Lisp source code.
    // Both parameters point to the pathnames of the input source file
    // and the output source file, respectively.  Return zero on success.
    extern "C" int boot_to_lisp(const char*, const char*);
 
+   namespace Boot {
+      // -- Parse all top-level forms from a token stream into the given
+      // forest.  Returns a vector of NodeIndex handles for each
+      // top-level form.
+      std::vector<Syntax::NodeIndex> parse_boot(
+         const std::vector<Token>&, Syntax::SyntaxForest&);
+
+      // -- Parse all top-level forms from a Spad token stream.
+      // If `consumed` is non-null, stores the number of tokens consumed.
+      std::vector<Syntax::NodeIndex> parse_spad(
+         const std::vector<Token>&, Syntax::SyntaxForest&,
+         std::size_t* consumed = nullptr);
+   }
+
    namespace Error {
-      // Exception type for filesystem error.
+      // -- Exception type for filesystem error.
       struct CannotOpenFile {
          std::string path;
       };

--- a/src/include/open-axiom/SourceFile
+++ b/src/include/open-axiom/SourceFile
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/SyntaxPrint
+++ b/src/include/open-axiom/SyntaxPrint
@@ -1,5 +1,5 @@
-// -*- C++ -*-
-// Copyright (C) 2014-2017, Gabriel Dos Reis.
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -15,9 +15,9 @@
 //       the documentation and/or other materials provided with the
 //       distribution.
 //
-//     - Neither the name of OpenAxiom. nor the names of its contributors
-//       may be used to endorse or promote products derived from this
-//       software without specific prior written permission.
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -33,52 +33,38 @@
 
 // --% Author: Gabriel Dos Reis
 // --% Description:
+// --%   S-expression printer for syntax trees.  Walks a SyntaxForest
+// --%   and emits a parenthesized representation that mirrors the
+// --%   original Boot translator's %Ast structure names.
 
-#include <string.h>
+#ifndef OPENAXIOM_SYNTAX_PRINT_included
+#define OPENAXIOM_SYNTAX_PRINT_included
+
+#include <iosfwd>
 #include <string>
-#include <open-axiom/diagnostics>
-#include <open-axiom/Parser>
+#include <vector>
 
-namespace {
-   const char* path_basename(const char* begin, const char* end) {
-      while (end > begin and end[-1] != '/' and end[-1] != '\\')
-         --end;
-      return end;
-   }
+#include <open-axiom/SyntaxTree>
 
-   const char* path_type(const char* begin, const char* end) {
-      while (end > begin and end[-1] != '.')
-         --end;
-      return end;
-   }
+namespace OpenAxiom::Syntax {
 
-   int process_file(const char* path) {
-      auto end = path + strlen(path);
-      if (path == end) {
-         std::cerr << "error: empty input file path\n";
-         return -1;
-      }
-      
-      auto base = path_basename(path, end);
-      if (base == end) {
-         std::cerr << "error: invalid input file path\n";
-         return -1;
-      }
-      
-      auto type = path_type(base, end);
-      if (base == type) {
-         std::cerr << "error: input file base without basename\n";
-         return -1;
-      }
+    // -- Extract the source text of a token from its fragment.
+    std::u8string token_text(TokenIndex ti,
+                             const std::vector<Token>& toks,
+                             const Fragment& frag);
 
-      std::string output { base, type };
-      output += "out";
-      return OpenAxiom::boot_to_lisp(path, output.c_str());
-   }
+    // -- Print a token's text to a stream, with |bar| quoting
+    //    for identifiers that need it.
+    void print_token(std::ostream& os, TokenIndex ti,
+                     const std::vector<Token>& toks,
+                     const Fragment& frag);
+
+    // -- Print a syntax node as an S-expression.
+    void print_sexpr(std::ostream& os,
+                     NodeIndex node,
+                     const SyntaxForest& forest,
+                     const std::vector<Token>& toks,
+                     const Fragment& frag);
 }
 
-int main(int argc, char* argv[]) {
-   for (int i = 1; i < argc; ++i) {
-      process_file(argv[i]);
-   }
-}
+#endif  // OPENAXIOM_SYNTAX_PRINT_included

--- a/src/include/open-axiom/SyntaxTree
+++ b/src/include/open-axiom/SyntaxTree
@@ -1,5 +1,5 @@
-// -*- C++ -*-
-// Copyright (C) 2017, Gabriel Dos Reis.
+// -- -*- C++ -*-
+// Copyright (C) 2017-2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -31,49 +31,954 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Abstract syntax tree representation for the Boot language.
+// --%   Each node is a lightweight struct referencing tokens by index.
+// --%   Trees are allocated in a SyntaxForest arena and referenced
+// --%   through compact 32-bit NodeIndex handles.
+
 #ifndef OPENAXIOM_SYNTAX_TREE_included
 #define OPENAXIOM_SYNTAX_TREE_included
 
-#include <stdint.h>
+#include <cstdint>
+#include <vector>
+
 #include <open-axiom/token>
+#include <open-axiom/storage>
 
-namespace OpenAxiom {
-   enum class SyntaxKind : uint8_t {
-      Module, Namespace, Import, Definition, Unparsed
-   };
-   
-   enum SyntaxTree : uint32_t { };
+namespace OpenAxiom::Syntax {
+    // -- NodeIndex: compact handle to a syntax tree node
+    // A NodeIndex packs a Kind tag (8 bits) and an index
+    // (24 bits) into the corresponding per-kind storage array.
+    // The sentinel value `none` represents the absence of a node.
+    enum class NodeIndex : std::uint32_t {
+        none = 0xFFFFFFFF  // sentinel: no node
+    };
 
-   constexpr SyntaxKind kind(SyntaxTree t) {
-      return SyntaxKind((uint32_t(t) & 0xFF000000) >> 24);
-   }
+    // -- Kind: discriminator for node types
+    // Each enumerator corresponds to one concrete syntax struct.
+    enum class Kind : std::uint8_t {
+        // -- Atoms --
+        Literal,            // integer, float, or string literal
+        Name,               // simple identifier
+        QualifiedName,      // module-qualified name (m::x)
+        // -- Module system --
+        Module,             // module declaration
+        Namespace,          // namespace directive
+        Import,             // import declaration
+        ImportSignature,    // import of a typed name from a module
+        // -- Definitions --
+        ConstantDef,        // constant definition (name == expr)
+        FunctionDef,        // function definition (name args == body)
+        MacroDef,           // macro definition (macro name args == body)
+        TypeAlias,          // type alias definition (name ==> type)
+        Signature,          // type signature (name : type)
+        // -- Expressions --
+        Apply,              // function application (f x)
+        InfixExpr,          // binary infix expression (x op y)
+        PrefixExpr,         // unary prefix expression (op x)
+        SuffixDot,          // dot suffix (x.)
+        Restrict,           // type restriction (x @ T)
+        Coerce,             // type coercion (x :: T)
+        Quote,              // quoted expression ('x)
+        Bracket,            // bracketed list construction [...]
+        Tuple,              // comma-separated expressions (a, b, c)
+        Sequence,           // semicolon-separated expressions
+        Pile,               // indentation-delimited expression sequence
+        // -- Types --
+        Mapping,            // function type (S -> T)
+        Forall,             // universally quantified type
+        // -- Control flow --
+        IfExpr,             // conditional (if p then a else b)
+        Return,             // return from function
+        Leave,              // leave from loop
+        Implies,            // guarded expression (p => x)
+        // -- Loops --
+        While,              // while-condition iterator
+        Until,              // until-condition iterator
+        ForIn,              // for-in iterator
+        SuchThat,           // filter (| predicate)
+        Iterators,          // composed iterator list
+        Cross,              // cross-product iterators
+        Repeat,             // repeat loop
+        // -- Pattern matching --
+        Is,                 // is-pattern test
+        Isnt,               // isnt-pattern test
+        EqualPattern,       // =expr in patterns
+        ColonAppend,        // :rest in list patterns
+        // -- Assignment & binding --
+        Assignment,         // mutation (x := y)
+        Lambda,             // lambda expression (x +-> body)
+        DefaultValue,       // optional default parameter value
+        KeyArg,             // keyword argument (key <- value)
+        // -- Segments --
+        BoundedSegment,     // bounded segment (a..b)
+        UnboundedSegment,   // unbounded segment (a..)
+        // -- Reduce --
+        Reduce,             // reduction (op/[...])
+        // -- Structural --
+        Structure,          // structure declaration
+        Record,             // record type definition
+        AccessorDef,        // record accessor definition
+        Case,               // case expression
+        // -- Exception handling --
+        Throw,              // throw expression
+        Catch,              // catch clause
+        Finally,            // finally clause
+        Try,                // try expression with handlers
+        // -- Scoping --
+        Where,              // where clause
+        Dynamic,            // local declaration
+        // -- Spad type system --
+        With,               // category definition
+        Add,                // domain implementation
+        Capsule,            // scoped definition block
+        Pretend,            // unsafe type assertion
+        Has,                // category membership test
+        Collect,            // list comprehension
+        Join,               // category join
+        // -- Spad declarations --
+        FreeDecl,           // free variable declaration
+        ExportDecl,         // explicit export declaration
+        // -- Embedded Lisp --
+        LispExpr,           // )lisp directive
+        // -- Fallback --
+        Unparsed,           // unparsed token range
+    };
 
-   constexpr uint32_t index(SyntaxTree t) {
-      return uint32_t(t) & 0x00FFFFFF;
-   }
+    // -- Extract the kind tag from a NodeIndex.
+    constexpr Kind kind(NodeIndex n)
+    {
+        return Kind((std::uint32_t(n) & 0xFF000000) >> 24);
+    }
 
-   struct ModuleSyntax {
-      TokenIndex keyword;
-      TokenIndex name;
-   };
+    // -- Extract the storage index from a NodeIndex.
+    constexpr std::uint32_t index(NodeIndex n)
+    {
+        return std::uint32_t(n) & 0x00FFFFFF;
+    }
 
-   struct NamespaceSyntax {
-      TokenIndex keyword;
-      TokenIndex name;
-   };
+    // -- Construct a NodeIndex from a kind and an index.
+    constexpr NodeIndex make_node(Kind k, std::uint32_t idx)
+    {
+        return NodeIndex((std::uint32_t(k) << 24) | (idx & 0x00FFFFFF));
+    }
 
-   struct ImportSyntax {
-      TokenIndex keyword;
-   };
+    // -- Test whether a NodeIndex designates an actual node.
+    constexpr bool valid(NodeIndex n)
+    {
+        return n != NodeIndex::none;
+    }
 
-   struct DefinitionSyntax {
-      TokenIndex keyword;
-   };
+    // -- NodeSpan: contiguous range of child nodes
+    // Represents a slice into a shared NodeIndex array, used for
+    // variable-length child lists (e.g. tuple elements, pile items,
+    // function parameters, catch clauses).
+    struct NodeSpan {
+        std::uint32_t offset;   // start index into the shared child array
+        std::uint32_t count;    // number of child nodes in this span
+    };
 
-   struct UnparsedSyntax {
-      TokenIndex first;
-      TokenIndex last;
-   };
+    // -- Concrete syntax node structs
+    // Each struct corresponds to one Kind enumerator.
+    // Fields reference tokens via TokenIndex and subtrees via
+    // NodeIndex.  Variable-length children use NodeSpan.
+
+    // ------- Atoms -------
+
+    // -- A literal constant: integer, floating-point, or string.
+    struct LiteralSyntax {
+        TokenIndex token;       // the literal token
+    };
+
+    // -- A simple identifier.
+    struct NameSyntax {
+        TokenIndex token;       // the identifier token
+    };
+
+    // -- A module-qualified name, e.g. `M::x`.
+    struct QualifiedNameSyntax {
+        NodeIndex qualifier;    // left-hand name (the module)
+        TokenIndex separator;   // the `::` token
+        NodeIndex name;         // right-hand name
+    };
+
+    // ------- Module system -------
+
+    // -- A module declaration: `module Name(exports) where interface`.
+    struct ModuleSyntax {
+        TokenIndex keyword;     // the `module` token
+        NodeIndex name;         // module name
+        NodeSpan exports;       // exported symbol list
+        NodeSpan interface;     // where-clause definitions
+    };
+
+    // -- A namespace directive: `namespace Name`.
+    struct NamespaceSyntax {
+        TokenIndex keyword;     // the `namespace` token
+        NodeIndex name;         // namespace name
+    };
+
+    // -- An import declaration: `import Name`.
+    struct ImportSyntax {
+        TokenIndex keyword;     // the `import` token
+        NodeIndex what;         // imported module or namespace expression
+    };
+
+    // -- An import of a typed name: `import sig for name in module`.
+    struct ImportSignatureSyntax {
+        TokenIndex keyword;     // the `import` token
+        NodeIndex signature;    // type signature being imported
+        NodeIndex name;         // name of the binding
+        NodeIndex provenance;   // source module (or NodeIndex::none)
+    };
+
+    // ------- Definitions -------
+
+    // -- A constant definition: `name == body`.
+    struct ConstantDefSyntax {
+        NodeIndex name;         // defined name
+        TokenIndex definer;     // the `==` token
+        NodeIndex body;         // right-hand-side expression
+    };
+
+    // -- A function definition: `name params == body`.
+    struct FunctionDefSyntax {
+        NodeIndex name;         // function name
+        NodeSpan parameters;    // formal parameter list
+        TokenIndex definer;     // the `==` token
+        NodeIndex body;         // function body expression
+    };
+
+    // -- A macro definition: `macro name params == body`.
+    struct MacroDefSyntax {
+        TokenIndex keyword;     // the `macro` token
+        NodeIndex name;         // macro name
+        NodeSpan parameters;    // formal parameter list
+        TokenIndex definer;     // the `==` token
+        NodeIndex body;         // macro body expression
+    };
+
+    // -- A type alias: `TypeName ==> Type`.
+    struct TypeAliasSyntax {
+        NodeIndex name;         // alias name (possibly with parameters)
+        TokenIndex definer;     // the `==>` token
+        NodeIndex type;         // target type expression
+    };
+
+    // -- A type signature: `name : type`.
+    struct SignatureSyntax {
+        NodeIndex name;         // signed name
+        TokenIndex colon;       // the `:` token
+        NodeIndex type;         // type expression
+    };
+
+    // ------- Expressions -------
+
+    // -- Function application: `f(args)` or juxtaposition `f x`.
+    struct ApplySyntax {
+        NodeIndex function;     // operator expression
+        NodeSpan arguments;     // argument list
+    };
+
+    // -- Binary infix expression: `lhs op rhs`.
+    struct InfixExprSyntax {
+        NodeIndex lhs;          // left operand
+        TokenIndex op;          // operator token
+        NodeIndex rhs;          // right operand
+    };
+
+    // -- Unary prefix expression: `op operand`.
+    struct PrefixExprSyntax {
+        TokenIndex op;          // operator token
+        NodeIndex operand;      // operand expression
+    };
+
+    // -- Dot suffix: `expr.`
+    struct SuffixDotSyntax {
+        NodeIndex operand;      // base expression
+        TokenIndex dot;         // the `.` token
+    };
+
+    // -- Type restriction: `expr @ type`.
+    struct RestrictSyntax {
+        NodeIndex expr;         // expression being restricted
+        TokenIndex at;          // the `@` token
+        NodeIndex type;         // target type
+    };
+
+    // -- Type coercion: `expr :: type`.
+    struct CoerceSyntax {
+        NodeIndex expr;         // expression being coerced
+        TokenIndex colon_colon; // the `::` token
+        NodeIndex type;         // target type
+    };
+
+    // -- Quoted expression: `'expr`.
+    struct QuoteSyntax {
+        TokenIndex apostrophe;  // the `'` token
+        NodeIndex expr;         // quoted expression
+    };
+
+    // -- Bracketed list construction: `[elements]`.
+    struct BracketSyntax {
+        TokenIndex open;        // the `[` token
+        NodeSpan elements;      // list of child expressions
+        TokenIndex close;       // the `]` token
+    };
+
+    // -- Comma-separated tuple: `a, b, c`.
+    struct TupleSyntax {
+        NodeSpan elements;      // tuple component expressions
+    };
+
+    // -- Semicolon-separated sequence: `a; b; c`.
+    struct SequenceSyntax {
+        NodeSpan statements;    // ordered statements
+    };
+
+    // -- Indentation-delimited pile of expressions.
+    struct PileSyntax {
+        NodeSpan items;         // pile-separated items
+    };
+
+    // ------- Types -------
+
+    // -- Function type: `(S1, S2) -> T` or `S -> T`.
+    struct MappingSyntax {
+        NodeSpan sources;       // source type(s)
+        TokenIndex arrow;       // the `->` token
+        NodeIndex target;       // return type
+    };
+
+    // -- Universally quantified type: `forall a . T`.
+    struct ForallSyntax {
+        TokenIndex keyword;     // the `forall` token
+        NodeSpan variables;     // quantified type variables
+        TokenIndex dot;         // the `.` separator
+        NodeIndex body;         // body type expression
+    };
+
+    // ------- Control flow -------
+
+    // -- Conditional: `if cond then consequent else alternate`.
+    struct IfExprSyntax {
+        TokenIndex keyword;     // the `if` token
+        NodeIndex condition;    // condition expression
+        NodeIndex consequent;   // then-branch
+        NodeIndex alternate;    // else-branch (NodeIndex::none if absent)
+    };
+
+    // -- Return from a function: `return expr`.
+    struct ReturnSyntax {
+        TokenIndex keyword;     // the `return` token
+        NodeIndex value;        // returned expression
+    };
+
+    // -- Leave from a loop: `leave expr`.
+    struct LeaveSyntax {
+        TokenIndex keyword;     // the `leave` token
+        NodeIndex value;        // value to leave with
+    };
+
+    // -- Guarded expression: `condition => body`.
+    struct ImpliesSyntax {
+        NodeIndex condition;    // guard expression
+        TokenIndex arrow;       // the `=>` token
+        NodeIndex body;         // consequent expression
+    };
+
+    // ------- Loops -------
+
+    // -- While-condition iterator: `while predicate`.
+    struct WhileSyntax {
+        TokenIndex keyword;     // the `while` token
+        NodeIndex condition;    // loop condition
+    };
+
+    // -- Until-condition iterator: `until predicate`.
+    struct UntilSyntax {
+        TokenIndex keyword;     // the `until` token
+        NodeIndex condition;    // termination condition
+    };
+
+    // -- For-in iterator: `for var in sequence [by step]`.
+    struct ForInSyntax {
+        TokenIndex keyword;     // the `for` token
+        NodeIndex variable;     // iteration variable
+        NodeIndex sequence;     // iterated collection or segment
+        NodeIndex step;         // step expression (NodeIndex::none if absent)
+    };
+
+    // -- Filter (such-that) iterator: `| predicate`.
+    struct SuchThatSyntax {
+        TokenIndex bar;         // the `|` token
+        NodeIndex predicate;    // filter expression
+    };
+
+    // -- Composed list of iterators.
+    struct IteratorsSyntax {
+        NodeSpan clauses;       // individual iterator nodes
+    };
+
+    // -- Cross-product iterators: `iters1 cross iters2`.
+    struct CrossSyntax {
+        NodeSpan factors;       // iterator groups to cross
+    };
+
+    // -- Repeat loop: `iterators repeat body`.
+    struct RepeatSyntax {
+        NodeIndex iterators;    // iterator composition
+        TokenIndex keyword;     // the `repeat` token
+        NodeIndex body;         // loop body expression
+    };
+
+    // ------- Pattern matching -------
+
+    // -- Pattern test: `expr is pattern`.
+    struct IsSyntax {
+        NodeIndex expr;         // expression to test
+        TokenIndex keyword;     // the `is` token
+        NodeIndex pattern;      // pattern to match
+    };
+
+    // -- Negative pattern test: `expr isnt pattern`.
+    struct IsntSyntax {
+        NodeIndex expr;         // expression to test
+        TokenIndex keyword;     // the `isnt` token
+        NodeIndex pattern;      // pattern to match
+    };
+
+    // -- Equality pattern in pattern context: `=expr`.
+    struct EqualPatternSyntax {
+        TokenIndex eq;          // the `=` token
+        NodeIndex expr;         // expression to compare against
+    };
+
+    // -- Colon-append in patterns or brackets: `[:rest]`.
+    struct ColonAppendSyntax {
+        NodeSpan head;          // leading elements before the colon
+        TokenIndex colon;       // the `:` token
+        NodeIndex rest;         // tail expression
+    };
+
+    // ------- Assignment & binding -------
+
+    // -- Assignment: `target := value`.
+    struct AssignmentSyntax {
+        NodeIndex target;       // left-hand side
+        TokenIndex colon_eq;    // the `:=` token
+        NodeIndex value;        // right-hand side expression
+    };
+
+    // -- Lambda expression: `params +-> body`.
+    struct LambdaSyntax {
+        NodeSpan parameters;    // formal parameter(s)
+        TokenIndex arrow;       // the `+->` token
+        NodeIndex body;         // body expression
+    };
+
+    // -- Default parameter value: `name := default`.
+    struct DefaultValueSyntax {
+        NodeIndex name;         // parameter name
+        TokenIndex definer;     // the `==` token
+        NodeIndex value;        // default expression
+    };
+
+    // -- Keyword argument: `key <- value`.
+    struct KeyArgSyntax {
+        NodeIndex key;          // keyword name
+        TokenIndex arrow;       // the `<-` token
+        NodeIndex value;        // argument value
+    };
+
+    // ------- Segments -------
+
+    // -- Bounded segment: `lo .. hi`.
+    struct BoundedSegmentSyntax {
+        NodeIndex lo;           // lower bound
+        TokenIndex dots;        // the `..` token
+        NodeIndex hi;           // upper bound
+    };
+
+    // -- Unbounded segment: `lo ..`
+    struct UnboundedSegmentSyntax {
+        NodeIndex lo;           // lower bound
+        TokenIndex dots;        // the `..` token
+    };
+
+    // ------- Reduce -------
+
+    // -- Reduction: `op / collection`.
+    struct ReduceSyntax {
+        NodeIndex op;           // reducing operator
+        TokenIndex slash;       // the `/` token
+        NodeIndex body;         // collection or construct being reduced
+    };
+
+    // ------- Structural -------
+
+    // -- Structure declaration: `structure Name == variants`.
+    struct StructureSyntax {
+        TokenIndex keyword;     // the `structure` token
+        NodeIndex name;         // type name with optional params
+        TokenIndex definer;     // the `==` token
+        NodeSpan variants;      // variant or record definitions
+    };
+
+    // -- Record definition: `Record(fields) with accessors`.
+    struct RecordSyntax {
+        TokenIndex keyword;     // the `Record` token (or name token)
+        NodeSpan fields;        // field signature list
+        NodeSpan accessors;     // accessor definitions
+    };
+
+    // -- Accessor definition: `name == (.field)`.
+    struct AccessorDefSyntax {
+        NodeIndex name;         // accessor name
+        TokenIndex definer;     // the `==` token
+        NodeIndex selector;     // field selection expression
+    };
+
+    // -- Case expression: `case expr of branches`.
+    struct CaseSyntax {
+        TokenIndex keyword;     // the `case` token
+        NodeIndex expr;         // discriminated expression
+        NodeSpan branches;      // case branches (Implies nodes)
+    };
+
+    // ------- Exception handling -------
+
+    // -- Throw expression: `throw expr`.
+    struct ThrowSyntax {
+        TokenIndex keyword;     // the `throw` token
+        NodeIndex expr;         // exception expression
+    };
+
+    // -- Catch clause: `catch(sig) => body`.
+    struct CatchSyntax {
+        TokenIndex keyword;     // the `catch` token
+        NodeIndex signature;    // exception variable signature
+        NodeIndex body;         // handler body expression
+    };
+
+    // -- Finally clause: `finally expr`.
+    struct FinallySyntax {
+        TokenIndex keyword;     // the `finally` token
+        NodeIndex body;         // cleanup expression
+    };
+
+    // -- Try expression: `try body catch ... finally ...`.
+    struct TrySyntax {
+        TokenIndex keyword;     // the `try` token
+        NodeIndex body;         // guarded expression
+        NodeSpan handlers;      // catch and finally clauses
+    };
+
+    // ------- Scoping -------
+
+    // -- Where clause: `body where definitions`.
+    struct WhereSyntax {
+        NodeIndex body;         // main expression
+        TokenIndex keyword;     // the `where` token
+        NodeSpan definitions;   // local definitions
+    };
+
+    // -- Dynamic (local) declaration: `local x`.
+    struct DynamicSyntax {
+        NodeIndex expr;         // locally-bound expression
+    };
+
+    // ------- Spad type system -------
+
+    // -- Category definition: `with { sig; sig; ... }`
+    // or infix: `T with { ... }`.
+    struct WithSyntax {
+        TokenIndex keyword;     // the 'with' token
+        NodeIndex body;         // pile/sequence of signatures
+    };
+
+    // -- Domain implementation: `T add { defs }`.
+    struct AddSyntax {
+        TokenIndex keyword;     // the 'add' token
+        NodeIndex body;         // capsule body
+    };
+
+    // -- Scoped definition block inside `add`.
+    struct CapsuleSyntax {
+        NodeSpan items;         // definition list
+    };
+
+    // -- Unsafe type assertion: `x pretend T`.
+    struct PretendSyntax {
+        NodeIndex expr;         // expression
+        TokenIndex keyword;     // the 'pretend' token
+        NodeIndex type;         // target type
+    };
+
+    // -- Category membership test: `D has Cat`.
+    struct HasSyntax {
+        NodeIndex expr;         // domain expression
+        TokenIndex keyword;     // the 'has' token
+        NodeIndex type;         // category/capability
+    };
+
+    // -- List comprehension: `[body for x in ...]`.
+    struct CollectSyntax {
+        NodeIndex body;         // element expression
+        NodeIndex iterators;    // iterator tree
+    };
+
+    // -- Category join: `Join(Cat1, Cat2, ...)`.
+    struct JoinSyntax {
+        TokenIndex keyword;     // the 'Join' identifier
+        NodeSpan arguments;     // joined categories
+    };
+
+    // ------- Spad declarations -------
+
+    // -- Free variable declaration: `free x`.
+    struct FreeDeclSyntax {
+        TokenIndex keyword;     // the 'free' token
+        NodeIndex expr;         // variable(s)
+    };
+
+    // -- Explicit export: `export sig`.
+    struct ExportDeclSyntax {
+        TokenIndex keyword;     // the 'export' token
+        NodeIndex signature;    // what is exported
+    };
+
+    // ------- Embedded Lisp -------
+
+    // -- Lisp escape: `)lisp code`.
+    struct LispExprSyntax {
+        TokenIndex token;       // the Lisp expression token
+    };
+
+    // ------- Fallback -------
+
+    // -- Unparsed token range, used as fallback for unrecognized input.
+    struct UnparsedSyntax {
+        TokenIndex first;       // first token in the range
+        TokenIndex last;        // last token in the range
+    };
+
+    // -- SyntaxForest: arena holding all syntax nodes
+    // All nodes are owned by a single SyntaxForest.  Nodes are
+    // allocated into per-kind vectors and referenced through
+    // NodeIndex handles.  Variable-length child lists share a
+    // single flat NodeIndex vector; each list is described by
+    // a NodeSpan (offset + count) into that vector.
+    struct SyntaxForest {
+        // -- Child list storage --
+
+        // -- Allocate a contiguous span of `count` child slots and
+        // return a NodeSpan referencing them.
+        NodeSpan allocate_span(std::uint32_t count);
+
+        // -- Access the i-th child within a span.
+        NodeIndex& child(NodeSpan span, std::uint32_t i);
+        const NodeIndex& child(NodeSpan span, std::uint32_t i) const;
+
+        // -- Node allocation --
+        // Each function allocates a node of the given kind in the
+        // corresponding vector and returns its NodeIndex handle.
+
+        NodeIndex make_literal(const LiteralSyntax&);
+        NodeIndex make_name(const NameSyntax&);
+        NodeIndex make_qualified_name(const QualifiedNameSyntax&);
+        NodeIndex make_module(const ModuleSyntax&);
+        NodeIndex make_namespace(const NamespaceSyntax&);
+        NodeIndex make_import(const ImportSyntax&);
+        NodeIndex make_import_signature(const ImportSignatureSyntax&);
+        NodeIndex make_constant_def(const ConstantDefSyntax&);
+        NodeIndex make_function_def(const FunctionDefSyntax&);
+        NodeIndex make_macro_def(const MacroDefSyntax&);
+        NodeIndex make_type_alias(const TypeAliasSyntax&);
+        NodeIndex make_signature(const SignatureSyntax&);
+        NodeIndex make_apply(const ApplySyntax&);
+        NodeIndex make_infix(const InfixExprSyntax&);
+        NodeIndex make_prefix(const PrefixExprSyntax&);
+        NodeIndex make_suffix_dot(const SuffixDotSyntax&);
+        NodeIndex make_restrict(const RestrictSyntax&);
+        NodeIndex make_coerce(const CoerceSyntax&);
+        NodeIndex make_quote(const QuoteSyntax&);
+        NodeIndex make_bracket(const BracketSyntax&);
+        NodeIndex make_tuple(const TupleSyntax&);
+        NodeIndex make_sequence(const SequenceSyntax&);
+        NodeIndex make_pile(const PileSyntax&);
+        NodeIndex make_mapping(const MappingSyntax&);
+        NodeIndex make_forall(const ForallSyntax&);
+        NodeIndex make_if(const IfExprSyntax&);
+        NodeIndex make_return(const ReturnSyntax&);
+        NodeIndex make_leave(const LeaveSyntax&);
+        NodeIndex make_implies(const ImpliesSyntax&);
+        NodeIndex make_while(const WhileSyntax&);
+        NodeIndex make_until(const UntilSyntax&);
+        NodeIndex make_for_in(const ForInSyntax&);
+        NodeIndex make_such_that(const SuchThatSyntax&);
+        NodeIndex make_iterators(const IteratorsSyntax&);
+        NodeIndex make_cross(const CrossSyntax&);
+        NodeIndex make_repeat(const RepeatSyntax&);
+        NodeIndex make_is(const IsSyntax&);
+        NodeIndex make_isnt(const IsntSyntax&);
+        NodeIndex make_equal_pattern(const EqualPatternSyntax&);
+        NodeIndex make_colon_append(const ColonAppendSyntax&);
+        NodeIndex make_assignment(const AssignmentSyntax&);
+        NodeIndex make_lambda(const LambdaSyntax&);
+        NodeIndex make_default_value(const DefaultValueSyntax&);
+        NodeIndex make_key_arg(const KeyArgSyntax&);
+        NodeIndex make_bounded_segment(const BoundedSegmentSyntax&);
+        NodeIndex make_unbounded_segment(const UnboundedSegmentSyntax&);
+        NodeIndex make_reduce(const ReduceSyntax&);
+        NodeIndex make_structure(const StructureSyntax&);
+        NodeIndex make_record(const RecordSyntax&);
+        NodeIndex make_accessor_def(const AccessorDefSyntax&);
+        NodeIndex make_case(const CaseSyntax&);
+        NodeIndex make_throw(const ThrowSyntax&);
+        NodeIndex make_catch(const CatchSyntax&);
+        NodeIndex make_finally(const FinallySyntax&);
+        NodeIndex make_try(const TrySyntax&);
+        NodeIndex make_where(const WhereSyntax&);
+        NodeIndex make_dynamic(const DynamicSyntax&);
+        NodeIndex make_with(const WithSyntax&);
+        NodeIndex make_add(const AddSyntax&);
+        NodeIndex make_capsule(const CapsuleSyntax&);
+        NodeIndex make_pretend(const PretendSyntax&);
+        NodeIndex make_has(const HasSyntax&);
+        NodeIndex make_collect(const CollectSyntax&);
+        NodeIndex make_join(const JoinSyntax&);
+        NodeIndex make_free_decl(const FreeDeclSyntax&);
+        NodeIndex make_export_decl(const ExportDeclSyntax&);
+        NodeIndex make_lisp_expr(const LispExprSyntax&);
+        NodeIndex make_unparsed(const UnparsedSyntax&);
+
+        // -- Node access by index --
+        // Each function retrieves a previously allocated node by
+        // its position within the per-kind storage vector.
+
+        const LiteralSyntax& literal(std::uint32_t i) const { return literals[i]; }
+        const NameSyntax& name(std::uint32_t i) const { return names[i]; }
+        const QualifiedNameSyntax& qualified_name(std::uint32_t i) const { return qualified_names[i]; }
+        const ModuleSyntax& module(std::uint32_t i) const { return modules[i]; }
+        const NamespaceSyntax& namespace_node(std::uint32_t i) const { return namespaces[i]; }
+        const ImportSyntax& import_node(std::uint32_t i) const { return imports[i]; }
+        const ImportSignatureSyntax& import_signature(std::uint32_t i) const { return import_signatures[i]; }
+        const ConstantDefSyntax& constant_def(std::uint32_t i) const { return constant_defs[i]; }
+        const FunctionDefSyntax& function_def(std::uint32_t i) const { return function_defs[i]; }
+        const MacroDefSyntax& macro_def(std::uint32_t i) const { return macro_defs[i]; }
+        const TypeAliasSyntax& type_alias(std::uint32_t i) const { return type_aliases[i]; }
+        const SignatureSyntax& signature(std::uint32_t i) const { return signatures[i]; }
+        const ApplySyntax& apply(std::uint32_t i) const { return applications[i]; }
+        const InfixExprSyntax& infix_expr(std::uint32_t i) const { return infix_exprs[i]; }
+        const PrefixExprSyntax& prefix_expr(std::uint32_t i) const { return prefix_exprs[i]; }
+        const SuffixDotSyntax& suffix_dot(std::uint32_t i) const { return suffix_dots[i]; }
+        const RestrictSyntax& restrict_node(std::uint32_t i) const { return restricts[i]; }
+        const CoerceSyntax& coerce(std::uint32_t i) const { return coercions[i]; }
+        const QuoteSyntax& quote(std::uint32_t i) const { return quotes[i]; }
+        const BracketSyntax& bracket(std::uint32_t i) const { return brackets[i]; }
+        const TupleSyntax& tuple(std::uint32_t i) const { return tuples[i]; }
+        const SequenceSyntax& sequence(std::uint32_t i) const { return sequences[i]; }
+        const PileSyntax& pile(std::uint32_t i) const { return piles[i]; }
+        const MappingSyntax& mapping(std::uint32_t i) const { return mappings[i]; }
+        const ForallSyntax& forall(std::uint32_t i) const { return foralls[i]; }
+        const IfExprSyntax& if_expr(std::uint32_t i) const { return if_exprs[i]; }
+        const ReturnSyntax& return_node(std::uint32_t i) const { return returns[i]; }
+        const LeaveSyntax& leave(std::uint32_t i) const { return leaves[i]; }
+        const ImpliesSyntax& implies(std::uint32_t i) const { return implications[i]; }
+        const WhileSyntax& while_node(std::uint32_t i) const { return whiles[i]; }
+        const UntilSyntax& until_node(std::uint32_t i) const { return untils[i]; }
+        const ForInSyntax& for_in(std::uint32_t i) const { return for_ins[i]; }
+        const SuchThatSyntax& such_that(std::uint32_t i) const { return such_thats[i]; }
+        const IteratorsSyntax& iterators(std::uint32_t i) const { return iterators_list[i]; }
+        const CrossSyntax& cross(std::uint32_t i) const { return crosses[i]; }
+        const RepeatSyntax& repeat(std::uint32_t i) const { return repeats[i]; }
+        const IsSyntax& is_test(std::uint32_t i) const { return is_tests[i]; }
+        const IsntSyntax& isnt_test(std::uint32_t i) const { return isnt_tests[i]; }
+        const EqualPatternSyntax& equal_pattern(std::uint32_t i) const { return equal_patterns[i]; }
+        const ColonAppendSyntax& colon_append(std::uint32_t i) const { return colon_appends[i]; }
+        const AssignmentSyntax& assignment(std::uint32_t i) const { return assignments[i]; }
+        const LambdaSyntax& lambda(std::uint32_t i) const { return lambdas[i]; }
+        const DefaultValueSyntax& default_value(std::uint32_t i) const { return default_values[i]; }
+        const KeyArgSyntax& key_arg(std::uint32_t i) const { return key_args[i]; }
+        const BoundedSegmentSyntax& bounded_segment(std::uint32_t i) const { return bounded_segments[i]; }
+        const UnboundedSegmentSyntax& unbounded_segment(std::uint32_t i) const { return unbounded_segments[i]; }
+        const ReduceSyntax& reduce(std::uint32_t i) const { return reduces[i]; }
+        const StructureSyntax& structure(std::uint32_t i) const { return structures[i]; }
+        const RecordSyntax& record(std::uint32_t i) const { return records[i]; }
+        const AccessorDefSyntax& accessor_def(std::uint32_t i) const { return accessor_defs[i]; }
+        const CaseSyntax& case_node(std::uint32_t i) const { return cases[i]; }
+        const ThrowSyntax& throw_node(std::uint32_t i) const { return throws[i]; }
+        const CatchSyntax& catch_node(std::uint32_t i) const { return catches[i]; }
+        const FinallySyntax& finally_node(std::uint32_t i) const { return finallys[i]; }
+        const TrySyntax& try_node(std::uint32_t i) const { return trys[i]; }
+        const WhereSyntax& where(std::uint32_t i) const { return wheres[i]; }
+        const DynamicSyntax& dynamic(std::uint32_t i) const { return dynamics[i]; }
+        const WithSyntax& with_node(std::uint32_t i) const { return withs[i]; }
+        const AddSyntax& add_node(std::uint32_t i) const { return adds[i]; }
+        const CapsuleSyntax& capsule(std::uint32_t i) const { return capsules[i]; }
+        const PretendSyntax& pretend_node(std::uint32_t i) const { return pretends[i]; }
+        const HasSyntax& has_node(std::uint32_t i) const { return has_tests[i]; }
+        const CollectSyntax& collect(std::uint32_t i) const { return collects[i]; }
+        const JoinSyntax& join_node(std::uint32_t i) const { return joins[i]; }
+        const FreeDeclSyntax& free_decl(std::uint32_t i) const { return free_decls[i]; }
+        const ExportDeclSyntax& export_decl(std::uint32_t i) const { return export_decls[i]; }
+        const LispExprSyntax& lisp_expr(std::uint32_t i) const { return lisp_exprs[i]; }
+        const UnparsedSyntax& unparsed_node(std::uint32_t i) const { return unparsed[i]; }
+
+    private:
+        // -- Shared flat array for variable-length child lists.
+        std::vector<NodeIndex> children;
+
+        // -- Per-kind storage arrays.
+        std::vector<LiteralSyntax> literals;
+        std::vector<NameSyntax> names;
+        std::vector<QualifiedNameSyntax> qualified_names;
+        std::vector<ModuleSyntax> modules;
+        std::vector<NamespaceSyntax> namespaces;
+        std::vector<ImportSyntax> imports;
+        std::vector<ImportSignatureSyntax> import_signatures;
+        std::vector<ConstantDefSyntax> constant_defs;
+        std::vector<FunctionDefSyntax> function_defs;
+        std::vector<MacroDefSyntax> macro_defs;
+        std::vector<TypeAliasSyntax> type_aliases;
+        std::vector<SignatureSyntax> signatures;
+        std::vector<ApplySyntax> applications;
+        std::vector<InfixExprSyntax> infix_exprs;
+        std::vector<PrefixExprSyntax> prefix_exprs;
+        std::vector<SuffixDotSyntax> suffix_dots;
+        std::vector<RestrictSyntax> restricts;
+        std::vector<CoerceSyntax> coercions;
+        std::vector<QuoteSyntax> quotes;
+        std::vector<BracketSyntax> brackets;
+        std::vector<TupleSyntax> tuples;
+        std::vector<SequenceSyntax> sequences;
+        std::vector<PileSyntax> piles;
+        std::vector<MappingSyntax> mappings;
+        std::vector<ForallSyntax> foralls;
+        std::vector<IfExprSyntax> if_exprs;
+        std::vector<ReturnSyntax> returns;
+        std::vector<LeaveSyntax> leaves;
+        std::vector<ImpliesSyntax> implications;
+        std::vector<WhileSyntax> whiles;
+        std::vector<UntilSyntax> untils;
+        std::vector<ForInSyntax> for_ins;
+        std::vector<SuchThatSyntax> such_thats;
+        std::vector<IteratorsSyntax> iterators_list;
+        std::vector<CrossSyntax> crosses;
+        std::vector<RepeatSyntax> repeats;
+        std::vector<IsSyntax> is_tests;
+        std::vector<IsntSyntax> isnt_tests;
+        std::vector<EqualPatternSyntax> equal_patterns;
+        std::vector<ColonAppendSyntax> colon_appends;
+        std::vector<AssignmentSyntax> assignments;
+        std::vector<LambdaSyntax> lambdas;
+        std::vector<DefaultValueSyntax> default_values;
+        std::vector<KeyArgSyntax> key_args;
+        std::vector<BoundedSegmentSyntax> bounded_segments;
+        std::vector<UnboundedSegmentSyntax> unbounded_segments;
+        std::vector<ReduceSyntax> reduces;
+        std::vector<StructureSyntax> structures;
+        std::vector<RecordSyntax> records;
+        std::vector<AccessorDefSyntax> accessor_defs;
+        std::vector<CaseSyntax> cases;
+        std::vector<ThrowSyntax> throws;
+        std::vector<CatchSyntax> catches;
+        std::vector<FinallySyntax> finallys;
+        std::vector<TrySyntax> trys;
+        std::vector<WhereSyntax> wheres;
+        std::vector<DynamicSyntax> dynamics;
+        std::vector<WithSyntax> withs;
+        std::vector<AddSyntax> adds;
+        std::vector<CapsuleSyntax> capsules;
+        std::vector<PretendSyntax> pretends;
+        std::vector<HasSyntax> has_tests;
+        std::vector<CollectSyntax> collects;
+        std::vector<JoinSyntax> joins;
+        std::vector<FreeDeclSyntax> free_decls;
+        std::vector<ExportDeclSyntax> export_decls;
+        std::vector<LispExprSyntax> lisp_exprs;
+        std::vector<UnparsedSyntax> unparsed;
+    };
+
+    // -- Node field descriptors for generic traversal
+
+    // -- Discriminator for field values within a node descriptor.
+    enum class FieldRole : std::uint8_t {
+        Child,          // a child subtree (NodeIndex)
+        Span,           // an inline child list (NodeSpan)
+        WrappedSpan,    // a parenthesized child list (NodeSpan)
+        Token,          // a token, printed with identifier quoting
+        Literal,        // a token, printed verbatim
+    };
+
+    // -- A single field within a node descriptor.
+    struct NodeField {
+        FieldRole role;
+        union {
+            NodeIndex child;
+            NodeSpan span;
+            TokenIndex token;
+        };
+    };
+
+    // -- Compact description of a node's shape and field values.
+    struct NodeDescriptor {
+        const char* tag;            // S-expression tag (nullptr for leaves)
+        std::uint8_t count;         // number of fields
+        NodeField fields[4];        // ordered field values
+    };
+
+    // -- Helpers for constructing NodeField values.
+    inline NodeField child_field(NodeIndex n)
+    {
+        NodeField f { };
+        f.role = FieldRole::Child;
+        f.child = n;
+        return f;
+    }
+
+    inline NodeField span_field(NodeSpan s)
+    {
+        NodeField f { };
+        f.role = FieldRole::Span;
+        f.span = s;
+        return f;
+    }
+
+    inline NodeField wrapped_span_field(NodeSpan s)
+    {
+        NodeField f { };
+        f.role = FieldRole::WrappedSpan;
+        f.span = s;
+        return f;
+    }
+
+    inline NodeField token_field(TokenIndex t)
+    {
+        NodeField f { };
+        f.role = FieldRole::Token;
+        f.token = t;
+        return f;
+    }
+
+    inline NodeField literal_field(TokenIndex t)
+    {
+        NodeField f { };
+        f.role = FieldRole::Literal;
+        f.token = t;
+        return f;
+    }
+
+    // -- Return the S-expression tag name for a given Kind.
+    //    Returns nullptr for leaf nodes (Literal, Name).
+    const char* tag_name(Kind);
+
+    // -- Describe a node's shape and extract its field values.
+    NodeDescriptor describe_node(NodeIndex node,
+                                 const SyntaxForest& forest);
 }
 
 #endif  // OPENAXIOM_SYNTAX_TREE_included

--- a/src/include/open-axiom/defaults
+++ b/src/include/open-axiom/defaults
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -43,13 +43,13 @@ namespace OpenAxiom {
    // -- known as `based class parameterized by derived classes', or
    // -- `curiously recurring pattern'.
    namespace defaults {
-      // generate definition for != assuming existence of ==.
+      // -- generate definition for != assuming existence of ==.
       template<typename t>
       struct neq {
          friend bool operator!=(t x, t y) { return not(x == y); }
       };
 
-      // generate definitions for ordering functions assuming <.
+      // -- generate definitions for ordering functions assuming <.
       template<typename t>
       struct ordering {
          friend bool operator<=(t x, t y) { return not(y < x); }

--- a/src/include/open-axiom/diagnostics
+++ b/src/include/open-axiom/diagnostics
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/dialect
+++ b/src/include/open-axiom/dialect
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013-2017, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -37,7 +37,7 @@
 #include <stdint.h>
 
 namespace OpenAxiom {
-   // Languages for which we have parsers.
+   // -- Languages for which we have parsers.
    enum class Language : uint8_t {
       Spad = 0x1,               // Spad programming language
       Boot = 0x2,               // Boot programming language

--- a/src/include/open-axiom/hash-table
+++ b/src/include/open-axiom/hash-table
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2010, Gabriel Dos Reis.
 // All rights reserved.
 //
@@ -41,9 +41,7 @@
 #include <open-axiom/storage>
 
 namespace OpenAxiom {
-   // --------------------
    // -- HashTableEntry --
-   // --------------------
    // Datatype for entries in a parameterized hash table.
    // The type parameter is required to be a value-construcitble datatype.
    // A table bucket entry is required to be at least 8-byte aligned
@@ -55,9 +53,7 @@ namespace OpenAxiom {
       size_t hash;             // hash code of stored data
    };
 
-   // --------------------
    // -- BasicHashTable --
-   // --------------------
    // A simple hash table data structure.  Ideally, we would like to use
    // standard C++ types, but hash tables were only in a C++ 2003 TR,
    // officially part of C++0x standard library.  We still don't have

--- a/src/include/open-axiom/iterator
+++ b/src/include/open-axiom/iterator
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.

--- a/src/include/open-axiom/sexpr
+++ b/src/include/open-axiom/sexpr
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2010-2017, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -50,9 +50,7 @@
 
 namespace OpenAxiom {
    namespace Sexpr {
-      // ------------
       // -- Lexeme --
-      // ------------
       struct Lexeme {
          enum Type {
             unknown,                 // unidentified token
@@ -79,25 +77,21 @@ namespace OpenAxiom {
             sharp_integer_sharp      // back reference, #n#
          };
 
-         std::pair<const Byte*, const Byte*> boundary;
+         std::pair<const char8_t*, const char8_t*> boundary;
          Ordinal line;
-         const Byte* begin() const { return boundary.first; }
-         const Byte* end() const { return boundary.second; }
+         const char8_t* begin() const { return boundary.first; }
+         const char8_t* end() const { return boundary.second; }
          Ordinal size() const { return end() - begin(); }
       };
 
-      // ------------
       // -- Syntax --
-      // ------------
       // Base class of syntax object classes.
       struct Syntax {
          struct Visitor;        // base class of syntax visitors
          virtual void accept(Visitor&) const = 0;
       };
 
-      // ----------------
       // -- AtomSyntax --
-      // ----------------
       // An atom is a syntax object consisting of exatly one token.
       // This should not be confused with the notion of atom
       // in Lisp languages. 
@@ -108,36 +102,28 @@ namespace OpenAxiom {
          explicit AtomSyntax(const Lexeme&);
       };
 
-      // -------------------
       // -- IntegerSyntax --
-      // -------------------
       // Integer literal syntax objects
       struct IntegerSyntax : AtomSyntax {
          explicit IntegerSyntax(const Lexeme&);
          void accept(Visitor&) const;
       };
 
-      // ---------------------
       // -- CharacterSyntax --
-      // ---------------------
       // Character literal syntax objects.
       struct CharacterSyntax : AtomSyntax {
          explicit CharacterSyntax(const Lexeme&);
          void accept(Visitor&) const;
       };
 
-      // ------------------
       // -- StringSyntax --
-      // ------------------
       // Striing literal syntax objjects.
       struct StringSyntax : AtomSyntax {
          explicit StringSyntax(const Lexeme&);
          void accept(Visitor&) const;
       };
 
-      // ------------------
       // -- SymbolSyntax --
-      // ------------------
       struct SymbolSyntax : AtomSyntax {
          enum Kind {
             ordinary   = 0x0,   // an interned symbol
@@ -147,18 +133,16 @@ namespace OpenAxiom {
          };
          SymbolSyntax(const Lexeme&, Kind);
          Kind kind() const { return sort; }
-         const Byte* begin() const { return lexeme().begin(); }
-         const Byte* end() const { return lexeme().end(); }
+         const char8_t* begin() const { return lexeme().begin(); }
+         const char8_t* end() const { return lexeme().end(); }
          std::size_t size() const { return lexeme().size(); }
-         Byte operator[](std::size_t i) const { return begin()[i]; }
+         char8_t operator[](std::size_t i) const { return begin()[i]; }
          void accept(Visitor&) const;
       private:
          const Kind sort;
       };
 
-      // ---------------------
       // -- ReferenceSyntax --
-      // ---------------------
       // Back reference object to a syntax object.
       struct ReferenceSyntax : AtomSyntax {
          ReferenceSyntax(const Lexeme&, Ordinal);
@@ -168,9 +152,7 @@ namespace OpenAxiom {
          Ordinal pos;
       };
 
-      // ------------------
       // -- AnchorSyntax --
-      // ------------------
       // Base anchor syntax object.
       struct AnchorSyntax : Syntax {
          AnchorSyntax(size_t, const Syntax*);
@@ -204,73 +186,55 @@ namespace OpenAxiom {
          std::pair<const Syntax*, const Syntax*> rep;
       };
 
-      // -----------------
       // -- QuoteSyntax --
-      // -----------------
       // Quotation syntax object.
       struct QuoteSyntax : unary_form<QuoteSyntax> {
          explicit QuoteSyntax(const Syntax*);
       };
       
-      // ---------------------
       // -- AntiquoteSyntax --
-      // ---------------------
       // Quasi-quotation syntax object.
       struct AntiquoteSyntax : unary_form<AntiquoteSyntax> {
          explicit AntiquoteSyntax(const Syntax*);
       };
       
-      // ------------
       // -- Expand --
-      // ------------
       // Expansion request inside a quasi-quotation.
       struct Expand : unary_form<Expand> {
          explicit Expand(const Syntax*);
       };
       
-      // ----------
       // -- Eval --
-      // ----------
       // Read-time evaluation request syntax object.
       struct Eval : unary_form<Eval> {
          explicit Eval(const Syntax*);
       };
       
-      // ------------
       // -- Splice --
-      // ------------
       // Splice request syntax object inside a quasi-quotation.
       struct Splice : unary_form<Splice> {
          explicit Splice(const Syntax*);
       };
       
-      // --------------
       // -- Function --
-      // --------------
       // Function literal syntax object.
       struct Function : unary_form<Function> {
          explicit Function(const Syntax*);
       };
 
-      // -------------
       // -- Include --
-      // -------------
       // Conditional inclusion syntax object
       struct Include : binary_form<Include> {
          Include(const Syntax*, const Syntax*);
       };
 
-      // -------------
       // -- Exclude --
-      // -------------
       // Conditional exclusion syntax object
       struct Exclude : binary_form<Exclude> {
          Exclude(const Syntax*, const Syntax*);
       };
 
-      // ----------------
       // -- ListSyntax --
-      // ----------------
       // List syntax objects.
       struct ListSyntax : Syntax, private std::vector<const Syntax*> {
          typedef std::vector<const Syntax*> base;
@@ -292,9 +256,7 @@ namespace OpenAxiom {
          bool dot;
       };
       
-      // ------------------
       // -- VectorSyntax --
-      // ------------------
       // VectorSyntax syntax objects.
       struct VectorSyntax : Syntax, private std::vector<const Syntax*> {
          typedef std::vector<const Syntax*> base;
@@ -311,9 +273,7 @@ namespace OpenAxiom {
          void accept(Visitor&) const;
       };
 
-      // ---------------------
       // -- Syntax::Visitor --
-      // ---------------------
       struct Syntax::Visitor {
          virtual void visit(const IntegerSyntax&) = 0;
          virtual void visit(const CharacterSyntax&) = 0;
@@ -345,9 +305,7 @@ namespace OpenAxiom {
          v.visit(static_cast<const T&>(*this));
       }
 
-      // ---------------
       // -- Allocator --
-      // ---------------
       // Allocator of syntax objects.
       struct Allocator {
          Allocator();
@@ -393,22 +351,22 @@ namespace OpenAxiom {
 
       // -- Reader --
       struct RawInput {
-         const Byte* start;
-         const Byte* end;
+         const char8_t* start;
+         const char8_t* end;
          Ordinal lineno;
       };
 
       struct Reader {
          struct State {
             RawInput bytes;
-            const Byte* cur;
-            const Byte* line;
+            const char8_t* cur;
+            const char8_t* line;
             Allocator alloc;
          };
 
          explicit Reader(const RawInput&);
-         Reader(const Byte*, const Byte*);
-         const Byte* position(Ordinal);
+         Reader(const char8_t*, const char8_t*);
+         const char8_t* position(Ordinal);
          bool at_start() const { return st.cur == st.bytes.start; }
          const Syntax* read();
       private:

--- a/src/include/open-axiom/storage
+++ b/src/include/open-axiom/storage
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2010-2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -47,138 +47,126 @@
 #include <string>
 
 namespace OpenAxiom {
-   // Datatype for the unit of storage.
+   // -- Datatype for the unit of storage.
    using Byte = unsigned char;
 
-   // -----------------
    // -- SystemError --
-   // -----------------
    // Objects of (type derived from) this type are used to report
    // error orignating from the OpenAxiom core system.
    struct SystemError {
       explicit SystemError(const std::string&);
       virtual ~SystemError();
-      // Return the text of the diagnostic message.
+      // -- Return the text of the diagnostic message.
       virtual const std::string& message() const;
    protected:
       const std::string text;
    };
 
-   // Report a file system error
+   // -- Report a file system error
    void filesystem_error(const std::string&);
    
    namespace Memory {
-      // Datatype for pointers to data.
+      // -- Datatype for pointers to data.
       using Pointer = void*;
 
-      // Precision of the host OS storage page unit in byte count
+      // -- Precision of the host OS storage page unit in byte count
       size_t page_size();
 
-      // Acquire raw memory from the host OS.
+      // -- Acquire raw memory from the host OS.
       Pointer os_acquire_raw_memory(size_t);
 
-      // Release raw storage to the hosting OS.  The first operand must
+      // -- Release raw storage to the hosting OS.  The first operand must
       // be a pointer value previously returned by `os_acquire_raw_memory'.
       // Otherwise, the result is undefined.
       void os_release_raw_memory(Pointer, size_t);
 
-      // Acquire `n' pages of memory storage from the host OS.
+      // -- Acquire `n' pages of memory storage from the host OS.
       inline Pointer
       acquire_raw_pages(size_t n) {
          return os_acquire_raw_memory(n * page_size());
       }
 
-      // Release `n' pages of storage starting the location `p'.
+      // -- Release `n' pages of storage starting the location `p'.
       inline void
       release_raw_pages(Pointer p, size_t n) {
          os_release_raw_memory(p, n * page_size());
       }
       
-      // -------------
       // -- Storage --
-      // -------------
       // This class provides low-level abstractions intented for use
       // to implement higher level storage abstractions.
       struct Storage {
-         // Objects of this abstract datatype hold storage objects.
+         // -- Objects of this abstract datatype hold storage objects.
          struct Handle;
          
-         // Return the storage pointed to by the operand.  It
+         // -- Return the storage pointed to by the operand.  It
          // must be a pointer value previously returned by `acquire'.
          // Otherwise, the result is undefined.
          static void release(Handle*);
          
-         // Return the start address of storage area.  Clients would
+         // -- Return the start address of storage area.  Clients would
          // want to add padding bytes necessary to accomodate alignment
          // requirements.  
          // Note: this should not be confused with the address of
          // the handle object.
          static Pointer begin(Handle*);
 
-         // Courtesy conversion function from pointer to byte address.
+         // -- Courtesy conversion function from pointer to byte address.
          static Byte* byte_address(Pointer h) {
             return static_cast<Byte*>(h);
          }
 
-         // Round up `n' to a multiple of `a', a power of 2.
+         // -- Round up `n' to a multiple of `a', a power of 2.
          static size_t
          round_up(size_t n, size_t a) {
             return (n + a - 1) & ~(a - 1);
          }
       };
 
-      // -------------------------
       // -- SinglyLinkedStorage --
-      // -------------------------
       // This class implements a simple single-linked list of storage
       // objects.  Each storage object in the link is created with
       // a specific starting alignment requirements.
       struct SinglyLinkedStorage : Storage {
-         // Return the previous handle in the link chain.
+         // -- Return the previous handle in the link chain.
          static Handle*& previous(Handle*);
       };
 
-      // -------------------------
       // -- DoublyLinkedStorage --
-      // -------------------------
       // Like SinglyLinkedStorage, except that the chain of storage
       // object supports bidirectional travervsal.
       struct DoublyLinkedStorage : Storage {
-         // Same as Storage::acquire, except that begin(h) returns an
+         // -- Same as Storage::acquire, except that begin(h) returns an
          // address that satisfies the alignment requirement `a'.
          static Handle* acquire(size_t n, size_t a);
          
-         // Return the previous handle in the link chain.
+         // -- Return the previous handle in the link chain.
          static Handle*& previous(Handle*);
          
-         // Return the next handle in the link chain.
+         // -- Return the next handle in the link chain.
          static Handle*& next(Handle*);
       };
 
-      // ------------------
       // -- BlockStorage --
-      // ------------------
       // This class implements a simple single-linked list of block storage.
       // Each block maintains information about the next allocatable
       // address within that block.
       struct BlockStorage : SinglyLinkedStorage {
-         // Same as SinglyLinkedStorage::acquire(); initialize internal
+         // -- Same as SinglyLinkedStorage::acquire(); initialize internal
          // bookkeepking machinery.
          static Handle* acquire(size_t n, size_t a);
 
-         // Return the next allocatable address within the given block.
+         // -- Return the next allocatable address within the given block.
          static Pointer next_address(Handle*);
 
-         // Return the amount of allocatable byte in the given block.
+         // -- Return the amount of allocatable byte in the given block.
          static size_t room(Handle*);
 
-         // Set `n' bytes aside with the given storage block.
+         // -- Set `n' bytes aside with the given storage block.
          static Pointer book(Handle*, size_t);
       };
 
-      // -----------
       // -- Arena --
-      // -----------
       // Extensible storage holding objects of a given type.
       // The totality of all objects held in such a storage does not
       // necessarily constitute a contiguous block.  However,
@@ -186,27 +174,27 @@ namespace OpenAxiom {
       // to `allocate()' occupy a contiguous block of storage.
       template<typename T>
       struct Arena : protected BlockStorage {
-         // Acquire storage capable of holding `n' objects of type `T'.
+         // -- Acquire storage capable of holding `n' objects of type `T'.
          explicit Arena(size_t);
-         // Release all storage acquired by this object, upon end of life.
+         // -- Release all storage acquired by this object, upon end of life.
          ~Arena();
-         // allocate storage for `n' more objects of type `T'.
+         // -- allocate storage for `n' more objects of type `T'.
          T* allocate(size_t);
-         // Number of objects of type `T' allocated in this storage.
+         // -- Number of objects of type `T' allocated in this storage.
          size_t population() const;
 
       protected:
-         // Address of the first object of type `T' in a storage.
+         // -- Address of the first object of type `T' in a storage.
          static T* first_object(Handle* h) {
             return static_cast<T*>(BlockStorage::begin(h));
          }
 
-         // Address of one-past-the-end object of type `T' in this storage.
+         // -- Address of one-past-the-end object of type `T' in this storage.
          static T* last_object(Handle* h) {
             return static_cast<T*>(BlockStorage::next_address(h));
          }
 
-         // Number of objects allocated in a storage.
+         // -- Number of objects allocated in a storage.
          static size_t object_count(Handle* h) {
             return last_object(h) - first_object(h);
          }
@@ -228,7 +216,7 @@ namespace OpenAxiom {
       Arena<T>::allocate(size_t n) {
          const size_t sz = n * sizeof(T);
          if (BlockStorage::room(store) < sz) {
-            // Not enough room left.  Make sure we allocate storage
+            // -- Not enough room left.  Make sure we allocate storage
             // at least as big as the current.
             Handle* h = acquire(std::max(n, object_count(store)), alignof(T));
             previous(h) = store;
@@ -244,7 +232,7 @@ namespace OpenAxiom {
       
       template<typename T>
       Arena<T>::~Arena() {
-         // Release storage in the reverse order of their
+         // -- Release storage in the reverse order of their
          // their allocation.
          while (store != nullptr) {
             Handle* current = store;
@@ -253,9 +241,7 @@ namespace OpenAxiom {
          }
       }
 
-      // -------------
       // -- Factory --
-      // -------------
       template<typename T>
       struct Factory : Arena<T> {
          using Handler = typename Arena<T>::Handle;
@@ -263,19 +249,19 @@ namespace OpenAxiom {
          Factory() : Arena<T>(nominal_population()) { }
          ~Factory();
 
-         // Allocate storage and value-construct an object of type `T'.
+         // -- Allocate storage and value-construct an object of type `T'.
          T* make() {
             return new(this->allocate(1)) T{ };
          }
 
-         // Allocate storage and construct an object of type `T'.
+         // -- Allocate storage and construct an object of type `T'.
          template<typename... Args>
          T* make(const Args&... args) {
             return new(this->allocate(1)) T{args...};
          }
 
       private:
-         // Return 1 or the number of objects that can fit in a page unit.
+         // -- Return 1 or the number of objects that can fit in a page unit.
          static size_t nominal_population() {
             const size_t psz = page_size();
             if (sizeof (T) > psz)
@@ -284,7 +270,7 @@ namespace OpenAxiom {
          }
       };
 
-      // Destroy objects in the reverse order of their construction.
+      // -- Destroy objects in the reverse order of their construction.
       template<typename T>
       Factory<T>::~Factory() {
          for (auto s = this->store; s != nullptr; s = Arena<T>::previous(s)) {

--- a/src/include/open-axiom/string-pool
+++ b/src/include/open-axiom/string-pool
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2010-2015, Gabriel Dos Reis.
 // All rights reserved.
 //
@@ -43,25 +43,21 @@
 namespace OpenAxiom {
    struct StringPool;
 
-   // ----------------
    // -- StringItem --
-   // ----------------
    // String data allocated from a stringpool.
    struct StringItem {
-      const Byte* begin() const { return text; }
-      const Byte* end() const { return text + length; }
+      const char8_t* begin() const { return text; }
+      const char8_t* end() const { return text + length; }
       size_t size() const { return length; }
-      bool equal(const Byte*, size_t) const;
+      bool equal(const char8_t*, size_t) const;
    protected:
-      const Byte* text;         // pointer to the byte sequence
-      size_t length;            // number of bytes in this string
+      const char8_t* text;      // pointer to the character sequence
+      size_t length;            // number of characters in this string
       friend StringPool;
       StringItem() : text(), length() { }
    };
 
-   // ----------------
    // -- StringPool --
-   // ----------------
    // A string-pool object is a repository of long-living string objects.
    // It contains no duplicates, therefore allows  fast equality 
    // comparison of string objects.
@@ -69,15 +65,15 @@ namespace OpenAxiom {
       using BasicHashTable<StringItem>::EntryType;
 
       StringPool();
-      // Intern a NUL-terminated sequence of characters.
+      // -- Intern a NUL-terminated sequence of characters.
       EntryType* intern(const char*);
 
-      // Intern a sequence of characters given by its start and length.
-      EntryType* intern(const Byte*, size_t);
+      // -- Intern a sequence of characters given by its start and length.
+      EntryType* intern(const char8_t*, size_t);
    private:
-      Memory::Arena<Byte> strings; // character blub
-      // Allocate a string from the internal arena.
-      const Byte* make_copy(const Byte*, size_t);
+      Memory::Arena<char8_t> strings; // character storage
+      // -- Allocate a string from the internal arena.
+      const char8_t* make_copy(const char8_t*, size_t);
    };
 
    using InternedString = const StringPool::EntryType*;

--- a/src/include/open-axiom/structure
+++ b/src/include/open-axiom/structure
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -37,7 +37,7 @@
 namespace OpenAxiom {
    // -- helper classes for structural abstractions --
    namespace structure {
-      // unary structures
+      // -- unary structures
       template<typename T>
       struct unary {
          explicit constexpr unary(const T& t) : arg(t) { };
@@ -46,7 +46,7 @@ namespace OpenAxiom {
          const T arg;
       };
 
-      // binary structures
+      // -- binary structures
       template<typename T, typename U = T>
       struct binary {
          constexpr binary(const T& t, const U& u) : arg0(t), arg1(u) { };
@@ -57,7 +57,7 @@ namespace OpenAxiom {
          const U arg1;
       };
 
-      // ternary structures
+      // -- ternary structures
       template<typename T, typename U = T, typename V = U>
       struct ternary {
          constexpr ternary(const T& t, const U& u, const V& v)

--- a/src/include/open-axiom/token
+++ b/src/include/open-axiom/token
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2013-2024, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -36,14 +36,14 @@
 
 #include <cstdint>
 #include <limits>
-#include <stack>
 #include <iosfwd>
 #include <string_view>
+#include <open-axiom/Charset>
 #include <open-axiom/dialect>
 #include <open-axiom/InputFragment>
 
 namespace OpenAxiom {
-   // Categorization of Boot and Spad tokens.
+   // -- Categorization of Boot and Spad tokens.
    enum class TokenCategory : std::uint8_t {
       Unclassified,             // token of unknown class
       Whitespace,               // white-space characters
@@ -62,7 +62,7 @@ namespace OpenAxiom {
 
    std::ostream& operator<<(std::ostream&, TokenCategory);
 
-   // The abstract value associated with a token.
+   // -- The abstract value associated with a token.
    // Note: All token values are within the bound of an 8-bit integer.
    enum class TokenValue : std::uint8_t {
 #undef OPENAXIOM_DEFINE_TOKEN
@@ -85,13 +85,13 @@ namespace OpenAxiom {
       return std::uint32_t(t) & 0x00FFFFFF;
    }
 
-   // Program text region, with a fragment.
+   // -- Program text region, with a fragment.
    struct Region {
       FragmentCursor start;
       FragmentCursor end;
    };
 
-   // Given a symbolic or alphabetic token, retrieve its category
+   // -- Given a symbolic or alphabetic token, retrieve its category
    // and associated abstract value.
    struct TokenClassification {
       TokenCategory category;
@@ -102,9 +102,9 @@ namespace OpenAxiom {
       }
    };
 
-   TokenClassification classify(std::string_view);
+   TokenClassification classify(std::string_view, Language = Language::All);
 
-   // Token data structure: a region of text with a classification.
+   // -- Token data structure: a region of text with a classification.
    struct Token : Region, TokenClassification { };
 
    // -- Exception types
@@ -118,15 +118,36 @@ namespace OpenAxiom {
       ColumnIndex column;
    };
 
-   // Object of this datatype decompose a program fragment into a
+   // -- Object of this datatype decomposes a program fragment into a
    // token stream.  The tokens are of type indicated by Tok.
+   //
+   // The tokenizer produces raw tokens (identifiers, operators,
+   // literals, whitespace, comments, etc.) but does NOT emit
+   // formatting tokens (Indent/Justify/Unindent).  Formatting
+   // structure is added by the separate pile() phase, which mirrors
+   // the algorithm of pile.boot.
+   //
+   // Line continuation:
+   //   A trailing underscore at the very end of a line (e.g. `and_`)
+   //   signals that the next physical line continues the current
+   //   logical line.  In that case, the tokenizer simply advances
+   //   to the next line and continues lexing as if no line break
+   //   occurred.
    template<typename Tok>
    struct Tokenizer {
       Tokenizer(const Fragment& f)
             : frag(f),
               pos{ 0, frag.front().indent }
       {
-         indents.push(pos);
+         // -- Skip leading Meta/Ignorable lines so the tokenizer
+         // never produces tokens for reader/system commands.
+         while (pos.line < frag.size()
+                and (frag[pos.line].kind == LineKind::Meta
+                     or frag[pos.line].kind == LineKind::Ignorable)) {
+            ++pos.line;
+         }
+         if (pos.line < frag.size())
+            pos.column = frag(pos).indent;
       }
 
       bool eos() const
@@ -138,7 +159,6 @@ namespace OpenAxiom {
    private:
       const Fragment& frag;
       FragmentCursor pos;
-      std::stack<FragmentCursor> indents;
 
       std::size_t line_length() const { return frag(pos).size(); }
 
@@ -149,21 +169,13 @@ namespace OpenAxiom {
       Tok finish(Tok&, Language);
    };
 
-   bool separator_or_punctuator(std::uint8_t);
+   bool separator_or_punctuator(char8_t);
 
    template<typename T>
    inline void comment_token(T& t, TokenValue v)
    {
       t.category = TokenCategory::Comment;
       t.value = v;
-   }
-
-   template<typename T>
-   inline T& formatting_token(T& t, TokenValue v)
-   {
-      t.category = TokenCategory::Formatting;
-      t.value = v;
-      return t;
    }
 
    template<typename T>
@@ -222,7 +234,7 @@ namespace OpenAxiom {
       while (frag.covering(pos) && not done) {
          switch (frag(pos)[pos.column++]) {
          case '"': done = !escape;
-            // fallthrough
+            // -- fallthrough
          default: escape = false; break;
          case '_':
             if (pos.column == frag(pos).size()
@@ -243,13 +255,25 @@ namespace OpenAxiom {
    template<typename L>
    void skip_to_end_of_integer(L& line, ColumnIndex& idx)
    {
-      while (idx < line.size() and isdigit(line[idx]))
+      while (idx < line.size() and ascii_digit(line[idx]))
+         ++idx;
+   }
+
+   template<typename L>
+   void skip_radix_digits(L& line, ColumnIndex& idx)
+   {
+      while (idx < line.size() and ascii_xdigit(line[idx]))
          ++idx;
    }
    
-   static bool next_line(const Fragment& frag, FragmentCursor& pos)
+   inline bool next_line(const Fragment& frag, FragmentCursor& pos)
    {
-      if (++pos.line < frag.size()) {
+      while (++pos.line < frag.size()) {
+         // -- Skip comment-only and reader/system lines so they
+         // don't affect indentation or produce tokens.
+         if (frag[pos.line].kind == LineKind::Ignorable
+             or frag[pos.line].kind == LineKind::Meta)
+            continue;
          pos.column = frag(pos).indent;
          return true;
       }
@@ -265,12 +289,20 @@ namespace OpenAxiom {
    }
 
    template<typename L, typename T>
-   T& number(L& line, ColumnIndex& idx, T& t)
+   T& number(L& line, ColumnIndex& idx, T& t, Language dialect = Language::Boot)
    {
       integer(line, idx, t);
+      // -- Spad radix notation: NNrDDD (e.g. 16rFF, 2r1010).
+      if (dialect == Language::Spad
+          and idx < line.size() and line[idx] == 'r')
+      {
+         ++idx;
+         skip_radix_digits(line, idx);
+         return t;
+      }
       if (idx >= line.size() or line[idx] != '.')
          return t;
-      if (++idx >= line.size() or not isdigit(line[idx])) {
+      if (++idx >= line.size() or not ascii_digit(line[idx])) {
          --idx;
          return t;
       }
@@ -281,43 +313,77 @@ namespace OpenAxiom {
          return t;
       if (++idx < line.size() and (line[idx] == '+' or line[idx] == '-'))
          ++idx;
-      if (idx >= line.size() or not isdigit(line[idx]))
+      if (idx >= line.size() or not ascii_digit(line[idx]))
          throw MissingExponent{ line.number, idx };
       skip_to_end_of_integer(line, idx);
       return t;
    }
 
    inline bool
-   identifier_head(std::uint8_t c)
+   identifier_head(char8_t c)
    {
-      return isalpha(c) or c == '%' or c == '_';
+      return ascii_alpha(c) or c == u8'%' or c == u8'_';
    }
 
    inline bool
-   identifier_part(uint8_t c)
+   identifier_part(char8_t c)
    {
-      return identifier_head(c) or isdigit(c);
+      return identifier_head(c) or ascii_digit(c);
    }
 
    inline bool
-   identifier_suffix(std::uint8_t c)
+   identifier_suffix(char8_t c)
    {
-      return c == '!' or c == '?';
+      return c == u8'!' or c == u8'?';
    }
 
-   inline bool internal_prefix(std::uint8_t c)
+   inline bool internal_prefix(char8_t c)
    {
-      return c == '%' or c == '$';
+      return c == u8'%' or c == u8'$';
    }
 
    template<typename L>
    inline void
-   skip_prefix(L& line, ColumnIndex& idx, std::uint8_t c)
+   skip_prefix(L& line, ColumnIndex& idx, char8_t c)
    {
       while (idx < line.size() and line[idx] == c)
          ++idx;
    }
 
+   // -- Scan an identifier or keyword token.
+   //
+   // Boot identifiers may contain:
+   //   - Head characters: alpha, '%', '_'
+   //   - Continuation characters: head chars + digits
+   //   - Apostrophe (Boot only): e.g. x' or don't
+   //   - Suffix characters: '!' or '?'
+   //   - Internal prefix '$' or '%' for system names: $foo, %thing
+   //
+   // Underscore serves double duty:
+   //   - Inside an identifier, underscore is an escape character that
+   //     allows the next character to be included literally.  This is
+   //     how Boot spells identifiers containing special characters,
+   //     e.g. _+ means the identifier "plus" spelled as the literal
+   //     character '+'.  When an escape is seen, keyword classification
+   //     is suppressed (the escaped identifier is always treated as a
+   //     user identifier, never a keyword).
+   //   - At the very end of a line, underscore is NOT part of the
+   //     identifier; it is a line-continuation marker that the
+   //     tokenizer's `get()` method processes separately.  For example,
+   //     in the Boot source:
+   //         (cons? first u             and_
+   //          CAAR u isnt [.,:.]        and_
+   //          ...
+   //     each `and_` at end-of-line means "keyword `and` followed by
+   //     a continuation underscore".  If the identifier scanner were
+   //     to consume the trailing underscore, the tokenizer would see
+   //     `and_` as a single identifier instead of the keyword `and`,
+   //     and the continuation semantics would be lost.
+   //
+   // After scanning, the resulting text is classified (via `classify()`)
+   // to determine whether it matches a reserved keyword or operator.
+   // If the identifier contained underscore escapes, classification
+   // is skipped -- escaped names are always user identifiers.
    template<typename L, typename T>
    T& identifier(L& line, ColumnIndex& idx, T& t, Language dialect)
    {
@@ -328,17 +394,35 @@ namespace OpenAxiom {
          skip_prefix(line, idx, line[idx]);
       bool saw_escape = false;
       while (idx < line.size()) {
-         if (not identifier_part(line[idx]) and line[idx - 1] != '_')
+         if (not identifier_part(line[idx])
+             and (line[idx - 1] != '_' or line[idx] == ' ' or line[idx] == '\t')
+             and not (dialect == Language::Boot and line[idx] == '\'')
+             and not (dialect == Language::Spad and line[idx] == '?'))
             break;
-         else if (line[idx] == '_')
+         else if (line[idx] == '_') {
+            // -- An underscore at the end of a line is a continuation
+            // marker, not part of the identifier.  Stop the scan
+            // here so that get() sees the trailing underscore and
+            // handles line continuation properly.
+            if (idx + 1 >= line.size())
+               break;
             saw_escape = true;
+         }
          ++idx;
       }
       while (idx < line.size() and identifier_suffix(line[idx]))
          ++idx;
+      // -- In Spad, trailing apostrophes are prime marks that are part
+      // of the name: x', x'', etc.  Unlike Boot where apostrophes
+      // can appear mid-identifier (e.g. don't), Spad primes are
+      // strictly suffixes.
+      if (dialect == Language::Spad) {
+         while (idx < line.size() and line[idx] == '\'')
+            ++idx;
+      }
 
       if (!saw_escape) {
-         auto info = classify(line.sub_string(start, idx));
+         auto info = classify(as_chars(line.sub_string(start, idx)), dialect);
          if (info.category != TokenCategory::Identifier) {
             t.category = info.category;
             t.value = info.value;
@@ -554,7 +638,14 @@ namespace OpenAxiom {
    template<typename Tok>
    void sharp_et_al(const Fragment& frag, FragmentCursor& pos, Tok& t, Language dialect)
    {
-      if (dialect != Language::Lisp)
+      if (dialect == Language::Spad
+          and frag.covering(pos) and ascii_digit(frag[pos]))
+      {
+         // -- Spad argument designator: #1, #2, etc.
+         skip_to_end_of_integer(frag(pos), pos.column);
+         operator_token(t, TokenValue::ArgumentDesignator);
+      }
+      else if (dialect != Language::Lisp)
          operator_token(t, TokenValue::Sharp);
       else if (frag.covering(pos))
          switch (frag[pos++]) {
@@ -603,9 +694,10 @@ namespace OpenAxiom {
       case '$': dollar_et_al(frag, pos, t, dialect); break;
 
       default:
-         if (isdigit(c))
-            number(frag(pos), pos.column, t);
-         else if (identifier_head(c))
+         if (ascii_digit(c))
+            number(frag(pos), pos.column, t, dialect);
+         else if (identifier_head(c)
+                  or (dialect == Language::Spad and c == '?'))
             identifier(frag(pos), pos.column, t, dialect);
          else
             junk(frag(pos), pos.column, t);
@@ -616,6 +708,16 @@ namespace OpenAxiom {
       return t;
    }
 
+   // -- Main entry point for retrieving the next token from the fragment.
+   //
+   // The tokenizer produces raw tokens: identifiers, operators,
+   // literals, whitespace, and comments.  It does NOT emit any
+   // formatting tokens (Indent/Justify/Unindent); those are added
+   // by the separate pile() phase.
+   //
+   // When the cursor reaches the end of a line, the tokenizer
+   // advances to the next line and continues lexing.  Line
+   // continuation (trailing underscore) joins lines seamlessly.
    template<typename Tok>
    Tok Tokenizer<Tok>::get(Language dialect)
    {
@@ -624,6 +726,8 @@ namespace OpenAxiom {
       
       if (eos())
          return eos_token(t);
+
+      // -- Skip leading whitespace on the current line.
       switch (frag[pos]) {
       case ' ':
          skip_whitespace(frag(pos), pos.column);
@@ -635,33 +739,33 @@ namespace OpenAxiom {
          break;
       }
 
+      // -- Line continuation: trailing underscore joins the next
+      // physical line seamlessly.
       if (line_continuation()) {
          if (next_line(frag, pos))
             return finish(t, dialect);
          return eos_token(t);
       }
-      else if (pos.column >= line_length()) {
+
+      // -- End of current line: advance to next line.
+      if (pos.column >= line_length()) {
          if (not next_line(frag, pos))
             return eos_token(t);
-         t.start = t.end = pos;
-         auto indent = indents.top();
-         if (indent.column < pos.column) {
-            indents.push(pos);
-            return formatting_token(t, TokenValue::Indent);
-         }
-         else if (indent.column > pos.column) {
-            indents.pop();
-            return formatting_token(t, TokenValue::Unindent);
-         }
-
-         return formatting_token(t, TokenValue::Justify);
+         t.start = pos;
+         return finish(t, dialect);
       }
 
+      // -- Lex the next token character.
       return finish(t, dialect);
    }
 
    // -- Token streams.
    std::vector<Token> words(const Fragment&, Language);
+
+   // -- Pile phase: restructure a flat token stream by inserting
+   // Indent/Justify/Unindent tokens based on indentation.
+   // Mirrors the algorithm of pile.boot.
+   std::vector<Token> pile(const std::vector<Token>&);
 
 }
 

--- a/src/include/open-axiom/token-value
+++ b/src/include/open-axiom/token-value
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2014-2017, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -76,6 +76,7 @@ OPENAXIOM_DEFINE_TOKEN(SharpColon, "#:", Operator, Language::Lisp)
 OPENAXIOM_DEFINE_TOKEN(SharpPlus, "#+", Punctuator, Language::Lisp)
 OPENAXIOM_DEFINE_TOKEN(SharpMinus, "#-", Punctuator, Language::Lisp)
 OPENAXIOM_DEFINE_TOKEN(SharpDot, "#.", Operator, Language::Lisp)
+OPENAXIOM_DEFINE_TOKEN(ArgumentDesignator, "#n", Operator, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(Dollar, "$", Operator, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(Ampersand, "&", Operator, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(RightArrow, "->", Operator, Language::BootSpad)
@@ -113,8 +114,10 @@ OPENAXIOM_DEFINE_TOKEN(Cross, "cross", Operator, Language::BootSpad)
 OPENAXIOM_DEFINE_TOKEN(Do, "do", Keyword, Language::BootSpad)
 OPENAXIOM_DEFINE_TOKEN(Else, "else", Keyword, Language::BootSpad)
 OPENAXIOM_DEFINE_TOKEN(Exists, "exists", Keyword, Language::Spad)
+OPENAXIOM_DEFINE_TOKEN(Export, "export", Keyword, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(Finally, "finally", Keyword, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(For, "for", Keyword, Language::BootSpad)
+OPENAXIOM_DEFINE_TOKEN(Free, "free", Keyword, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(Forall, "forall", Keyword, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(From, "from", Keyword, Language::Spad)
 OPENAXIOM_DEFINE_TOKEN(Function, "function", Keyword, Language::Boot)

--- a/src/include/open-axiom/vm
+++ b/src/include/open-axiom/vm
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2011-2022, Gabriel Dos Reis.
 // All rights reserved.
 //
@@ -154,9 +154,7 @@ namespace OpenAxiom {
       //     T      0x10
 
 
-      // -----------
       // -- Value --
-      // -----------
       // All VM values fit in a universal value datatype.
       using ValueBits = std::uintptr_t;
       using ValueMask = ValueBits;
@@ -186,20 +184,20 @@ namespace OpenAxiom {
       struct ValueTrait {
       };
 
-      // Return the tag of an abstract value, when viewed as a potential
+      // -- Return the tag of an abstract value, when viewed as a potential
       // T-value.
       template<typename T>
       constexpr ValueBits tag(Value v) {
          return ValueBits(v) & ValueTrait<T>::tag_mask;
       }
 
-      // Return true if the abstract value is, in fact, a T-value.
+      // -- Return true if the abstract value is, in fact, a T-value.
       template<typename T>
       constexpr bool is(Value v) {
          return tag<T>(v) == ValueTrait<T>::tag;
       }
 
-      // Return the pristine bits of an abstract value without its tag.
+      // -- Return the pristine bits of an abstract value without its tag.
       template<typename T>
       constexpr ValueBits native(Value v) {
          return ValueBits(v) & ~ValueTrait<T>::tag_mask;
@@ -215,9 +213,7 @@ namespace OpenAxiom {
          three    = 3,          // Exactly three arguments.
       };
 
-      // -----------
       // -- Boxed --
-      // -----------
       // Any internal value is of a class derived from this.
       internal_type Boxed {
          struct Visitor;
@@ -225,7 +221,7 @@ namespace OpenAxiom {
          virtual void accept(Visitor&) const = 0;
       };
 
-      // Provide an S-view of a T-typed expression, assuming the type T
+      // -- Provide an S-view of a T-typed expression, assuming the type T
       // derives from S.
       template<typename S, typename T>
       inline const S& as(const T& t) { return t; }
@@ -253,9 +249,7 @@ namespace OpenAxiom {
       struct Callable : Boxed {
       };
       
-      // -------------
       // -- Fixnum ---
-      // -------------
       // VM integers are divided into classes: small numbers,
       // and large numbers.  A small number fits entirely in a register.
       // A large number is allocated and represented by its address.
@@ -281,9 +275,7 @@ namespace OpenAxiom {
          return Value((ValueBits(i) << 1 ) | ValueTrait<Fixnum>::tag);
       }
 
-      // ------------
       // -- String --
-      // ------------
       using String = InternedString;
 
       template<>
@@ -304,9 +296,7 @@ namespace OpenAxiom {
          return is<String>(v) ? to_string(v) : nullptr;
       }
 
-      // -------------
       // -- Pointer --
-      // -------------
       // Allocated objects are represented by their addresses.
       using Memory::Pointer;
 
@@ -324,9 +314,7 @@ namespace OpenAxiom {
          return Value(ValueBits(p) | ValueTrait<Memory::Pointer>::tag);
       }
 
-      // ----------
       // -- Pair --
-      // ----------
       struct alignas(8) ConsCell {
          Value head;
          Value tail;
@@ -348,7 +336,7 @@ namespace OpenAxiom {
          return Value(ValueBits(p) | ValueTrait<Pair>::tag);
       }
 
-      // Return true if argument designates a pair.
+      // -- Return true if argument designates a pair.
       constexpr Value consp(Value v) {
          return to_value(v != Value::nil and v != Value::t and is<Pair>(v));
       }
@@ -357,7 +345,7 @@ namespace OpenAxiom {
          return null(consp(v));
       }
 
-      // If `v' designates a pair, return a pointer to its
+      // -- If `v' designates a pair, return a pointer to its
       // concrete representation.
       inline Pair if_pair(Value v) {
          return consp(v) == Value::t ? to_pair(v) : nullptr;
@@ -370,9 +358,7 @@ namespace OpenAxiom {
          return Fixnum::zero;
       }
 
-      // ---------------
       // -- Character --
-      // ---------------
       // This datatype is prepared for Uncode characters even if
       // we do not handle UCN characters at the moment.
       enum class Character : ValueBits { };
@@ -414,9 +400,7 @@ namespace OpenAxiom {
          return SymbolAttribute(ValueBits(x) & ValueBits(y));
       }
 
-      // ------------
       // -- Symbol --
-      // ------------
       struct Symbol : Boxed {
          const InternedString name;
          Value value;
@@ -483,9 +467,7 @@ namespace OpenAxiom {
          std::vector<Binding> dynamic;
       };
 
-      // -------------
       // -- Package --
-      // -------------
       struct Package : Boxed {
          const InternedString name;
          std::set<Symbol, CmpByName> symbols;
@@ -496,9 +478,7 @@ namespace OpenAxiom {
          Symbol* find_symbol(InternedString);
       };
 
-      // --------------
       // -- Function --
-      // --------------
       struct FunctionBase : Callable {
          const Symbol* name;
          Value type;
@@ -507,9 +487,7 @@ namespace OpenAxiom {
          void accept(Visitor&) const override;
       };
 
-      // ------------------------
       // -- Builtin Operations --
-      // ------------------------
       // Types for native implementation of builtin operators.
       struct BasicContext;
 
@@ -565,9 +543,7 @@ namespace OpenAxiom {
       template<typename Code>
       void BuiltinFunction<Code>::accept(Visitor& v) const { v.visit(*this); }
 
-      // ------------------
       // -- BasicContext --
-      // ------------------
       // Provides basic evaluation services.
       struct BasicContext : StringPool {
          BasicContext();

--- a/src/io/InputFragment.cxx
+++ b/src/io/InputFragment.cxx
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -- -*- C++ -*-
 // Copyright (C) 2014-2024, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
@@ -32,12 +32,15 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <algorithm>
-#include <iterator>
-#include <istream>
 #include <ostream>
 #include <iostream>
+#include <open-axiom/Charset>
 #include <open-axiom/InputFragment>
+#include <open-axiom/LispValue>
+#include <open-axiom/token>
+#include <open-axiom/SyntaxTree>
+#include <open-axiom/Parser>
+#include <open-axiom/BootAst>
 
 namespace OpenAxiom {
 
@@ -45,75 +48,127 @@ namespace OpenAxiom {
       return os << '{' << cur.line << '-' << cur.column << '}';
    }
    
-   // Formatting program fragments.
+   // -- Formatting program fragments.
    std::ostream& operator<<(std::ostream& os, const Fragment& f) {
-      std::copy(f.begin(), f.end(),
-                std::ostream_iterator<std::string>(os, "\n"));
+      for (auto& line : f)
+         os << std::u8string_view(line) << '\n';
       return os;
    }
    
-   // Return the indentation level of a line.
-   // FIXME: reject or expand tabs as appropriate.
+   // -- Return the indentation level of a line.
    static ColumnIndex indentation(const Line& line) {
       ColumnIndex idx { };
       for (auto c : line) {
-         if (not isblank(c))
+         if (not ascii_blank(c))
             break;
          ++idx;
       }
       return idx;
    }
 
-   // Remove trailing white-space characters from the line.
+   // -- Expand tab characters to spaces using 8-column tab stops.
+   // Boot source files use tabs for continuation indentation in
+   // several places, so proper expansion is needed to make
+   // indentation comparisons correct.
+   static Line& expand_tabs(Line& line) {
+      if (line.find(u8'\t') == std::u8string::npos)
+         return line;
+      std::u8string result;
+      result.reserve(line.size());
+      ColumnIndex col = 0;
+      for (char8_t c : line) {
+         if (c == u8'\t') {
+            ColumnIndex next_stop = (col / 8 + 1) * 8;
+            result.append(next_stop - col, u8' ');
+            col = next_stop;
+         }
+         else {
+            result += c;
+            ++col;
+         }
+      }
+      static_cast<std::u8string&>(line) = std::move(result);
+      return line;
+   }
+
+   // -- Remove trailing white-space characters and carriage returns from the line.
    static Line& trim_right(Line& line) {
       auto n = line.length();
-      while (n > 0 and isblank(line[n-1]))
+      while (n > 0 and (ascii_blank(line[n-1]) or line[n-1] == u8'\r'))
          --n;
       line.resize(n);
       return line;
    }
 
-   // Return true if line is entirely a positive comment, i.e. a description.
+   // -- Return true if line is entirely a positive comment, i.e. a description.
    static bool positive_comment(const Line& line) {
       if (line.indent + 1 >= line.length())
          return false;
-      return line[line.indent] == '+' and line[line.indent + 1] == '+';
+      return line[line.indent] == u8'+' and line[line.indent + 1] == u8'+';
    }
 
-   // Return true if line is entirely a negative comment.
+   // -- Return true if line is entirely a negative comment.
    static bool negative_comment(const Line& line) {
       if (line.indent + 1 >= line.length())
          return false;
-      return line[line.indent] == '-' and line[line.indent + 1] == '-';
+      return line[line.indent] == u8'-' and line[line.indent + 1] == u8'-';
    }
    
-   // Clean up and dress up the line with indentation information.
+   // -- Clean up and dress up the line with indentation information.
    static Line& prop_up(Line& line) {
-      line.indent = indentation(trim_right(line));
+      line.indent = indentation(expand_tabs(trim_right(line)));
       if (negative_comment(line))
          line.kind = LineKind::Ignorable;
       else if (positive_comment(line))
          line.kind = LineKind::Description;
-      else if (line.indent == 0 and not line.empty() and line.front() == ')')
+      else if (line.indent == 0 and not line.empty() and line.front() == u8')')
          line.kind = LineKind::Meta;
       else
          line.kind = LineKind::Ordinary;
       return line;
    }
 
-   // -- A source input transform a character stream into a program fragment
-   // -- stream, delivering a fragment one at a time.
+   // -- A source input transforms a flat character buffer into a program
+   // -- fragment stream, delivering a fragment one at a time.
    struct SourceInput {
-      SourceInput(std::istream& is) : input(is), line{ } { }
-      // Return the next program fragment from this input source.
+      explicit SourceInput(std::u8string_view buf)
+         : buffer{ buf }, pos{ }, line{ } { }
+      // -- Return the next program fragment from this input source.
       Fragment get();
       
    private:
-      std::istream& input;
+      std::u8string_view buffer;
+      std::size_t pos;
       Line line;
+
+      // -- Extract the next physical line from the buffer.
+      // Returns false at end of input.
+      bool getline();
    };
 
-   // Decompose the input souce file into fragments, and return one
+   bool SourceInput::getline() {
+      if (pos >= buffer.size())
+      {
+         static_cast<std::u8string&>(line).clear();
+         return false;
+      }
+      auto nl = buffer.find(u8'\n', pos);
+      if (nl == std::u8string_view::npos)
+      {
+         static_cast<std::u8string&>(line).assign(buffer.data() + pos,
+                                                  buffer.size() - pos);
+         pos = buffer.size();
+      }
+      else
+      {
+         static_cast<std::u8string&>(line).assign(buffer.data() + pos,
+                                                  nl - pos);
+         pos = nl + 1;
+      }
+      return true;
+   }
+
+   // -- Decompose the input source file into fragments, and return one
    // fragment at a time.
    Fragment SourceInput::get() {
       Fragment fragment;
@@ -125,7 +180,7 @@ namespace OpenAxiom {
          fragment.push_back(line);
       }
 
-      while (std::getline(input, line)) {
+      while (getline()) {
          ++line.number;
          prop_up(line);
          if (line.indent >= line.length())
@@ -139,9 +194,16 @@ namespace OpenAxiom {
          else if (line.kind == LineKind::Description and line.indent == 0)
             ;                   // Toplevel descriptions preceed items.
          else if (indents.empty()) {
-            // Consecutive rows of wisecracks make up a fragment of their own.
-            if (line.indent == 0)
-               break;
+            // -- No code lines collected yet.  If the fragment already
+            // has non-code lines (Meta, Description), an indent-0
+            // ordinary line starts a *new* top-level -- break.
+            // Only when the fragment is entirely empty do we allow
+            // an indent-0 line to begin it (e.g. Spad files that
+            // start with 'import' before ')abbrev').
+            if (line.indent == 0) {
+               if (not fragment.empty())
+                  break;
+            }
             else if (fragment.empty())
                std::cerr << "warning: white space at begining of fragment"
                          << " on line " << line.number << '\n';
@@ -160,12 +222,197 @@ namespace OpenAxiom {
       return fragment;
    }
 
-   Prose read_source(std::istream& is)
+   Prose read_source(std::u8string_view source)
    {
       Prose text { };
-      SourceInput src { is };
+      SourceInput src { source };
       while (auto f = src.get())
          text.push_back(f);
+      return text;
+   }
+
+   // -- Reader with directive evaluation
+   //
+   // Processes )if / )elseif / )else / )endif conditionals:
+   //
+   //   )if <boot-expr>
+   //     ... included if expr is true ...
+   //   )elseif <boot-expr>
+   //     ... included if previous was false and expr is true ...
+   //   )else
+   //     ... included if all previous branches were false ...
+   //   )endif
+   //
+   // The condition <boot-expr> is tokenized as Boot, parsed,
+   // lowered to Lisp AST, and evaluated against the features list.
+   //
+   // )abbrev lines are silently skipped.
+   // )eval lines are silently skipped (not yet implemented).
+
+   namespace {
+
+      // -- Parse a reader directive line.
+      //    Returns the directive keyword and the rest of the line.
+      struct Directive {
+         std::u8string_view keyword;  // u8"if", u8"elseif", u8"else", u8"endif",
+                                      // -- u8"eval", u8"abbrev", or u8""
+         std::u8string_view rest;     // text after the directive keyword
+      };
+
+      Directive parse_directive(const Line& line)
+      {
+         Directive d { {}, {} };
+         if (line.empty() or line.front() != u8')')
+            return d;
+         // -- Skip the leading ')'.
+         std::size_t i = 1;
+         // -- Extract the directive keyword.
+         auto start = i;
+         while (i < line.size() and line[i] != u8' ' and line[i] != u8'\t')
+            ++i;
+         d.keyword = std::u8string_view(line).substr(start, i - start);
+         // -- Skip whitespace.
+         while (i < line.size() and (line[i] == u8' ' or line[i] == u8'\t'))
+            ++i;
+         d.rest = std::u8string_view(line).substr(i);
+         return d;
+      }
+
+      // -- Evaluate a Boot condition expression.
+      //    Tokenizes, parses, lowers, then evaluates against features.
+      bool eval_boot_condition(std::u8string_view expr,
+                               Lisp::Value features)
+      {
+         if (expr.empty())
+            return false;
+
+         // -- Build a one-line fragment from the condition text.
+         Fragment frag;
+         Line cond_line;
+         static_cast<std::u8string&>(cond_line) = std::u8string(expr);
+         cond_line.number = 0;
+         cond_line.indent = 0;
+         cond_line.kind = LineKind::Ordinary;
+         frag.push_back(cond_line);
+
+         try {
+            auto toks = pile(words(frag, Language::Boot));
+            if (toks.empty())
+               return false;
+
+            Syntax::SyntaxForest forest;
+            auto forms = Boot::parse_boot(toks, forest);
+            if (forms.empty())
+               return false;
+
+            Lisp::Arena arena;
+            Boot::LoweringContext ctx{ forest, toks, frag, arena };
+            auto lowered = Boot::lower(forms[0], ctx);
+            return Lisp::eval_condition(lowered, features);
+         }
+         catch (...) {
+            // -- If anything goes wrong, treat as false.
+            return false;
+         }
+      }
+
+      // -- Conditional inclusion state for one nesting level.
+      struct CondState {
+         bool any_taken;     // has any branch been included so far?
+         bool active;        // is the current branch included?
+      };
+
+   } // anonymous namespace
+
+   Prose read_source(std::u8string_view source,
+                     Lisp::Value features)
+   {
+      Prose text { };
+      SourceInput src { source };
+
+      // -- Stack of conditional inclusion states (for nesting).
+      std::vector<CondState> cond_stack;
+
+      // -- Helper: are we currently including lines?
+      auto including = [&]() -> bool {
+         for (auto& cs : cond_stack)
+            if (not cs.active)
+               return false;
+         return true;
+      };
+
+      while (auto f = src.get())
+      {
+         // -- Process the fragment: evaluate reader directives
+         // ()if / )elseif / )else / )endif) and handle conditional
+         // inclusion.  Other Meta lines pass through unchanged.
+         Fragment filtered;
+         for (auto& line : f)
+         {
+            if (line.kind == LineKind::Meta)
+            {
+               auto dir = parse_directive(line);
+
+               if (dir.keyword == u8"if")
+               {
+                  bool result = including()
+                     and eval_boot_condition(dir.rest, features);
+                  cond_stack.push_back({ result, result });
+                  continue;
+               }
+               if (dir.keyword == u8"elseif")
+               {
+                  if (not cond_stack.empty())
+                  {
+                     auto& cs = cond_stack.back();
+                     if (cs.any_taken)
+                        cs.active = false;
+                     else
+                     {
+                        // -- Evaluate only if no branch taken yet
+                        // and all enclosing levels are active.
+                        bool outer_active = true;
+                        for (std::size_t i = 0;
+                             i + 1 < cond_stack.size(); ++i)
+                           if (not cond_stack[i].active)
+                           { outer_active = false; break; }
+                        bool result = outer_active
+                           and eval_boot_condition(dir.rest,
+                                                   features);
+                        cs.active = result;
+                        if (result)
+                           cs.any_taken = true;
+                     }
+                  }
+                  continue;
+               }
+               if (dir.keyword == u8"else")
+               {
+                  if (not cond_stack.empty())
+                  {
+                     auto& cs = cond_stack.back();
+                     cs.active = not cs.any_taken;
+                  }
+                  continue;
+               }
+               if (dir.keyword == u8"endif")
+               {
+                  if (not cond_stack.empty())
+                     cond_stack.pop_back();
+                  continue;
+               }
+               // -- Non-conditional Meta line ()abbrev, )eval, etc.):
+               // include if currently active.
+            }
+
+            // -- Include the line only if all conditions are active.
+            if (including())
+               filtered.push_back(line);
+         }
+
+         if (filtered)
+            text.push_back(std::move(filtered));
+      }
       return text;
    }
 }

--- a/src/io/charset.cxx
+++ b/src/io/charset.cxx
@@ -1,5 +1,7 @@
-// -- Copyright (C) 2011, Gabriel Dos Reis.
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
 // All rights reserved.
+// Written by Gabriel Dos Reis.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -13,9 +15,9 @@
 //       the documentation and/or other materials provided with the
 //       distribution.
 //
-//     - Neither the name of The Numerical Algorithms Group Ltd. nor the
-//       names of its contributors may be used to endorse or promote products
-//       derived from this software without specific prior written permission.
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -29,26 +31,24 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// --% Author: Gabriel Dos Reis.
-
-
-#include "open-axiom.h"
+#include <ostream>
+#include <open-axiom/Charset>
 
 namespace OpenAxiom {
-   Filesystem::Filesystem(const std::string& d)
-         : root(d),
-           alg(d + "/algebra"),
-           db(alg)
-   { }
+   std::ostream& operator<<(std::ostream& os, std::u8string_view s)
+   {
+      return os.write(reinterpret_cast<const char*>(s.data()), s.size());
+   }
 
-   std::string Filesystem::sysdir() const { return root; }
-
-   std::string Filesystem::algdir() const { return alg; }
-
-   std::string Filesystem::dbdir() const { return db; }
-
-   std::string
-   database_filepath(const Filesystem& fs, const std::string& file) {
-      return fs.dbdir() + "/" + file + ".daase";
+   void print_bar_quoted(std::ostream& os, std::u8string_view name)
+   {
+      os << '|';
+      for (char8_t c : name)
+      {
+         if (c == u8'|' or c == u8'\\')
+            os << '\\';
+         os << static_cast<char>(c);
+      }
+      os << '|';
    }
 }

--- a/src/io/std-streams.cxx
+++ b/src/io/std-streams.cxx
@@ -1,4 +1,4 @@
-// Copyright (C) 2013, Gabriel Dos Reis.
+// -- Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -35,6 +35,7 @@ core_SOURCES = \
 	cfuns-c.cxx \
 	sockio-c.cxx \
 	../utils/storage.cxx \
+	../io/charset.cxx \
 	../io/std-streams.cxx \
 	../io/InputFragment.cxx \
 	../syntax/token.cxx \

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -39,7 +39,12 @@ core_SOURCES = \
 	../io/InputFragment.cxx \
 	../syntax/token.cxx \
 	../syntax/sexpr.cxx \
-	../syntax/Parser.cxx
+	../syntax/boot-ast.cxx \
+	../syntax/boot-translator.cxx \
+	../syntax/lisp-value.cxx \
+	../syntax/Parser.cxx \
+	../syntax/syntax-print.cxx \
+	../syntax/syntax-tree.cxx
 
 terminal_io_SOURCES = cursor.c edin.c fnct_key.c openpty.c prt.c wct.c
 

--- a/src/lib/cfuns-c.cxx
+++ b/src/lib/cfuns-c.cxx
@@ -61,7 +61,7 @@
 namespace fs = std::filesystem;
 
 namespace OpenAxiom {
-   // Make a copy of string data on free store.
+   // -- Make a copy of string data on free store.
    static char*
    copy_c_str(const std::string& s) {
       return strdup(s.c_str());
@@ -203,7 +203,7 @@ writeablep(const char* path)
    DWORD attributes = GetFileAttributes(path);
    if (attributes == INVALID_FILE_ATTRIBUTES)
    {
-      // The file does not exist, so check to see if the directory is writable.
+      // -- The file does not exist, so check to see if the directory is writable.
       auto dir = oa_dirname(path);
       auto result = axiom_has_write_access(dir);
       LocalFree(dir);

--- a/src/lib/sockio-c.cxx
+++ b/src/lib/sockio-c.cxx
@@ -491,7 +491,7 @@ wait_for_client_write(openaxiom_sio* sock, const Byte* buf,
   }
 }
 
-// Prefix a message with a given string for diagnostic purposes.
+// -- Prefix a message with a given string for diagnostic purposes.
 static std::string diagnostic(const char* prefix, const char* msg)
 {
   std::string s = prefix;

--- a/src/rt/Database.cc
+++ b/src/rt/Database.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014, Gabriel Dos Reis.
+// -- Copyright (C) 2013-2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -35,11 +35,17 @@
 namespace OpenAxiom {
    namespace VM {
       Database::Database(const std::string& path)
-            : file(path), reader{ file.begin(), file.end() }, toc() {
+            : file(path),
+              reader {
+                 reinterpret_cast<const char8_t*>(file.begin()),
+                 reinterpret_cast<const char8_t*>(file.end())
+              },
+              toc()
+      {
       }
 
-      Value
-      Database::find_with(Value key, Lisp::Evaluator& ctx) {
+      Value Database::find_with(Value key, Lisp::Evaluator& ctx)
+      {
          auto p = dict.find(key);
          if (p != dict.end())
             return p->second;

--- a/src/rt/Lisp.cc
+++ b/src/rt/Lisp.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014, Gabriel Dos Reis.
+// -- Copyright (C) 2013-2014, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -31,6 +31,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <open-axiom/Lisp>
+#include <open-axiom/Charset>
 #include <typeinfo>
 #include <ostream>
 #include <sstream>
@@ -53,7 +54,7 @@ namespace OpenAxiom {
       { }
 
       static void unbound_function_symbol_error(const Symbol* sym) {
-         std::string s { sym->name->begin(), sym->name->end() };
+         std::string s { as_chars({ sym->name->begin(), sym->name->size() }) };
          throw UnboundFunctionSymbol(s + " has no function definition");
       }
       
@@ -119,7 +120,8 @@ namespace OpenAxiom {
 
       static void
       integer_too_large(const Sexpr::IntegerSyntax& x) {
-         std::string s { x.lexeme().begin(), x.lexeme().end() };
+         auto sv = as_chars({ x.lexeme().begin(), x.lexeme().size() });
+         std::string s { sv };
          throw IntegerOverflow{ s + " is too large for Fixnum; max value is "
                + std::to_string(FixnumBits(Fixnum::maximum)) };
       }
@@ -133,11 +135,11 @@ namespace OpenAxiom {
          auto cur = x.lexeme().begin();
          FixnumBits val = 0;
          switch (*cur) {
-         case '-': neg = true;
-         case '+': ++cur;
+         case u8'-': neg = true;
+         case u8'+': ++cur;
          default:
             for (; cur < x.lexeme().end(); ++cur) {
-               auto d = *cur - '0';
+               auto d = *cur - u8'0';
                if (val < fixmax_by_ten)
                   val = 10 * val + d;
                else if (val > fixmax_by_ten or d > fixmax_lsd)
@@ -236,33 +238,35 @@ namespace OpenAxiom {
 
       static std::string
       canonical_name(const Sexpr::SymbolSyntax& x) {
-         if (x.kind() & Sexpr::SymbolSyntax::absolute)
-            return { x.begin(), x.end() };
+         if (x.kind() & Sexpr::SymbolSyntax::absolute) {
+            auto sv = as_chars({ x.begin(), x.size() });
+            return { sv.begin(), sv.end() };
+         }
          const auto sz = x.size();
          std::string s(sz, char{ });
          for (std::size_t i = 0; i < sz; ++i)
-            s[i] = toupper(x[i]);
+            s[i] = toupper(static_cast<char>(x[i]));
          return s;
       }
 
-      // Return the (global) symbol value
+      // -- Return the (global) symbol value
       static Symbol*
       retrieve_symbol(Evaluator* ctx, const Sexpr::SymbolSyntax& x) {
          const auto s = canonical_name(x);
          auto name = ctx->intern(s.c_str());
          if (x.kind() & Sexpr::SymbolSyntax::keyword)
             return ctx->make_keyword(name);
-         // Note: Uninterned symbols are always distincts;
+         // -- Note: Uninterned symbols are always distincts;
          else if (x.kind() & Sexpr::SymbolSyntax::uninterned)
             unbound_symbol_error(s);
-         // FIXME: if this is a qualified symbol, lookup in its home.
+         // -- FIXME: if this is a qualified symbol, lookup in its home.
          else if (auto symbol = ctx->current_package()->find_symbol(name))
             return symbol;
          unbound_symbol_error(s);
          return nullptr;
       }
 
-      // Return the value designated by this symbol.
+      // -- Return the value designated by this symbol.
       static Value
       evaluate(Evaluator* ctx, const Sexpr::SymbolSyntax& x) {
          const auto s = canonical_name(x);
@@ -279,7 +283,7 @@ namespace OpenAxiom {
          return symbol->value;
       }
 
-      // Return the denotation of a sharp-apostrophe syntax.
+      // -- Return the denotation of a sharp-apostrophe syntax.
 
       static const Callable*
       symbol_function(Evaluator* ctx, const Sexpr::SymbolSyntax& s) {
@@ -324,7 +328,7 @@ namespace OpenAxiom {
             return Value::nil;
          auto s = dynamic_cast<const Sexpr::SymbolSyntax*>(x.front());
          if (s == nullptr)
-            // FIXME: real error
+            // -- FIXME: real error
             unimplemented(x);
          if (auto op = special_operator(*s))
             return op(ctx, x);
@@ -472,9 +476,9 @@ namespace OpenAxiom {
       static void format(String s, std::ostream& os) {
          os << '"';
          for (auto c : *s) {
-            if (c == '"')
+            if (c == u8'"')
                os << '\\';
-            os << char(c);
+            os << static_cast<char>(c);
          }
          os << '"';
       }
@@ -503,14 +507,12 @@ namespace OpenAxiom {
             std::ostream& os;
             V(std::ostream& s) : os(s) { }
             void visit(const Symbol& s) {
-               // FIXME: handle escapes.
-               std::copy(s.name->begin(), s.name->end(),
-                         std::ostream_iterator<char>(os));
+               // -- FIXME: handle escapes.
+               os << as_chars({ s.name->begin(), s.name->size() });
             }
             void visit(const Package& p) {
                os << "#<PACKAGE ";
-               std::copy(p.name->begin(), p.name->end(),
-                         std::ostream_iterator<char>(os));
+               os << as_chars({ p.name->begin(), p.name->size() });
                os << '>';
             }
             void visit(const FunctionBase& f) {

--- a/src/rt/driver.cc
+++ b/src/rt/driver.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2014, Gabriel Dos Reis.
+// -- Copyright (C) 2014, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -40,7 +40,7 @@ static OpenAxiom::Sexpr::RawInput
 raw_input(const std::string& line, OpenAxiom::Ordinal lineno) {
    if (line.empty())
       return { nullptr, nullptr, lineno };
-   auto p = reinterpret_cast<const OpenAxiom::Byte*>(&line[0]);
+   auto p = reinterpret_cast<const char8_t*>(&line[0]);
    return { p, p + line.size(), lineno };
 }
 

--- a/src/rt/vm.cc
+++ b/src/rt/vm.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2011-2022, Gabriel Dos Reis.
+// -- Copyright (C) 2011-2022, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -57,7 +57,7 @@ namespace OpenAxiom {
       Environment::Environment() = default;
 
       Environment::~Environment() {
-         // Restore value of special variables bound in this environment.
+         // -- Restore value of special variables bound in this environment.
          const auto end = dynamic.rend();
          for (auto p = dynamic.rbegin(); p != end; ++p)
             p->symbol->value = p->value;

--- a/src/syntax/Parser.cxx
+++ b/src/syntax/Parser.cxx
@@ -1,5 +1,5 @@
-// -*- C++ -*-
-// Copyright (C) 2014-2024, Gabriel Dos Reis.
+// -- -*- C++ -*-
+// Copyright (C) 2014-2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -15,9 +15,9 @@
 //       the documentation and/or other materials provided with the
 //       distribution.
 //
-//     - Neither the name of OpenAxiom. nor the names of its contributors
-//       may be used to endorse or promote products derived from this
-//       software without specific prior written permission.
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,71 +31,3485 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <iostream>
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Recursive-descent parser for the Boot language.
+// --%
+// --%   Boot is the implementation language of OpenAxiom.  It is a
+// --%   statically-scoped, mostly-functional language with Lisp-like
+// --%   S-expression quoting, ML-like pattern matching (is/isnt),
+// --%   significant indentation (the "off-side rule"), and algebraic
+// --%   notation for arithmetic and function application.
+// --%
+// --%   This parser operates on a flat vector of tokens produced by
+// --%   Tokenizer<Token> (see <open-axiom/token>).  The tokenizer has
+// --%   already resolved physical lines into logical lines within each
+// --%   Fragment, and has injected three kinds of formatting tokens at
+// --%   line boundaries:
+// --%     Indent   - new line is deeper than the current indentation,
+// --%     Unindent - new line is shallower,
+// --%     Justify  - new line is at the same level.
+// --%
+// --%   These formatting tokens encode the off-side rule: an Indent
+// --%   opens a new "pile" (a vertically-aligned block of items), and
+// --%   the matching Unindent closes it.  Justify separates adjacent
+// --%   items within the same pile.
+// --%
+// --%   The parser uses the formatting tokens only at the "pile"
+// --%   level of the grammar.  Inside parentheses, brackets, or braces,
+// --%   `delimiter_depth > 0` tracks the nesting, and certain constructs
+// --%   (like `==` as default-value) are disambiguated by it.
+// --%
+// --% Grammar (operator precedence, lowest to highest):
+// --%
+// --%   toplevel      > comma
+// --%   comma         > module | import | namespace | tuple_of(where)
+// --%   semicolon     > semi_list(comma)
+// --%   where         > definition [ 'where' local-defs ]
+// --%   definition    > 'macro' name params '==' where
+// --%                  | exit [ '==' (where | pile) ]
+// --%   exit          > assign [ '=>' where ]
+// --%   assign        > statement [ ':=' assign | '+->' assign | '<-' logical ]
+// --%   statement     > conditional | loop | try | expression
+// --%   expression    > [':'] logical
+// --%   logical       > return_expr { 'or' return_expr }
+// --%   return_expr   > 'return' assign | 'leave' logical
+// --%                  | 'throw' application | 'do' statement
+// --%                  | and_expr
+// --%   and_expr      > compare { 'and' compare }
+// --%   compare       > is_expr [ comp_op is_expr | 'in' is_expr ]
+// --%   is_expr       > segment [ 'is' pattern | 'isnt' pattern | 'has' application ]
+// --%   segment       > arith [ '..' arith ]
+// --%   arith         > minus { ('+' | '-') minus }
+// --%   minus         > ['-'] euclid
+// --%   euclid        > times { ('quo' | 'rem') times }
+// --%   times         > reduce | expt { ('*' | '/') expt }
+// --%   reduce        > op '/' (construct | application)
+// --%   expt          > typed { '**' typed }
+// --%   typed         > application [ '@' typing | '::' typing
+// --%                                | ':' typing | '->' typed ]
+// --%   typing        > 'forall' vars '.' typing | application [ '->' application ]
+// --%   application   > primary { '.' primary | '(' args ')' | juxtaposition }
+// --%   primary       > ''' sexp | '(' semicolon ')' | '[' construct ']'
+// --%                  | '.' | prefix_op primary | 'leave' primary
+// --%                  | 'if' ... | 'case' ... | 'structure' ... | 'function' primary
+// --%                  | pile | 'namespace' name | name | literal
+// --%
+// --% Pattern grammar (used after 'is' and 'isnt'):
+// --%   pattern       > pattern_item
+// --%   pattern_item  > '=' expr | ':' pattern_item | '[' pattern_list ']'
+// --%                  | '.' | ''' sexp | constant
+// --%                  | name [ '::' name ] [ ':=' pattern_item ]
+// --%   pattern_list  > pattern_item { ',' pattern_item }
+// --%
+// --% S-expression grammar (used after quote '):
+// --%   sexp          > '-' INTEGER | ''' sexp
+// --%                  | '(' { sexp } [ '.' sexp ] ')'
+// --%                  | atom
+// --%   sexp_atom     > identifier | integer | float | string
+// --%                  | keyword-as-symbol | operator-as-symbol
+
+#include <algorithm>
 #include <fstream>
-#include <vector>
-#include <string>
-#include <stack>
+#include <iostream>
 #include <iterator>
-#include <ctype.h>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
 
+#include <open-axiom/Charset>
 #include <open-axiom/diagnostics>
+#include <open-axiom/FileMapping>
 #include <open-axiom/InputFragment>
-#include <open-axiom/token>
 #include <open-axiom/Parser>
+#include <open-axiom/SyntaxTree>
+#include <open-axiom/token>
 
+namespace OpenAxiom::Boot {
+    using Syntax::NodeIndex;
+    using Syntax::NodeSpan;
+    using Syntax::SyntaxForest;
+    using Syntax::Kind;
+
+    namespace {
+
+        // -- Operator classification
+
+        // -- Return true if the token value is a prefix operator.
+        bool prefix_operator(TokenValue v)
+        {
+            switch (v)
+            {
+            case TokenValue::Sharp:
+            case TokenValue::Minus:
+            case TokenValue::Tilde:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- Return true if the token value is an infix operator.
+        bool infix_operator(TokenValue v)
+        {
+            switch (v)
+            {
+            case TokenValue::Plus:
+            case TokenValue::Minus:
+            case TokenValue::Star:
+            case TokenValue::Slash:
+            case TokenValue::StarStar:
+            case TokenValue::Quo:
+            case TokenValue::Rem:
+            case TokenValue::Mod:
+            case TokenValue::And:
+            case TokenValue::Or:
+            case TokenValue::Less:
+            case TokenValue::LessEq:
+            case TokenValue::Greater:
+            case TokenValue::GreaterEq:
+            case TokenValue::Eq:
+            case TokenValue::TildeEq:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- Return true if the token value can head a reduce.
+        bool reduce_operator(TokenValue v)
+        {
+            return infix_operator(v) or v == TokenValue::Sharp;
+        }
+
+        // -- Return true if the token is a comparison operator.
+        bool comparison_operator(TokenValue v)
+        {
+            switch (v)
+            {
+            case TokenValue::Eq:
+            case TokenValue::TildeEq:
+            case TokenValue::Less:
+            case TokenValue::LessEq:
+            case TokenValue::Greater:
+            case TokenValue::GreaterEq:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- Operator predicates for left-associative chains.
+        bool comparison_or_in_operator(TokenValue v)
+        {
+            return comparison_operator(v) or v == TokenValue::In;
+        }
+
+        bool exponentiation_operator(TokenValue v)
+        {
+            return v == TokenValue::StarStar;
+        }
+
+        bool multiplicative_operator(TokenValue v)
+        {
+            return v == TokenValue::Star or v == TokenValue::Slash;
+        }
+
+        bool euclidean_operator(TokenValue v)
+        {
+            return v == TokenValue::Quo or v == TokenValue::Rem;
+        }
+
+        bool additive_operator(TokenValue v)
+        {
+            return v == TokenValue::Plus or v == TokenValue::Minus;
+        }
+
+        bool conjunction_operator(TokenValue v)
+        {
+            return v == TokenValue::And;
+        }
+
+        bool disjunction_operator(TokenValue v)
+        {
+            return v == TokenValue::Or;
+        }
+
+        // -- Return true if the token can start an iterator or guard clause.
+        bool starts_iterator(TokenValue v)
+        {
+            return v == TokenValue::For
+                or v == TokenValue::While
+                or v == TokenValue::Until
+                or v == TokenValue::Bar;
+        }
+
+        // -- Return true if the token is a structural delimiter that
+        //    terminates S-expression lists.  These tokens cannot
+        //    appear as atoms in S-expressions.
+        bool sexp_structural_delimiter(TokenValue v)
+        {
+            switch (v)
+            {
+            case TokenValue::OpenParen:
+            case TokenValue::CloseParen:
+            case TokenValue::OpenBracket:
+            case TokenValue::CloseBracket:
+            case TokenValue::OpenBrace:
+            case TokenValue::CloseBrace:
+            case TokenValue::Comma:
+            case TokenValue::Semicolon:
+            case TokenValue::Dot:
+            case TokenValue::Apostrophe:
+            case TokenValue::Backquote:
+            case TokenValue::Indent:
+            case TokenValue::Unindent:
+            case TokenValue::Justify:
+            case TokenValue::EndOfStream:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- Return true if the token is a Spad structural keyword
+        //    that cannot be used as an identifier name.
+        bool spad_structural_keyword(TokenValue v)
+        {
+            switch (v)
+            {
+            case TokenValue::If:
+            case TokenValue::Then:
+            case TokenValue::Else:
+            case TokenValue::For:
+            case TokenValue::While:
+            case TokenValue::Until:
+            case TokenValue::Repeat:
+            case TokenValue::Where:
+            case TokenValue::With:
+            case TokenValue::Add:
+            case TokenValue::Import:
+            case TokenValue::Return:
+            case TokenValue::From:
+            case TokenValue::Macro:
+            case TokenValue::Inline:
+            case TokenValue::Free:
+            case TokenValue::Export:
+            case TokenValue::Do:
+            case TokenValue::EqEq:
+            case TokenValue::ColonEq:
+            case TokenValue::Implies:
+            case TokenValue::MapsTo:
+            case TokenValue::FatArrow:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- Return true if the token terminates juxtaposition application.
+        //
+        //    In Boot, function application by juxtaposition (`f x`)
+        //    must not consume tokens that belong to an enclosing
+        //    context.  This classifier lists every token value that
+        //    ends a juxtaposition chain: infix operators, delimiters,
+        //    assignment/definition operators, formatting tokens,
+        //    keywords that start new clauses, and type operators.
+        bool terminates_juxtaposition(TokenValue v)
+        {
+            if (infix_operator(v))
+                return true;
+            switch (v)
+            {
+            case TokenValue::EndOfStream:
+            case TokenValue::Comma:
+            case TokenValue::Semicolon:
+            case TokenValue::CloseParen:
+            case TokenValue::CloseBracket:
+            case TokenValue::CloseBrace:
+            case TokenValue::CloseMetaParen:
+            case TokenValue::CloseMetaBracket:
+            case TokenValue::CloseMetaBrace:
+            case TokenValue::ColonEq:
+            case TokenValue::EqEq:
+            case TokenValue::Implies:
+            case TokenValue::MapsTo:
+            case TokenValue::LeftArrow:
+            case TokenValue::Then:
+            case TokenValue::Else:
+            case TokenValue::Where:
+            case TokenValue::Indent:
+            case TokenValue::Unindent:
+            case TokenValue::Justify:
+            case TokenValue::Is:
+            case TokenValue::Isnt:
+            case TokenValue::Has:
+            case TokenValue::By:
+            case TokenValue::In:
+            case TokenValue::Cross:
+            case TokenValue::Repeat:
+            case TokenValue::Catch:
+            case TokenValue::Finally:
+            case TokenValue::With:
+            case TokenValue::Colon:
+            case TokenValue::DotDot:
+            case TokenValue::ColonColon:
+            case TokenValue::At:
+            case TokenValue::RightArrow:
+            case TokenValue::Pretend:
+            case TokenValue::Add:
+            case TokenValue::FatArrow:
+            case TokenValue::Free:
+            case TokenValue::Export:
+            case TokenValue::From:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        // -- ParseError: diagnostic for syntax errors
+        struct ParseError : Diagnostics::BasicError {
+            LineNumber line;
+            ColumnIndex column;
+            explicit ParseError(const std::string& msg,
+                                LineNumber l = 0, ColumnIndex c = 0)
+                : BasicError(msg), line(l), column(c)
+            { }
+        };
+
+        // -- ParserState
+
+        // -- Central mutable state for the recursive-descent parser.
+        //
+        // The parser consumes a flat `vector<Token>` using a cursor
+        // (`position`).  Parsed sub-expressions are communicated
+        // between grammar rules via an explicit `stack` of NodeIndex
+        // values: a production pushes its result, and the caller pops
+        // it.  This avoids returning NodeIndex from every function
+        // (many productions are "bool: did we match?").
+        //
+        // Key fields:
+        //   `delimiter_depth` - nesting depth inside balanced
+        //       delimiters (parens, brackets, braces).  Used for
+        //       semantic decisions (e.g. `name == value` inside
+        //       parens is a default-value, not a definition).
+        //       The pile phase never emits formatting tokens inside
+        //       balanced delimiters, so this field has no formatting
+        //       role.
+        //   `forest` - arena allocator for AST nodes (SyntaxForest).
+        //
+        // Snapshot/restore: several grammar rules need tentative
+        // parsing (try one alternative, backtrack on failure).  The
+        // Snapshot struct captures the full parser state (position,
+        // stack depth, delimiter_depth) so it can be cheaply restored.
+        struct ParserState {
+            const std::vector<Token>& tokens;
+            std::uint32_t position;
+            int delimiter_depth;    // nesting depth inside ()[]{}
+            std::vector<NodeIndex> stack;
+            SyntaxForest& forest;
+            Language dialect;
+
+            ParserState(const std::vector<Token>& toks, SyntaxForest& f,
+                        Language lang = Language::Boot)
+                : tokens(toks), position(0), delimiter_depth(0),
+                  forest(f), dialect(lang)
+            { }
+
+            bool spad() const { return dialect == Language::Spad; }
+
+            const Token* current() const
+            {
+                if (position >= tokens.size())
+                    return nullptr;
+                return &tokens[position];
+            }
+
+            void advance()
+            {
+                if (position < tokens.size())
+                    ++position;
+            }
+
+            TokenIndex current_index() const
+            {
+                return TokenIndex(position);
+            }
+
+            // -- Peek at the value of the current token, skipping
+            //    whitespace and comments.  Formatting tokens
+            //    (Indent/Justify/Unindent) are always visible.
+            TokenValue peek_value();
+
+            bool match(TokenValue v);
+
+            TokenIndex require(TokenValue v, const std::string& context);
+
+            void push(NodeIndex n) { stack.push_back(n); }
+
+            NodeIndex pop();
+
+            struct Snapshot {
+                std::uint32_t position;
+                std::size_t stack_depth;
+                int delimiter_depth;
+            };
+
+            Snapshot save() const
+            {
+                return { position, stack.size(), delimiter_depth };
+            }
+
+            void restore(const Snapshot& s)
+            {
+                position = s.position;
+                stack.resize(s.stack_depth);
+                delimiter_depth = s.delimiter_depth;
+            }
+
+            NodeSpan make_span(const std::vector<NodeIndex>& nodes);
+        };
+
+        // -- RAII guard for delimiter_depth inside balanced delimiters.
+        struct DelimiterGuard {
+            ParserState& ps;
+            explicit DelimiterGuard(ParserState& p) : ps(p) { ++ps.delimiter_depth; }
+            ~DelimiterGuard() { --ps.delimiter_depth; }
+            DelimiterGuard(const DelimiterGuard&) = delete;
+            DelimiterGuard& operator=(const DelimiterGuard&) = delete;
+        };
+
+        TokenValue ParserState::peek_value()
+        {
+            while (auto t = current())
+            {
+                switch (t->category)
+                {
+                case TokenCategory::Whitespace:
+                case TokenCategory::Comment:
+                    advance();
+                    continue;
+                default:
+                    return t->value;
+                }
+            }
+            return TokenValue::EndOfStream;
+        }
+
+        bool ParserState::match(TokenValue v)
+        {
+            if (peek_value() == v)
+            {
+                advance();
+                return true;
+            }
+            return false;
+        }
+
+        TokenIndex ParserState::require(TokenValue v, const std::string& ctx)
+        {
+            auto idx = current_index();
+            if (not match(v))
+            {
+                auto t = current();
+                LineNumber ln = 0;
+                ColumnIndex col = 0;
+                std::string found_str = "<end>";
+                if (t != nullptr)
+                {
+                    ln = t->start.line;
+                    col = t->start.column;
+                    std::ostringstream oss;
+                    oss << t->value;
+                    found_str = oss.str();
+                }
+                throw ParseError("expected " + ctx
+                    + " but found " + found_str
+                    + " [at line " + std::to_string(ln)
+                    + ", col " + std::to_string(col) + "]", ln, col);
+            }
+            return idx;
+        }
+
+        NodeIndex ParserState::pop()
+        {
+            if (stack.empty())
+                return NodeIndex::none;
+            auto n = stack.back();
+            stack.pop_back();
+            return n;
+        }
+
+        NodeSpan ParserState::make_span(const std::vector<NodeIndex>& nodes)
+        {
+            auto span = forest.allocate_span(
+                static_cast<std::uint32_t>(nodes.size()));
+            for (std::uint32_t i = 0; i < nodes.size(); ++i)
+                forest.child(span, i) = nodes[i];
+            return span;
+        }
+
+        // -- Forward declarations
+        bool parse_comma(ParserState& ps);
+        bool parse_where(ParserState& ps);
+        bool parse_definition(ParserState& ps);
+        bool parse_assign(ParserState& ps);
+        bool parse_exit(ParserState& ps);
+        bool parse_statement(ParserState& ps);
+        bool parse_expression(ParserState& ps);
+        bool parse_logical(ParserState& ps);
+        bool parse_return_expr(ParserState& ps);
+        bool parse_and_expr(ParserState& ps);
+        bool parse_compare(ParserState& ps);
+        bool parse_is_expr(ParserState& ps);
+        bool parse_arith(ParserState& ps);
+        bool parse_times(ParserState& ps);
+        bool parse_euclid(ParserState& ps);
+        bool parse_minus(ParserState& ps);
+        bool parse_expt(ParserState& ps);
+        bool parse_typed(ParserState& ps);
+        void parse_typed_tail(ParserState& ps);
+        bool parse_application(ParserState& ps);
+        bool parse_primary(ParserState& ps);
+        bool parse_name(ParserState& ps);
+        bool parse_constant(ParserState& ps);
+        bool parse_construct(ParserState& ps);
+        static std::vector<NodeIndex> parse_collection_body(
+            ParserState& ps, TokenValue close_tok);
+        bool parse_conditional(ParserState& ps);
+        bool parse_loop(ParserState& ps);
+        bool parse_try_expr(ParserState& ps);
+        bool parse_variable(ParserState& ps);
+        bool parse_typing(ParserState& ps);
+        bool parse_reduce(ParserState& ps);
+        bool parse_module(ParserState& ps);
+        bool parse_import(ParserState& ps);
+        bool parse_namespace(ParserState& ps);
+        bool parse_case_expr(ParserState& ps);
+        bool parse_struct(ParserState& ps);
+        bool parse_semicolon(ParserState& ps);
+        bool parse_segment(ParserState& ps);
+        bool parse_signature_tail(ParserState& ps);
+        bool parse_sexp(ParserState& ps);
+        bool parse_pattern_item(ParserState& ps);
+        bool parse_pattern_list(ParserState& ps);
+        bool parse_iterators(ParserState& ps);
+        bool parse_definition_item(ParserState& ps);
+        bool parse_capsule(ParserState& ps);
+        bool parse_with_body(ParserState& ps);
+
+        // -- Combinator helpers
+
+        // -- Build an application node from fn (already popped)
+        //    and arg (just parsed and still on stack).
+        static void push_apply(ParserState& ps, NodeIndex fn)
+        {
+            auto arg = ps.pop();
+            std::vector<NodeIndex> args = { arg };
+            auto span = ps.make_span(args);
+            ps.push(ps.forest.make_apply({ fn, span }));
+        }
+
+        // -- Parse a comma-separated list.  Wraps in Tuple if > 1.
+        //    Used for both actual tuple expressions and parameter lists.
+        //    Single elements are returned unwrapped to avoid trivial
+        //    one-element tuples polluting the AST.
+        // -- Parse a separated list of items.
+        //
+        //    Parses one or more items separated by `separator`.
+        //    If only one item is parsed, it is returned as-is;
+        //    otherwise the items are wrapped using `make`.
+        //    When `justify` is SkipJustify, a Justify token after
+        //    the separator is silently consumed (needed for
+        //    semicolons inside brace blocks where line breaks
+        //    produce Justify).
+        enum class Justify : bool { Keep, Skip };
+
+        template<typename MakeFn>
+        bool parse_separated_list(ParserState& ps,
+                                  bool (*parser)(ParserState&),
+                                  TokenValue separator,
+                                  MakeFn make,
+                                  Justify justify = Justify::Keep)
+        {
+            if (not parser(ps))
+                return false;
+            std::vector<NodeIndex> elts;
+            elts.push_back(ps.pop());
+            while (ps.match(separator))
+            {
+                if (justify == Justify::Skip)
+                    ps.match(TokenValue::Justify);
+                if (not parser(ps))
+                    break;
+                elts.push_back(ps.pop());
+            }
+            if (elts.size() == 1)
+                ps.push(elts[0]);
+            else
+            {
+                auto span = ps.make_span(elts);
+                ps.push((ps.forest.*make)({ span }));
+            }
+            return true;
+        }
+
+        bool parse_tuple_of(ParserState& ps,
+                            bool (*parser)(ParserState&))
+        {
+            return parse_separated_list(ps, parser,
+                TokenValue::Comma, &SyntaxForest::make_tuple);
+        }
+
+        bool parse_semi_list(ParserState& ps,
+                             bool (*parser)(ParserState&))
+        {
+            return parse_separated_list(ps, parser,
+                TokenValue::Semicolon, &SyntaxForest::make_sequence,
+                Justify::Skip);
+        }
+
+        // -- Parse an indentation-delimited pile (off-side block).
+        //
+        //    A pile is a sequence of items at the same indentation
+        //    level, introduced by an Indent token and terminated by
+        //    the matching Unindent.  Individual items within the pile
+        //    are separated by Justify tokens (same-level line breaks).
+        //
+        //    The `parser` argument determines what constitutes one
+        //    item; typically `parse_semicolon` for top-level piles
+        //    or `parse_definition_item` for where-clause piles.
+        //
+        //    Boot example:
+        //      foo x ==
+        //        a := x + 1      <- Indent before 'a', Justify before 'b'
+        //        b := a * 2      <- Unindent after 'b' (back to foo's level)
+        //        b
+        //
+        //    If the pile contains a single item, it is returned
+        //    unwrapped (no Pile node).
+
+        // -- Skip balanced INDENT/UNINDENT pairs from deeper-indented
+        //    comment lines (++ documentation) and match `target` at
+        //    the original pile level.
+        //
+        //    In Spad, ++ comments often appear at deeper indentation
+        //    than the signatures they document, creating INDENT/UNINDENT
+        //    formatting tokens that sit between pile items.  This
+        //    helper skips those balanced pairs and looks for `target`
+        //    (either Justify or Unindent) at depth 0.
+        static bool skip_nested_comments_and_match(
+            ParserState& ps, TokenValue target)
+        {
+            if (ps.match(target))
+                return true;
+            auto snap = ps.save();
+            int depth = 0;
+            for (;;)
+            {
+                auto v = ps.peek_value();
+                if (v == TokenValue::Indent)
+                {
+                    ps.advance();
+                    ++depth;
+                    continue;
+                }
+                if (v == TokenValue::Unindent and depth > 0)
+                {
+                    ps.advance();
+                    --depth;
+                    continue;
+                }
+                if (v == TokenValue::Justify and depth > 0)
+                {
+                    ps.advance();
+                    continue;
+                }
+                if (v == target and depth == 0)
+                {
+                    ps.advance();
+                    return true;
+                }
+                break;
+            }
+            ps.restore(snap);
+            return false;
+        }
+
+        bool parse_pile(ParserState& ps,
+                               bool (*parser)(ParserState&))
+        {
+            if (not ps.match(TokenValue::Indent))
+                return false;
+            std::vector<NodeIndex> items;
+            if (parser(ps))
+                items.push_back(ps.pop());
+            while (skip_nested_comments_and_match(ps, TokenValue::Justify))
+            {
+                if (parser(ps))
+                    items.push_back(ps.pop());
+            }
+            skip_nested_comments_and_match(ps, TokenValue::Unindent);
+            if (items.empty())
+                return false;
+            if (items.size() == 1)
+                ps.push(items[0]);
+            else
+            {
+                auto span = ps.make_span(items);
+                ps.push(ps.forest.make_pile({ span }));
+            }
+            return true;
+        }
+
+        // -- Helper: check for continuation-line operator.
+        //
+        //    In Boot, an expression can continue on the next line if
+        //    the next line is indented more deeply.  The tokenizer
+        //    emits an Indent token for such continuations.  If the
+        //    Indent is followed by a binary operator, this function
+        //    consumes the Indent and returns true.  Otherwise the
+        //    save point is restored and the function returns false.
+        static bool skip_continuation_indent(ParserState& ps,
+                            bool (*is_op)(TokenValue))
+        {
+            if (ps.peek_value() != TokenValue::Indent)
+                return false;
+            auto snap = ps.save();
+            ps.advance();   // skip Indent
+            if (is_op(ps.peek_value()))
+                return true;   // leave Indent consumed
+            ps.restore(snap);
+            return false;
+        }
+
+        // -- Parse a left-associative binary operator chain.
+        //
+        //    Parses `sub { op sub }` where `op` is any token for
+        //    which the `is_op` predicate returns true.  Each pair
+        //    is folded into an Infix AST node, left-to-right.
+        //
+        //    Handles continuation lines: if an Indent token precedes
+        //    the operator, it is consumed (and the matching Unindent
+        //    is consumed after the RHS).
+        //
+        //    Handles continuation lines: if an Indent token precedes
+        //    the operator, it is consumed (and the matching Unindent
+        //    is consumed after the RHS).  When the Unindent cannot
+        //    be consumed immediately (e.g. `while a or\n  b repeat
+        //    body` where `repeat body` sits between the RHS and the
+        //    Unindent), the orphaned Indent is recorded in `scope`
+        //    so that the enclosing construct (e.g. parse_loop) can
+        //    drain it after the intervening tokens have been parsed.
+        //
+        //    Used for arithmetic (+, -, *, /, **, quo, rem),
+        //    logical connectives (and, or), and comparison.
+        bool parse_left_assoc(ParserState& ps,
+                              bool (*sub)(ParserState&),
+                              bool (*is_op)(TokenValue))
+        {
+            if (not sub(ps))
+                return false;
+            for (;;)
+            {
+                bool continuation = false;
+                if (is_op(ps.peek_value()))
+                    ;  // operator on same line
+                else if (skip_continuation_indent(ps, is_op))
+                    continuation = true;
+                else
+                    break;
+
+                auto op = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                if (not sub(ps))
+                {
+                    ps.push(lhs);
+                    break;
+                }
+                auto rhs = ps.pop();
+                ps.push(ps.forest.make_infix({ lhs, op, rhs }));
+                if (continuation)
+                    ps.match(TokenValue::Unindent);
+            }
+            return true;
+        }
+
+        // -- Parse a right-associative binary operator chain.
+        //
+        //    a ** b ** c  =>  Infix(a, **, Infix(b, **, c))
+        //
+        //    After parsing the first sub-expression and seeing an operator
+        //    that satisfies is_op, the RHS is parsed by recursing into
+        //    parse_right_assoc itself (not into sub), giving right grouping.
+        bool parse_right_assoc(ParserState& ps,
+                               bool (*sub)(ParserState&),
+                               bool (*is_op)(TokenValue))
+        {
+            if (not sub(ps))
+                return false;
+            bool continuation = false;
+            if (is_op(ps.peek_value()))
+                ;
+            else if (skip_continuation_indent(ps, is_op))
+                continuation = true;
+            else
+                return true;
+
+            auto op = ps.current_index();
+            ps.advance();
+            auto lhs = ps.pop();
+            if (not parse_right_assoc(ps, sub, is_op))
+            {
+                ps.push(lhs);
+                if (continuation)
+                    ps.match(TokenValue::Unindent);
+                return true;
+            }
+            auto rhs = ps.pop();
+            ps.push(ps.forest.make_infix({ lhs, op, rhs }));
+            if (continuation)
+                ps.match(TokenValue::Unindent);
+            return true;
+        }
+
+        // -- Parse a quoted S-expression: ' sexp.
+        //
+        //    Shared by parse_primary, parse_sexp, and parse_pattern_item.
+        bool parse_quote(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Apostrophe)
+                return false;
+            auto apos = ps.current_index();
+            ps.advance();
+            if (not parse_sexp(ps))
+                return false;
+            auto expr = ps.pop();
+            ps.push(ps.forest.make_quote({ apos, expr }));
+            return true;
+        }
+
+        // -- Parse a keyword-prefixed unary expression.
+        //
+        //    Pattern: keyword operand > make_X({ kw, operand })
+        //    Used for return, leave, throw, while, until, etc.
+        //
+        //    `Make` is a pointer-to-member for the forest node
+        //    constructor, allowing different AST node types to be
+        //    built with the same code shape.
+        template<typename Syntax>
+        bool parse_prefix_kw(ParserState& ps,
+                             bool (*sub)(ParserState&),
+                             NodeIndex (SyntaxForest::*make)(const Syntax&))
+        {
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not sub(ps))
+                return false;
+            auto val = ps.pop();
+            ps.push((ps.forest.*make)({ kw, val }));
+            return true;
+        }
+
+        // -- Parse a parenthesized expression: '(' content ')'.
+        //
+        //    The pile phase never emits formatting tokens inside
+        //    balanced delimiters, so no special suppression is needed.
+        //
+        //    If the content parser fails (e.g. empty parens), an
+        //    empty tuple node is synthesized rather than failing.
+        //    This matches Boot's treatment of `()` as unit/void.
+        bool parse_paren(ParserState& ps,
+                                bool (*parser)(ParserState&))
+        {
+            if (not ps.match(TokenValue::OpenParen))
+                return false;
+            DelimiterGuard delim(ps);
+            bool ok = parser(ps);
+            if (not ok)
+            {
+                ps.push(ps.forest.make_tuple({ ps.make_span({}) }));
+                ok = true;
+            }
+            ps.require(TokenValue::CloseParen, "')'");
+            return ok;
+        }
+
+        // -- Parse a bracketed expression: '[' content ']'.
+        //
+        //    The pile phase never emits formatting tokens inside
+        //    balanced delimiters.  Boot uses brackets for:
+        //      - List construction: [1, 2, 3]
+        //      - List comprehension: [x*x for x in 1..10]
+        //      - Pattern matching: x is [first, :rest]
+        //
+        //    Note: this is the generic bracket parser used by pattern
+        //    matching.  List construction with comprehensions uses
+        //    parse_construct() instead, which adds iterator support.
+        bool parse_bracket(ParserState& ps,
+                                  bool (*parser)(ParserState&))
+        {
+            auto open_idx = ps.current_index();
+            if (not ps.match(TokenValue::OpenBracket))
+                return false;
+            DelimiterGuard delim(ps);
+            std::vector<NodeIndex> elts;
+            if (parser(ps))
+                elts.push_back(ps.pop());
+            auto close_idx = ps.current_index();
+            ps.require(TokenValue::CloseBracket, "']'");
+            auto span = ps.make_span(elts);
+            ps.push(ps.forest.make_bracket({ open_idx, span, close_idx }));
+            return true;
+        }
+
+        // -- S-expression parser (for quoted expressions: '(...))
+        //
+        // Boot inherits Lisp-style quoting: the apostrophe ' followed
+        // by an S-expression produces a literal data structure.  This
+        // is used extensively in Boot for:
+        //   - Symbol literals: 'FOO, 'SPADCALL
+        //   - Association lists: '((a . 1) (b . 2))
+        //   - Code templates: '(PROGN ,x ,y)
+        //   - Dispatch tables: '((+ WIDTH sumWidth) ...)
+        //
+        // The S-expression grammar is separate from the main
+        // expression grammar.  Inside an S-expression, almost any
+        // token (including keywords and operators) is treated as an
+        // atom - only structural delimiters like parentheses and
+        // commas retain their role.
+        //
+        // The parser handles:
+        //   - Atoms: identifiers, numbers, strings, keywords, operators
+        //   - Nested quotes: ''x, '('a 'b)
+        //   - Parenthesized lists: '(a b c)
+        //   - Dotted pairs: '(a . b)
+        //   - Negative numbers: '(-1)
+
+        // -- Parse any token as an S-expression atom: identifier,
+        //    integer, float, string, or keyword used as symbol.
+        //    Returns false only for structural delimiters that would
+        //    terminate an enclosing S-expression list.
+        bool parse_sexp_atom(ParserState& ps)
+        {
+            auto t = ps.current();
+            if (t == nullptr)
+                return false;
+            switch (t->category)
+            {
+            case TokenCategory::Identifier:
+            case TokenCategory::Integer:
+            case TokenCategory::FloatingPoint:
+            case TokenCategory::String:
+            {
+                auto idx = ps.current_index();
+                ps.advance();
+                ps.push(ps.forest.make_name({ idx }));
+                return true;
+            }
+            case TokenCategory::Keyword:
+            case TokenCategory::Operator:
+            case TokenCategory::Punctuator:
+            {
+                // -- Accept keywords and operators as S-expression atoms,
+                // but exclude structural delimiters that terminate lists.
+                if (sexp_structural_delimiter(t->value))
+                    return false;
+                auto idx = ps.current_index();
+                ps.advance();
+                ps.push(ps.forest.make_name({ idx }));
+                return true;
+            }
+            default:
+                return false;
+            }
+        }
+
+        // -- Parse an S-expression: atom, or (sexp*), or 'sexp.
+        bool parse_sexp(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            // -- Negative integer literal: - INTEGER → single atom.
+            // The lexer produces two tokens; S-expression semantics
+            // require them to be one (e.g. in dotted pairs like
+            // '(0 . -1)).  If the minus is not followed by an
+            // integer, fall through to parse_sexp_atom which
+            // accepts '-' as a plain operator atom.
+            if (v == TokenValue::Minus)
+            {
+                auto snap = ps.save();
+                auto op = ps.current_index();
+                ps.advance();
+                auto t = ps.current();
+                if (t != nullptr and t->category == TokenCategory::Integer)
+                {
+                    auto num = ps.current_index();
+                    ps.advance();
+                    auto operand = ps.forest.make_literal({ num });
+                    ps.push(ps.forest.make_prefix({ op, operand }));
+                    return true;
+                }
+                ps.restore(snap);
+            }
+            // -- Nested quote.
+            if (v == TokenValue::Apostrophe)
+                return parse_quote(ps);
+            // -- Parenthesized S-expression list.
+            if (v == TokenValue::OpenParen)
+            {
+                ps.advance();
+                DelimiterGuard delim(ps);
+                std::vector<NodeIndex> items;
+                while (parse_sexp(ps))
+                    items.push_back(ps.pop());
+                // -- Check for dotted pair: (a . b).
+                if (ps.match(TokenValue::Dot))
+                {
+                    if (parse_sexp(ps))
+                        items.push_back(ps.pop());
+                }
+                ps.require(TokenValue::CloseParen, "')' in S-expression");
+                auto span = ps.make_span(items);
+                ps.push(ps.forest.make_tuple({ span }));
+                return true;
+            }
+            return parse_sexp_atom(ps);
+        }
+
+        // -- Atom parsers
+
+        // -- Parse a simple identifier name.
+        //
+        //    In addition to TokenCategory::Identifier, this also
+        //    accepts the keyword `rule` as a name.  The `rule`
+        //    keyword is defined in the token vocabulary as a Boot
+        //    keyword, but no Boot grammar rule uses it as a keyword;
+        //    it appears only as a plain identifier in Boot source.
+        //    Accepting it here avoids tokenizer-level changes while
+        //    correctly parsing all Boot files.
+        bool parse_name(ParserState& ps)
+        {
+            if (ps.peek_value() == TokenValue::EndOfStream)
+                return false;
+            auto t = ps.current();
+            if (t == nullptr)
+                return false;
+            // -- Accept identifiers and keywords that are not used in Boot
+            // grammar but may appear as names in user code (e.g. 'rule').
+            if (t->category == TokenCategory::Identifier
+                or t->value == TokenValue::Rule
+                or t->value == TokenValue::Break
+                or t->value == TokenValue::Dollar)
+            {
+                auto idx = ps.current_index();
+                ps.advance();
+                ps.push(ps.forest.make_name({ idx }));
+                return true;
+            }
+            // -- In Spad, many keywords and operators can appear as
+            // operation names (e.g. `cross: (%,%) -> %`, `case`,
+            // `not`, `quo`, `mod`, etc.).  Accept them as names
+            // unless they are structural keywords that the parser
+            // relies on for delimiting constructs.
+            if (ps.spad()
+                and (t->category == TokenCategory::Keyword
+                     or t->category == TokenCategory::Operator))
+            {
+                if (spad_structural_keyword(t->value))
+                    return false;
+                auto idx = ps.current_index();
+                ps.advance();
+                ps.push(ps.forest.make_name({ idx }));
+                return true;
+            }
+            return false;
+        }
+
+        // -- Parse a literal constant (integer, float, or string).
+        bool parse_constant(ParserState& ps)
+        {
+            auto t = ps.current();
+            if (t == nullptr)
+                return false;
+            switch (t->category)
+            {
+            case TokenCategory::Integer:
+            case TokenCategory::FloatingPoint:
+            case TokenCategory::String:
+            {
+                auto idx = ps.current_index();
+                ps.advance();
+                ps.push(ps.forest.make_literal({ idx }));
+                return true;
+            }
+            default:
+                return false;
+            }
+        }
+
+        // -- Parse a dot (don't-care placeholder).
+        bool parse_dot(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Dot)
+                return false;
+            auto idx = ps.current_index();
+            ps.advance();
+            ps.push(ps.forest.make_name({ idx }));
+            return true;
+        }
+
+        // -- Primary expressions
+
+        // -- Parse a primary expression (highest precedence).
+        //
+        //    A primary is the tightest-binding syntactic unit.  It
+        //    includes:
+        //      'sexp         - quoted S-expression (data literal)
+        //      (expr)        - parenthesized grouping
+        //      [elts]        - bracket construction / list literal
+        //      .             - don't-care / wildcard
+        //      #expr, -expr, ~expr - prefix operators
+        //      leave expr    - early exit (tight binding variant used
+        //                      inside comprehensions, e.g.
+        //                      or/[... and leave x for ...])
+        //      if/case/structure/function - keyword constructs
+        //      Indent...     - an indented pile as a primary
+        //      namespace nm  - namespace reference
+        //      name, literal - identifiers and constants
+        //
+        //    `leave` appears at two precedence levels in Boot:
+        //      1. In parse_return_expr (loose binding): `leave expr`
+        //         as a statement, where expr can be a full logical.
+        //      2. Here in parse_primary (tight binding): `leave x`
+        //         as a primary, where x is a single primary.  This
+        //         is used inside `and` chains in comprehension guards.
+        bool parse_primary(ParserState& ps)
+        {
+            
+            auto v = ps.peek_value();
+
+            // -- Quoted S-expression: 'sexp.
+            if (v == TokenValue::Apostrophe)
+                return parse_quote(ps);
+
+            // -- Parenthesized expression.
+            if (v == TokenValue::OpenParen)
+                return parse_paren(ps, parse_semicolon);
+
+            // -- Bracket construction: [elements].
+            if (v == TokenValue::OpenBracket)
+                return parse_construct(ps);
+
+            // -- Spad delimited constructions: {}, [||], (||).
+            // All share the same structure: open, parse content,
+            // close, wrap in a Bracket node.
+            if (ps.spad())
+            {
+                auto delim_close = TokenValue::EndOfStream;
+                const char* close_name = nullptr;
+                bool use_collection_body = false;
+                if (v == TokenValue::OpenBrace)
+                {
+                    delim_close = TokenValue::CloseBrace;
+                    close_name = "'}'";
+                    use_collection_body = true;
+                }
+                else if (v == TokenValue::OpenMetaBracket)
+                {
+                    delim_close = TokenValue::CloseMetaBracket;
+                    close_name = "'|]'";
+                }
+                else if (v == TokenValue::OpenMetaParen)
+                {
+                    delim_close = TokenValue::CloseMetaParen;
+                    close_name = "'|)'";
+                }
+                if (close_name != nullptr)
+                {
+                    auto open = ps.current_index();
+                    ps.advance();
+                    DelimiterGuard delim(ps);
+                    std::vector<NodeIndex> elts;
+                    if (use_collection_body)
+                        elts = parse_collection_body(ps, delim_close);
+                    else if (parse_comma(ps))
+                        elts.push_back(ps.pop());
+                    auto close = ps.current_index();
+                    ps.require(delim_close, close_name);
+                    auto span = ps.make_span(elts);
+                    ps.push(ps.forest.make_bracket({ open, span, close }));
+                    return true;
+                }
+            }
+
+            // -- Dot (don't-care or field accessor).
+            if (v == TokenValue::Dot)
+                return parse_dot(ps);
+
+            // -- Prefix operator.
+            if (prefix_operator(v))
+                return parse_prefix_kw(ps, parse_primary,
+                                       &SyntaxForest::make_prefix);
+
+            // -- Leave: prefix unary in expression context (e.g. inside
+            // comprehension bodies: or/[... and leave x for ...]).
+            if (v == TokenValue::Leave)
+                return parse_prefix_kw(ps, parse_primary,
+                                       &SyntaxForest::make_leave);
+
+            // -- Keyword-initiated expressions.
+            switch (v)
+            {
+            case TokenValue::If:
+                return parse_conditional(ps);
+            case TokenValue::Case:
+                return parse_case_expr(ps);
+            case TokenValue::Structure:
+                return parse_struct(ps);
+            case TokenValue::Function:
+            {
+                ps.advance();
+                if (not parse_primary(ps))
+                    return false;
+                return true;
+            }
+            default:
+                break;
+            }
+
+            // -- A pile as primary.
+            if (v == TokenValue::Indent)
+                return parse_pile(ps, parse_semicolon);
+
+            // -- Namespace expression: namespace name.
+            if (v == TokenValue::Namespace)
+                return parse_namespace(ps);
+
+            // -- Spad: prefix 'with' - category definition.
+            if (v == TokenValue::With)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                if (not parse_with_body(ps))
+                    throw ParseError("expected body after 'with'");
+                auto body = ps.pop();
+                ps.push(ps.forest.make_with({ kw, body }));
+                return true;
+            }
+
+            // -- Spad: prefix 'add' - domain implementation.
+            if (v == TokenValue::Add)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                if (not parse_capsule(ps))
+                    throw ParseError("expected body after 'add'");
+                auto body = ps.pop();
+                ps.push(ps.forest.make_add({ kw, body }));
+                return true;
+            }
+
+            // -- Spad: 'free' declaration.
+            if (v == TokenValue::Free)
+                return parse_prefix_kw(ps, parse_expression,
+                                       &SyntaxForest::make_free_decl);
+
+            // -- Spad: 'export' declaration.
+            if (v == TokenValue::Export)
+                return parse_prefix_kw(ps, parse_expression,
+                                       &SyntaxForest::make_export_decl);
+
+            // -- Name or literal.
+            if (parse_name(ps))
+                return true;
+            if (parse_constant(ps))
+                return true;
+
+            return false;
+        }
+
+        // -- Application
+
+        // -- Parse function application: primary { selector | arg }.
+        //
+        //    Boot and Spad have three forms of function application:
+        //
+        //    1. Dot selector: `expr.name` or `expr.` (suffix dot)
+        //       Field access or qualified name lookup.
+        //
+        //    2. Parenthesized arguments: `f(x, y)`
+        //       Traditional function call notation.  The content
+        //       inside parens is parsed by parse_semicolon, which
+        //       means semicolons are valid separators (used in
+        //       multi-value expressions like `coreQuit(x > 0 => 1; 0)`).
+        //
+        //    3. Juxtaposition: `f x`
+        //       Argument by adjacency.  The parser must be careful
+        //       NOT to grab tokens that belong to an outer context
+        //       (infix operators, keywords, formatting tokens, etc.).
+        //       The large exclusion list below enumerates all tokens
+        //       that terminate juxtaposition.
+        //
+        //    Dot and parenthesized application are left-associative;
+        //    juxtaposition is right-associative:
+        //      `f.g(x).h` = (((f.g)(x)).h)
+        //      `f x y z`  = f(x(y(z)))
+        //
+        //    For (2) and (3), the parser uses tentative parsing with
+        //    save/restore: if the attempted parse fails, the state
+        //    is rewound and the loop breaks.
+        bool parse_application(ParserState& ps)
+        {
+            if (not parse_primary(ps))
+                return false;
+
+            for (;;)
+            {
+                auto v = ps.peek_value();
+
+                // -- Dot selector: expr.name or expr. (suffix dot).
+                if (v == TokenValue::Dot)
+                {
+                    auto dot = ps.current_index();
+                    ps.advance();
+                    auto base = ps.pop();
+                    if (parse_primary(ps))
+                    {
+                        auto selector = ps.pop();
+                        ps.push(ps.forest.make_infix({ base, dot, selector }));
+                    }
+                    else
+                    {
+                        ps.push(ps.forest.make_suffix_dot({ base, dot }));
+                    }
+                    continue;
+                }
+
+                // -- Parenthesized argument list: f(args).
+                if (v == TokenValue::OpenParen)
+                {
+                    auto snap = ps.save();
+                    auto fn = ps.pop();
+                    if (parse_paren(ps, parse_semicolon))
+                    {
+                        push_apply(ps, fn);
+                        continue;
+                    }
+                    ps.restore(snap);
+                    ps.push(fn);
+                    break;
+                }
+
+                // -- Juxtaposition application: f x y => f(x(y)).
+                // Right-associative: collect primaries iteratively
+                // then fold right-to-left to avoid deep recursion.
+                if (not terminates_juxtaposition(v))
+                {
+                    auto snap = ps.save();
+                    auto fn = ps.pop();
+
+                    // -- Try to parse one primary as the start of the
+                    // juxtaposed argument chain.
+                    if (not parse_primary(ps))
+                    {
+                        ps.restore(snap);
+                        ps.push(fn);
+                        break;
+                    }
+
+                    // -- Collect additional juxtaposed primaries
+                    // iteratively (each may also have dot/paren
+                    // suffixes, so we parse full "applicative"
+                    // primaries via the dot/paren loop above by
+                    // re-entering the for loop for those cases).
+                    // Here we only handle the "more juxtaposed
+                    // primaries" part without recursion.
+                    std::vector<NodeIndex> chain;
+                    chain.push_back(fn);
+                    chain.push_back(ps.pop());
+
+                    for (;;)
+                    {
+                        auto v2 = ps.peek_value();
+                        // -- Handle dot and paren for the last
+                        // collected primary before checking for
+                        // more juxtaposed primaries.
+                        if (v2 == TokenValue::Dot)
+                        {
+                            auto dot = ps.current_index();
+                            ps.advance();
+                            auto base = chain.back();
+                            if (parse_primary(ps))
+                            {
+                                auto sel = ps.pop();
+                                chain.back() = ps.forest.make_infix(
+                                    { base, dot, sel });
+                            }
+                            else
+                            {
+                                chain.back() = ps.forest.make_suffix_dot(
+                                    { base, dot });
+                            }
+                            continue;
+                        }
+                        if (v2 == TokenValue::OpenParen)
+                        {
+                            auto snap2 = ps.save();
+                            auto fn2 = chain.back();
+                            if (parse_paren(ps, parse_semicolon))
+                            {
+                                push_apply(ps, fn2);
+                                chain.back() = ps.pop();
+                                continue;
+                            }
+                            ps.restore(snap2);
+                            break;
+                        }
+                        if (terminates_juxtaposition(v2))
+                            break;
+                        auto snap2 = ps.save();
+                        if (not parse_primary(ps))
+                        {
+                            ps.restore(snap2);
+                            break;
+                        }
+                        chain.push_back(ps.pop());
+                    }
+
+                    // -- Fold right-to-left: f x y z => f(x(y(z)))
+                    // but z is just z, y(z), x(y(z)), f(x(y(z))).
+                    auto result = chain.back();
+                    for (auto i = chain.size() - 1; i-- > 0; )
+                    {
+                        ps.push(result);
+                        push_apply(ps, chain[i]);
+                        result = ps.pop();
+                    }
+                    ps.push(result);
+                    return true;
+                }
+                break;
+            }
+            return true;
+        }
+
+        // -- Type expressions
+
+        // -- Parse a type annotation (right-hand side of : or @).
+        //
+        //    This is the grammar for type expressions that appear
+        //    after type annotation operators (:, ::, @).  It is
+        //    separate from the main expression grammar because type
+        //    syntax allows `->` for function types:
+        //      (int, int) -> int
+        //      forall T . T -> T
+        //
+        //    The `forall` quantifier binds variables before a dot,
+        //    then the body is a recursive call to parse_typing.
+        //    The `->` for function types is only parsed here, not
+        //    in the main expression chain, because in expression
+        //    context `->` has a different role (see parse_typed).
+        bool parse_typing(ParserState& ps)
+        {
+            if (ps.peek_value() == TokenValue::Forall)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                std::vector<NodeIndex> vars;
+                while (parse_variable(ps))
+                    vars.push_back(ps.pop());
+                auto dot = ps.require(TokenValue::Dot, "'.' in forall");
+                if (not parse_typing(ps))
+                    throw ParseError("expected type after 'forall ... .'");
+                auto body = ps.pop();
+                auto span = ps.make_span(vars);
+                ps.push(ps.forest.make_forall({ kw, span, dot, body }));
+                return true;
+            }
+            if (not parse_application(ps))
+                return false;
+            if (ps.peek_value() == TokenValue::RightArrow)
+            {
+                auto arrow = ps.current_index();
+                ps.advance();
+                auto source = ps.pop();
+                std::vector<NodeIndex> src_list = { source };
+                auto src_span = ps.make_span(src_list);
+                if (not parse_application(ps))
+                    throw ParseError("expected return type after '->'");
+                auto target = ps.pop();
+                ps.push(ps.forest.make_mapping({ src_span, arrow, target }));
+            }
+            return true;
+        }
+
+        // -- Parse a typed expression: application [@ T | :: T | : T | -> T].
+        //
+        //    Boot supports four postfix type operators on expressions:
+        //
+        //      expr @ Type     - domain restriction (restrict)
+        //      expr :: Type    - coercion to Type (coerce)
+        //      expr : Type     - type signature (annotate)
+        //      expr -> Type    - function type in expression context
+        //
+        //    These all bind tighter than arithmetic but looser than
+        //    application.  They left-associate, so `a : T @ S` means
+        //    `(a : T) @ S`.
+        //
+        //    The `->` case is right-associative (parsed via recursive
+        //    call to parse_typed) because function types nest on the
+        //    right: `A -> B -> C` means `A -> (B -> C)`.
+        //
+        //    Note the distinction between `->` in parse_typing
+        //    (appears after : or @, in a pure type context) and
+        //    `->` here (appears in expression context, e.g. in
+        //    module export signatures like:
+        //      every?: (%Thing -> %Thing, %List %Thing) -> %Thing
+        //    The parenthesized part is parsed by parse_typed because
+        //    it appears as a regular expression inside parens).
+        // -- Helper: parse a postfix type operator.
+        //    Pops the LHS from the stack, parses the RHS with `rhs_parser`,
+        //    and pushes a ternary AST node built by `make`.
+        template<typename MakeFn>
+        static void parse_postfix_type_op(
+            ParserState& ps,
+            bool (*rhs_parser)(ParserState&),
+            MakeFn make,
+            const char* error_msg)
+        {
+            auto op = ps.current_index();
+            ps.advance();
+            auto lhs = ps.pop();
+            if (not rhs_parser(ps))
+                throw ParseError(error_msg);
+            auto rhs = ps.pop();
+            ps.push((ps.forest.*make)({ lhs, op, rhs }));
+        }
+
+        // -- Apply postfix type operators to an already-parsed operand.
+        //
+        //    Assumes the operand is already on the stack.  Handles
+        //    the same operators as parse_typed: @, ::, :, ->, pretend.
+        //    Factored out so that parse_times can call it after a
+        //    reduce expression, matching the old Pratt parser's
+        //    behaviour where a Nud-produced reduction feeds into the
+        //    Led loop for these operators.
+        void parse_typed_tail(ParserState& ps)
+        {
+            for (;;)
+            {
+                auto v = ps.peek_value();
+                if (v == TokenValue::At)
+                {
+                    parse_postfix_type_op(ps, parse_typing,
+                        &SyntaxForest::make_restrict,
+                        "expected type after '@'");
+                    continue;
+                }
+                if (v == TokenValue::ColonColon)
+                {
+                    parse_postfix_type_op(ps, parse_typing,
+                        &SyntaxForest::make_coerce,
+                        "expected type after '::'");
+                    continue;
+                }
+                if (v == TokenValue::Colon)
+                {
+                    parse_postfix_type_op(ps, parse_typing,
+                        &SyntaxForest::make_signature,
+                        "expected type after ':'");
+                    continue;
+                }
+                if (v == TokenValue::RightArrow)
+                {
+                    parse_postfix_type_op(ps, parse_typed,
+                        &SyntaxForest::make_infix,
+                        "expected type after '->'");
+                    continue;
+                }
+                if (v == TokenValue::Pretend)
+                {
+                    parse_postfix_type_op(ps, parse_application,
+                        &SyntaxForest::make_pretend,
+                        "expected type after 'pretend'");
+                    continue;
+                }
+                break;
+            }
+        }
+
+        bool parse_typed(ParserState& ps)
+        {
+            if (not parse_application(ps))
+                return false;
+            parse_typed_tail(ps);
+            return true;
+        }
+
+        // -- Try to parse ': type' signature tail.
+        //
+        //    Called after a name has been parsed, when we see a
+        //    colon that might introduce a type annotation.  Pops
+        //    the name from the stack, parses the type, and pushes
+        //    a Signature node (name : type).
+        //
+        //    Used in both parameter declarations (parse_variable)
+        //    and catch clauses (parse_try_expr).
+        bool parse_signature_tail(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Colon)
+                return false;
+            parse_postfix_type_op(ps, parse_typing,
+                &SyntaxForest::make_signature,
+                "expected type after ':'");
+            return true;
+        }
+
+        // -- Arithmetic
+        //
+        // The arithmetic operators follow standard mathematical
+        // precedence (tightest to loosest):
+        //   **         - exponentiation (right-associative)
+        //   *, /       - multiplication, division
+        //   quo, rem   - Euclidean quotient and remainder
+        //   unary -    - negation
+        //   +, -       - addition, subtraction
+        //
+        // Additionally, the reduce operator (e.g. +/[...]) is parsed
+        // at the same level as *.  A reduce expression like +/[x for ...]
+        // means "fold + over the list comprehension".
+
+        // -- Parse exponentiation: typed ** typed ** ... (right-associative).
+        bool parse_expt(ParserState& ps)
+        {
+            return parse_right_assoc(ps, parse_typed, exponentiation_operator);
+        }
+
+        // -- Parse reduce: op / collection.
+        //
+        //    A reduce expression folds a binary operator over a
+        //    collection.  The operator comes first, then '/', then
+        //    either a bracket construction or an application:
+        //      +/[x for x in 1..10]    - sum of 1 to 10
+        //      or/[p x for x in l]     - any element satisfies p?
+        //      #/args                  - length of args
+        //
+        //    The operator can be any infix or prefix operator
+        //    (checked by reduce_operator).  Parsing is tentative: if
+        //    the '/' does not follow the operator, we backtrack.
+        bool parse_reduce(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (not reduce_operator(v))
+                return false;
+            auto snap = ps.save();
+            auto op_idx = ps.current_index();
+            ps.advance();
+            if (ps.peek_value() != TokenValue::Slash)
+            {
+                ps.restore(snap);
+                return false;
+            }
+            auto slash = ps.current_index();
+            ps.advance();
+            auto op_node = ps.forest.make_name({ op_idx });
+            if (not parse_construct(ps) and not parse_application(ps))
+                throw ParseError("expected collection after reduce operator");
+            auto body = ps.pop();
+            ps.push(ps.forest.make_reduce({ op_node, slash, body }));
+            return true;
+        }
+
+        // -- Parse multiplication/division: expt { (* | /) expt }.
+        //    Also tries reduce (op/collection) first.
+        //
+        //    In the old Pratt parser, a reduction like `+/[...]` is
+        //    a Nud form: after it is parsed, the Led loop handles
+        //    postfix operators (`@`, `::`) and binary operators (`*`)
+        //    at their normal binding powers.  Here we emulate this:
+        //    after a successful reduce, run the typed-postfix loop
+        //    (for `@`, `::`, `:`, `pretend`) then continue with the
+        //    `*`/`/` chain so that `*/[...] * expr` and
+        //    `+/[...]@Type` both work.
+        bool parse_times(ParserState& ps)
+        {
+            if (not parse_reduce(ps))
+                return parse_left_assoc(ps, parse_expt, multiplicative_operator);
+            // -- Reduce succeeded — apply the same postfix type
+            // operators that parse_typed would apply.
+            parse_typed_tail(ps);
+            // -- Now continue with the * / chain.
+            for (;;)
+            {
+                if (not multiplicative_operator(ps.peek_value()))
+                    break;
+                auto op = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                if (not parse_expt(ps))
+                {
+                    ps.push(lhs);
+                    break;
+                }
+                auto rhs = ps.pop();
+                ps.push(ps.forest.make_infix({ lhs, op, rhs }));
+            }
+            return true;
+        }
+
+        // -- Parse Euclidean division: times { (quo | rem) times }.
+        bool parse_euclid(ParserState& ps)
+        {
+            return parse_left_assoc(ps, parse_times, euclidean_operator);
+        }
+
+        // -- Parse unary minus: ['-'] euclid.
+        bool parse_minus(ParserState& ps)
+        {
+            if (ps.peek_value() == TokenValue::Minus)
+                return parse_prefix_kw(ps, parse_euclid,
+                                       &SyntaxForest::make_prefix);
+            return parse_euclid(ps);
+        }
+
+        // -- Parse addition/subtraction: minus { (+ | -) minus }.
+        bool parse_arith(ParserState& ps)
+        {
+            return parse_left_assoc(ps, parse_minus, additive_operator);
+        }
+
+        // -- Segments
+        //
+        // A segment is a range expression using `..`:
+        //
+        //   1..10       - bounded range from 1 to 10
+        //   n..         - unbounded range starting at n
+        //
+        // Segments appear in for-loop iterators (for i in 1..n)
+        // and in list comprehensions ([x for x in 0..9]).
+        // The bounded form has both endpoints; the unbounded form
+        // has only a start.
+
+        // -- Parse: arith [.. [arith]].
+        bool parse_segment(ParserState& ps)
+        {
+            if (not parse_arith(ps))
+                return false;
+            if (ps.peek_value() == TokenValue::DotDot)
+            {
+                auto dots = ps.current_index();
+                ps.advance();
+                auto lo = ps.pop();
+                if (parse_arith(ps))
+                {
+                    auto hi = ps.pop();
+                    ps.push(ps.forest.make_bounded_segment({ lo, dots, hi }));
+                }
+                else
+                {
+                    ps.push(ps.forest.make_unbounded_segment({ lo, dots }));
+                }
+            }
+            return true;
+        }
+
+        // -- Pattern matching
+        //
+        // Boot has ML-style pattern matching via `is` and `isnt`:
+        //   x is [first, :rest]     - destructure a list
+        //   x isnt [.,:.] => ...    - guard: x is not a pair
+        //   f x is ['SPADCALL, =arg, n, ...] - match a specific shape
+        //
+        // Patterns differ from expressions:
+        //   =expr       - equality test: match if the value equals expr
+        //   :rest       - rest binding: bind remaining list elements
+        //   name := pat - bind-and-match: bind name while matching pat
+        //   name::name  - qualified symbol: e.g. KEYWORD::RELATIVE
+        //   [p1, p2, :r] - list destructuring
+        //   .           - don't-care (wildcard)
+        //   'SYMBOL     - quoted symbol literal
+        //   "string"    - string literal match
+        //
+        // The `is`/`isnt` keywords use nesting suppression to handle
+        // patterns that start on the next line:
+        //   argl.(sharpPosition-1) is
+        //     ['SPADCALL, =sharpArg, n, ...]
+        // Here the Indent before '[' would normally start a pile, but
+        // inside the nesting-suppressed region it is skipped.
+
+        // -- Parse a pattern item: =expr | :rest | . | name | constant
+        //    | [pattern-list].
+        bool parse_pattern_item(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            // -- Equality pattern: =expr.
+            if (v == TokenValue::Eq)
+            {
+                auto eq = ps.current_index();
+                ps.advance();
+                if (not parse_application(ps) and not parse_constant(ps))
+                    return false;
+                auto expr = ps.pop();
+                ps.push(ps.forest.make_equal_pattern({ eq, expr }));
+                return true;
+            }
+            // -- Colon pattern: :rest.
+            if (v == TokenValue::Colon)
+            {
+                auto colon = ps.current_index();
+                ps.advance();
+                if (parse_pattern_item(ps))
+                {
+                    auto rest = ps.pop();
+                    // -- Wrap as ColonAppend with empty head.
+                    ps.push(ps.forest.make_colon_append(
+                        { ps.make_span({}), colon, rest }));
+                }
+                else
+                {
+                    // -- Bare colon - treat as don't-care rest.
+                    ps.push(ps.forest.make_name({ colon }));
+                }
+                return true;
+            }
+            // -- Bracket pattern: [items].
+            if (v == TokenValue::OpenBracket)
+                return parse_bracket(ps, parse_pattern_list);
+            // -- Dot (don't-care).
+            if (v == TokenValue::Dot)
+                return parse_dot(ps);
+            // -- Quoted symbol.
+            if (v == TokenValue::Apostrophe)
+                return parse_quote(ps);
+            // -- String constant in pattern context.
+            if (parse_constant(ps))
+                return true;
+            // -- Name, possibly followed by :: qualifier or := binding.
+            if (parse_name(ps))
+            {
+                // -- Qualified name: PKG::SYM (e.g. KEYWORD::RELATIVE).
+                if (ps.peek_value() == TokenValue::ColonColon)
+                {
+                    auto cc = ps.current_index();
+                    ps.advance();
+                    auto pkg = ps.pop();
+                    if (parse_name(ps))
+                    {
+                        auto sym = ps.pop();
+                        ps.push(ps.forest.make_coerce({ pkg, cc, sym }));
+                    }
+                    else
+                    {
+                        ps.push(pkg);
+                    }
+                }
+                // -- Pattern binding: name := pattern (bind and match).
+                if (ps.peek_value() == TokenValue::ColonEq)
+                {
+                    auto ceq = ps.current_index();
+                    ps.advance();
+                    auto name = ps.pop();
+                    if (not parse_pattern_item(ps))
+                        return true;
+                    auto pat = ps.pop();
+                    ps.push(ps.forest.make_assignment({ name, ceq, pat }));
+                }
+                return true;
+            }
+            return false;
+        }
+
+        // -- Parse a comma-separated pattern list with optional
+        //    colon-append at the end: item, item, ..., :rest.
+        //
+        //    Produces a Tuple node when there are multiple items,
+        //    or a single pattern node otherwise.  Used inside
+        //    bracketed patterns: [first, second, :rest].
+        bool parse_pattern_list(ParserState& ps)
+        {
+            return parse_tuple_of(ps, parse_pattern_item);
+        }
+
+        // -- Parse is/isnt: segment [ (is|isnt) pattern | has expr ].
+        //
+        //    The `is` and `isnt` operators test whether a value
+        //    matches a structural pattern.  They bind tighter than
+        //    comparison operators but looser than segment expressions.
+        //
+        //    `has` tests for trait/category membership:
+        //      T has Ring   - does T have the Ring trait?
+        bool parse_is_expr(ParserState& ps)
+        {
+            if (not parse_segment(ps))
+                return false;
+            auto v = ps.peek_value();
+            if (v == TokenValue::Is or v == TokenValue::Isnt)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                auto expr = ps.pop();
+                // -- In Boot, `is` is destructuring: `x is [first, :rest]`.
+                // In Spad, `is` also tests multi-word type expressions
+                // via juxtaposition (e.g. `S is Polynomial Integer`
+                // means `S is Polynomial(Integer)`).
+                bool ok = ps.spad()
+                    ? parse_application(ps)
+                    : parse_pattern_item(ps);
+                if (not ok)
+                {
+                    ps.push(expr);
+                    return true;
+                }
+                auto pat = ps.pop();
+                if (v == TokenValue::Is)
+                    ps.push(ps.forest.make_is({ expr, kw, pat }));
+                else
+                    ps.push(ps.forest.make_isnt({ expr, kw, pat }));
+            }
+            else if (v == TokenValue::Has)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                auto expr = ps.pop();
+                if (not parse_application(ps))
+                    return true;
+                // -- Handle signature attribute: `T has name: Type`.
+                parse_signature_tail(ps);
+                auto trait = ps.pop();
+                ps.push(ps.forest.make_infix({ expr, kw, trait }));
+            }
+            return true;
+        }
+
+        // -- Comparison and logic
+        //
+        // Comparison operators (=, ~=, <, <=, >, >=) are non-
+        // associative: `a < b < c` is a syntax error; use
+        // `a < b and b < c`.  The keyword `in` is also handled
+        // here as a comparison (membership test: `x in collection`).
+        //
+        // Conjunction (`and`) and disjunction (`or`) are the standard
+        // logical connectives, with `and` binding tighter.
+
+        // -- Parse comparison: is_expr [ comp_op is_expr ].
+        //    Non-associative: at most one operator is consumed.
+        bool parse_compare(ParserState& ps)
+        {
+            return parse_left_assoc(ps, parse_is_expr, comparison_or_in_operator);
+        }
+
+        // -- Parse conjunction: compare { and compare }.
+        bool parse_and_expr(ParserState& ps)
+        {
+            return parse_left_assoc(ps, parse_compare, conjunction_operator);
+        }
+
+        // -- Control flow expressions
+        //
+        // Boot has several control-flow keywords that appear at the
+        // expression level (between logical operators and conditionals):
+        //
+        //   return expr   - return from the enclosing function
+        //   leave expr    - exit from the enclosing loop (like `break`)
+        //   throw expr    - raise an exception
+        //   do statement  - execute a statement for its side effects
+        //
+        // These all parse their operand at a specific precedence level:
+        //   - `return` takes a full assignment (loosest in this group)
+        //   - `leave` takes a logical expression
+        //   - `throw` takes an application (tight binding)
+        //   - `do` takes a statement
+
+        // -- Parse return/leave/throw, or fall through to and_expr.
+        bool parse_return_expr(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::Return)
+                return parse_prefix_kw(ps, parse_assign,
+                                       &SyntaxForest::make_return);
+            if (v == TokenValue::Leave)
+                return parse_prefix_kw(ps, parse_logical,
+                                       &SyntaxForest::make_leave);
+            if (v == TokenValue::Throw)
+                return parse_prefix_kw(ps, parse_application,
+                                       &SyntaxForest::make_throw);
+            // -- 'in namespace X do body': evaluate body in namespace X.
+            //   Matches original bpDo: IN Namespace DO ...
+            if (v == TokenValue::In)
+            {
+                auto in_tok = ps.current_index();
+                ps.advance();
+                if (not parse_namespace(ps))
+                    return false;
+                auto ns = ps.pop();
+                ps.require(TokenValue::Do, "'do' after 'in namespace'");
+                if (not parse_return_expr(ps))
+                    return false;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_coerce({ ns, in_tok, body }));
+                return true;
+            }
+            // -- 'do' keyword: do statement.
+            if (v == TokenValue::Do)
+            {
+                ps.advance();
+                return parse_statement(ps);
+            }
+            return parse_and_expr(ps);
+        }
+
+        // -- Parse disjunction: return_expr { or return_expr }.
+        bool parse_logical(ParserState& ps)
+        {
+            return parse_left_assoc(ps, parse_return_expr, disjunction_operator);
+        }
+
+        // -- Parse conditional: if cond then consequent [else alternate].
+        //
+        //    Boot's `if` is an expression (has a value), not a
+        //    statement.  Both branches can be multi-line piles.
+        //
+        //    The pile phase handles coagulation of multi-line
+        //    conditions (e.g. `if cond1\n  and cond2 then ...`)
+        //    by merging lines that end with infix operators.
+        //    Inside delimiters, no formatting tokens are emitted.
+        //    For multi-line then/else bodies, the pile phase wraps
+        //    siblings with Indent/Justify/Unindent, consumed by
+        //    parse_pile.
+        bool parse_conditional(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::If)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not parse_where(ps))
+                return false;
+            auto cond = ps.pop();
+            ps.require(TokenValue::Then, "'then'");
+            if (not parse_where(ps))
+                return false;
+            auto consequent = ps.pop();
+            auto alternate = NodeIndex::none;
+            // -- Check for 'else' which may follow:
+            //   (a) a Justify token (else at same column as if),
+            //   (b) directly (no intervening formatting), or
+            //   (c) an Indent token (when `if` is inline after `==`
+            //       and `else` is on a subsequent continuation line).
+            {
+                auto snap_j = ps.save();
+                bool else_indented = false;
+                if (ps.match(TokenValue::Justify)
+                    and ps.peek_value() == TokenValue::Else)
+                {
+                    ps.advance();
+                    if (parse_where(ps))
+                        alternate = ps.pop();
+                }
+                else
+                {
+                    ps.restore(snap_j);
+                    if (ps.match(TokenValue::Else))
+                    {
+                        if (parse_where(ps))
+                            alternate = ps.pop();
+                    }
+                    else if (ps.peek_value() == TokenValue::Indent)
+                    {
+                        auto snap_i = ps.save();
+                        ps.advance();
+                        if (ps.peek_value() == TokenValue::Else)
+                        {
+                            else_indented = true;
+                            ps.advance();
+                            if (parse_where(ps))
+                                alternate = ps.pop();
+                        }
+                        else
+                        {
+                            ps.restore(snap_i);
+                        }
+                    }
+                }
+                if (else_indented)
+                    ps.match(TokenValue::Unindent);
+            }
+            ps.push(ps.forest.make_if({ kw, cond, consequent, alternate }));
+            return true;
+        }
+
+        // -- Parse exit (guard): assign [ => where ].
+        //
+        //    A guard expression uses `=>` (fat arrow) to associate
+        //    a condition with an action.  In pile context, this is
+        //    the primary way to write multi-branch control flow:
+        //
+        //      condition1 => action1
+        //      condition2 => action2
+        //      otherwise  => default_action
+        //
+        //    The left side is the condition (parsed as assignment),
+        //    the right side is the consequent body (parsed as where).
+        //    The Implies node represents the `=>` relationship.
+        //
+        //    Guard expressions appear frequently in Boot's `case`
+        //    and `cond`-like patterns (piles of alternatives).
+        bool parse_exit(ParserState& ps)
+        {
+            if (not parse_assign(ps))
+                return false;
+
+            // -- Spad: infix 'with' - category extension (expr with body).
+            if (ps.peek_value() == TokenValue::With)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                if (not parse_with_body(ps))
+                    throw ParseError("expected body after 'with'");
+                auto body = ps.pop();
+                auto w = ps.forest.make_with({ kw, body });
+                ps.push(ps.forest.make_infix({ lhs, kw, w }));
+                // -- Allow chained: ... with { ... } add { ... }
+                if (ps.peek_value() == TokenValue::Add)
+                {
+                    auto akw = ps.current_index();
+                    ps.advance();
+                    auto wexpr = ps.pop();
+                    if (not parse_capsule(ps))
+                        throw ParseError("expected body after 'add'");
+                    auto abody = ps.pop();
+                    auto a = ps.forest.make_add({ akw, abody });
+                    ps.push(ps.forest.make_infix({ wexpr, akw, a }));
+                }
+                return true;
+            }
+
+            // -- Spad: infix 'add' - domain implementation (expr add body).
+            if (ps.peek_value() == TokenValue::Add)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                if (not parse_capsule(ps))
+                    throw ParseError("expected body after 'add'");
+                auto body = ps.pop();
+                auto a = ps.forest.make_add({ kw, body });
+                ps.push(ps.forest.make_infix({ lhs, kw, a }));
+                return true;
+            }
+
+            // -- Handle `=>` on the same line or on a continuation line
+            // (indented deeper, preceded by an Indent token).
+            bool continued = skip_continuation_indent(ps,
+                [](TokenValue v) { return v == TokenValue::Implies; });
+            if (ps.peek_value() == TokenValue::Implies)
+            {
+                auto arrow = ps.current_index();
+                ps.advance();
+                auto cond = ps.pop();
+                if (not parse_where(ps))
+                    return true;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_implies({ cond, arrow, body }));
+            }
+            if (continued)
+                ps.match(TokenValue::Unindent);
+            return true;
+        }
+
+        // -- Loops and iterators
+        //
+        // Boot and Spad support these iterator and guard forms:
+        //
+        //   for x in collection         - iterate over elements
+        //   for x in lo..hi             - iterate over a range
+        //   while condition             - loop while condition holds
+        //   until condition             - loop until condition holds
+        //   | predicate                 - such-that guard (filter)
+        //
+        // Iterators can be combined with `cross`:
+        //   for x in xs cross for y in ys
+        //   - Cartesian product: every (x,y) pair
+        //
+        // Without `cross`, adjacent iterators run in parallel (zip):
+        //   for x in xs for y in ys
+        //   - zipped: (x1,y1), (x2,y2), ...
+        //
+        // Loops are formed by iterators + `repeat` + body:
+        //   for x in collection repeat
+        //     process x
+        //
+        // The body can be a pile (multi-line), and `repeat` with
+        // no iterators gives an infinite loop:
+        //   repeat
+        //     line := readLine()
+        //     line = nil => leave
+        //     process line
+
+        // -- Parse a single iterator or guard clause.
+        //
+        //    Handles `for var in expr`, `while expr`, `until expr`,
+        //    and `| predicate` (such-that guard).
+        //    For `for`, nesting is bumped to suppress formatting
+        //    tokens inside the iterator clause, because the collection
+        //    expression may span multiple lines:
+        //
+        //      for x in remove(a,
+        //                      remove(b, l))
+        //
+        //    The consumed Indent/Unindent pairs are tracked and
+        //    drained after the clause is parsed.
+        bool parse_iterator(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::For)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                // -- The pile phase coagulates multi-line for-in
+                // clauses (single child appended directly).
+                // Parse formal: variable or dot (don't care).
+                if (not parse_variable(ps) and not parse_dot(ps))
+                    return false;
+                // -- In Spad, `for var: free in` and `for var: local in`
+                // declare the loop variable's storage class.
+                // Skip the `: free`/`: local` modifier.
+                if (ps.peek_value() == TokenValue::Colon)
+                {
+                    auto snap = ps.save();
+                    ps.advance();
+                    auto next = ps.peek_value();
+                    if (next == TokenValue::Free)
+                    {
+                        ps.advance();   // consume 'free'
+                    }
+                    else
+                    {
+                        ps.restore(snap);
+                    }
+                }
+                auto var = ps.pop();
+                ps.require(TokenValue::In, "'in' after for-variable");
+                if (not parse_segment(ps))
+                    return false;
+                auto seq = ps.pop();
+                auto step = NodeIndex::none;
+                if (ps.match(TokenValue::By))
+                {
+                    if (parse_arith(ps))
+                        step = ps.pop();
+                }
+                ps.push(ps.forest.make_for_in({ kw, var, seq, step }));
+                return true;
+            }
+            if (v == TokenValue::While)
+                return parse_prefix_kw(ps, parse_logical,
+                                       &SyntaxForest::make_while);
+            if (v == TokenValue::Until)
+                return parse_prefix_kw(ps, parse_logical,
+                                       &SyntaxForest::make_until);
+            if (v == TokenValue::Bar)
+                return parse_prefix_kw(ps, parse_where,
+                                       &SyntaxForest::make_such_that);
+            return false;
+        }
+
+        // -- Parse iterators, possibly cross-product.
+        //
+        //    Multiple iterators may be combined.  Adjacent iterators
+        //    without `cross` are zipped; with `cross`, they form a
+        //    Cartesian product (represented as a Cross AST node).
+        //
+        //    Result is a list of iterator nodes, optionally joined
+        //    by Cross nodes.  Returns false if no iterator is found.
+        bool parse_iterators(ParserState& ps)
+        {
+            std::vector<NodeIndex> first_group;
+            while (parse_iterator(ps))
+                first_group.push_back(ps.pop());
+            if (first_group.empty())
+                return false;
+            auto first_span = ps.make_span(first_group);
+            auto first_node = ps.forest.make_iterators({ first_span });
+            if (ps.peek_value() != TokenValue::Cross)
+            {
+                ps.push(first_node);
+                return true;
+            }
+            std::vector<NodeIndex> factors;
+            factors.push_back(first_node);
+            while (ps.match(TokenValue::Cross))
+            {
+                ps.match(TokenValue::Justify);
+                std::vector<NodeIndex> group;
+                while (parse_iterator(ps))
+                    group.push_back(ps.pop());
+                if (not group.empty())
+                {
+                    auto span = ps.make_span(group);
+                    factors.push_back(ps.forest.make_iterators({ span }));
+                }
+            }
+            auto cross_span = ps.make_span(factors);
+            ps.push(ps.forest.make_cross({ cross_span }));
+            return true;
+        }
+
+        // -- Parse a loop: [iterators] repeat body.
+        //
+        //    A loop consists of optional iterators followed by
+        //    `repeat` and a body.  The body is typically a pile
+        //    (parsed by parse_pile).  If iterators are present,
+        //    they are collected and wrapped with the repeat body
+        //    in a Repeat node.
+        //
+        //    `repeat` alone (no iterators) creates an infinite loop.
+        //    Use `leave` or `return` to exit.
+        bool parse_loop(ParserState& ps)
+        {
+            if (ps.peek_value() == TokenValue::Repeat)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                if (not parse_logical(ps))
+                    return false;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_repeat(
+                    { NodeIndex::none, kw, body }));
+                return true;
+            }
+            auto snap = ps.save();
+            if (parse_iterators(ps))
+            {
+                auto kw = ps.current_index();
+                bool continued = skip_continuation_indent(ps,
+                    [](TokenValue v) { return v == TokenValue::Repeat; });
+                ps.match(TokenValue::Repeat);
+                auto iters = ps.pop();
+                if (parse_where(ps))
+                {
+                    auto body = ps.pop();
+                    if (continued)
+                        ps.match(TokenValue::Unindent);
+                    ps.push(ps.forest.make_repeat({ iters, kw, body }));
+                    return true;
+                }
+                // -- Iterators without body - backtrack.
+                ps.restore(snap);
+            }
+            return false;
+        }
+
+        // -- Exception handling
+        //
+        // Boot supports structured exception handling:
+        //
+        //   try
+        //     dangerousOperation()
+        //   catch(e: SomeException) =>
+        //     handleError(e)
+        //   catch(e: OtherException) =>
+        //     handleOther(e)
+        //   finally
+        //     cleanup()
+        //
+        // The `try` body is an assign-level expression.  Each
+        // `catch` clause names a variable with a type signature
+        // and provides a handler body after `=>`.  An optional
+        // `finally` clause runs unconditionally after the body.
+        //
+        // Between clauses, the parser tolerates stray Justify
+        // (newline) and Semicolon tokens from formatting.
+
+        // -- Parse try expression.
+        bool parse_try_expr(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Try)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not parse_assign(ps))
+                return false;
+            auto body = ps.pop();
+            std::vector<NodeIndex> handlers;
+            while (true)
+            {
+                ps.match(TokenValue::Justify);
+                ps.match(TokenValue::Semicolon);
+                if (ps.peek_value() != TokenValue::Catch)
+                    break;
+                auto catch_kw = ps.current_index();
+                ps.advance();
+                ps.require(TokenValue::OpenParen, "'(' in catch");
+                if (not parse_name(ps))
+                    return false;
+                parse_signature_tail(ps);
+                auto sig = ps.pop();
+                ps.require(TokenValue::CloseParen, "')' in catch");
+                ps.require(TokenValue::Implies, "'=>' in catch");
+                if (not parse_assign(ps))
+                    return false;
+                auto handler_body = ps.pop();
+                handlers.push_back(
+                    ps.forest.make_catch({ catch_kw, sig, handler_body }));
+            }
+            ps.match(TokenValue::Justify);
+            ps.match(TokenValue::Semicolon);
+            if (ps.peek_value() == TokenValue::Finally)
+            {
+                auto fin_kw = ps.current_index();
+                ps.advance();
+                if (parse_assign(ps))
+                {
+                    auto fin_body = ps.pop();
+                    handlers.push_back(
+                        ps.forest.make_finally({ fin_kw, fin_body }));
+                }
+            }
+            auto handler_span = ps.make_span(handlers);
+            ps.push(ps.forest.make_try({ kw, body, handler_span }));
+            return true;
+        }
+
+        // -- Constructs (bracket list with optional iterators)
+        //
+        // Boot's bracket expressions serve dual duty:
+        //
+        //   1. Plain lists: [1, 2, 3]
+        //   2. List comprehensions: [f x for x in collection]
+        //
+        // A list comprehension is detected when the first comma
+        // expression is followed by an iterator keyword (for, while,
+        // until) or `repeat`.  The comprehension is represented as
+        // a Repeat node inside the Bracket node.
+        //
+        // Inside brackets, nesting is bumped to suppress formatting
+        // tokens, since bracket contents may span multiple lines:
+        //
+        //   [x for x in
+        //        longListName]
+
+        // -- Parse a construction: [ comma [iterators] ].
+        //    In Boot, [expr for x in l | pred] is a list comprehension.
+        // -- Parse the interior of a collection literal (bracket or
+        //    brace), possibly with trailing iterators forming a
+        //    comprehension.  Returns a (possibly empty) element list.
+        static std::vector<NodeIndex> parse_collection_body(
+            ParserState& ps,
+            TokenValue close_tok)
+        {
+            std::vector<NodeIndex> elts;
+            if (ps.peek_value() != close_tok)
+            {
+                if (parse_comma(ps))
+                {
+                    auto content = ps.pop();
+                    if (starts_iterator(ps.peek_value())
+                        or ps.peek_value() == TokenValue::Repeat)
+                    {
+                        ps.match(TokenValue::Repeat);
+                        if (parse_iterators(ps))
+                        {
+                            auto iters = ps.pop();
+                            auto collect = ps.forest.make_repeat(
+                                { iters, ps.current_index(), content });
+                            elts.push_back(collect);
+                        }
+                        else
+                            elts.push_back(content);
+                    }
+                    else
+                        elts.push_back(content);
+                }
+            }
+            return elts;
+        }
+
+        bool parse_construct(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::OpenBracket)
+                return false;
+            auto open = ps.current_index();
+            ps.advance();
+            DelimiterGuard delim(ps);
+            auto elts = parse_collection_body(ps, TokenValue::CloseBracket);
+            auto close = ps.current_index();
+            ps.require(TokenValue::CloseBracket, "']'");
+            auto span = ps.make_span(elts);
+            ps.push(ps.forest.make_bracket({ open, span, close }));
+            return true;
+        }
+
+        // -- Assignment, lambda, expression statements
+        //
+        // This level of the expression grammar handles three postfix
+        // operators that all follow a statement-level expression:
+        //
+        //   target := value     - assignment (mutable update)
+        //   param +-> body      - lambda (anonymous function)
+        //   key <- value        - key argument (named parameter)
+        //
+        // All three are right-associative: the right-hand side is
+        // parsed recursively at the same level.  Assignment and
+        // lambda are standard; key-arg is Boot-specific syntax for
+        // passing named arguments to functions.
+
+        // -- Parse assignment, lambda, or key-arg.
+        bool parse_assign(ParserState& ps)
+        {
+            if (not parse_statement(ps))
+                return false;
+            auto v = ps.peek_value();
+            if (v == TokenValue::ColonEq)
+            {
+                auto ceq = ps.current_index();
+                ps.advance();
+                auto target = ps.pop();
+                if (not parse_assign(ps))
+                    return true;
+                auto val = ps.pop();
+                ps.push(ps.forest.make_assignment({ target, ceq, val }));
+                return true;
+            }
+            if (v == TokenValue::MapsTo)
+            {
+                auto arrow = ps.current_index();
+                ps.advance();
+                auto param = ps.pop();
+                std::vector<NodeIndex> params = { param };
+                auto span = ps.make_span(params);
+                if (not parse_assign(ps))
+                    return true;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_lambda({ span, arrow, body }));
+                return true;
+            }
+            if (v == TokenValue::LeftArrow)
+            {
+                auto arrow = ps.current_index();
+                ps.advance();
+                auto key = ps.pop();
+                if (not parse_logical(ps))
+                    return true;
+                auto val = ps.pop();
+                ps.push(ps.forest.make_key_arg({ key, arrow, val }));
+                return true;
+            }
+            return true;
+        }
+
+        // -- Parse a statement: conditional, loop, try, or expression.
+        //
+        //    A statement is either a control-flow construct (if, for,
+        //    while, until, repeat, try) or a plain expression.  This
+        //    is the dispatch point where keyword-led constructs are
+        //    separated from expression parsing.
+        bool parse_statement(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::If)
+                return parse_conditional(ps);
+            if (v == TokenValue::For or v == TokenValue::While
+                or v == TokenValue::Until or v == TokenValue::Repeat)
+                return parse_loop(ps);
+            if (v == TokenValue::Try)
+                return parse_try_expr(ps);
+            return parse_expression(ps);
+        }
+
+        // -- Parse an expression: [:] logical.
+        //
+        //    In Boot, a leading colon creates a COLON application,
+        //    used for quoting or type-level references:
+        //      :Symbol     - the symbol Symbol itself (not its value)
+        //      :Package    - reference to a package by name
+        //
+        //    Without the colon prefix, an expression is just a
+        //    logical-level expression.
+        bool parse_expression(ParserState& ps)
+        {
+            
+            if (ps.peek_value() == TokenValue::Colon)
+            {
+                auto colon = ps.current_index();
+                ps.advance();
+                if (not parse_logical(ps))
+                    return false;
+                auto operand = ps.pop();
+                ps.push(ps.forest.make_prefix({ colon, operand }));
+                return true;
+            }
+            return parse_logical(ps);
+        }
+
+        // -- Variable (parameter) parsing
+        //
+        // Variables appear in function parameter lists, macro
+        // parameter lists, and destructuring patterns.  A variable
+        // can be:
+        //
+        //   name              - simple name
+        //   name: Type        - typed parameter
+        //   name is pattern   - destructuring bind
+        //   name == default   - parameter with default value
+        //   (pattern)         - parenthesized pattern
+        //   [pattern]         - list destructuring pattern
+        //   .                 - don't-care placeholder
+        //   "string", 42, etc - constant (matched literally)
+        //
+        // The `== default` form is only valid inside parenthesized
+        // parameter lists (nesting > 0), to distinguish it from
+        // `==` as a definition operator at top level.
+
+        // -- Parse a variable: name [: type | is pattern | == default],
+        //    or parenthesized/bracketed pattern.
+        bool parse_variable(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::OpenParen)
+                return parse_paren(ps, parse_comma);
+            if (v == TokenValue::OpenBracket)
+                return parse_bracket(ps, parse_pattern_list);
+            if (v == TokenValue::Dot)
+                return parse_dot(ps);
+            if (parse_constant(ps))
+                return true;
+            if (parse_name(ps))
+            {
+                // -- Optional tail: signature, is-destructuring,
+                // or default value.
+                v = ps.peek_value();
+                if (v == TokenValue::Colon)
+                {
+                    // -- In Spad, `var: free` is a storage modifier,
+                    // not a type annotation.  Skip the signature.
+                    auto snap = ps.save();
+                    ps.advance();   // skip ':'
+                    auto next = ps.peek_value();
+                    ps.restore(snap);
+                    if (next != TokenValue::Free)
+                        parse_signature_tail(ps);
+                }
+                else if (v == TokenValue::Is)
+                {
+                    auto kw = ps.current_index();
+                    ps.advance();
+                    auto name = ps.pop();
+                    if (parse_pattern_item(ps))
+                    {
+                        auto pat = ps.pop();
+                        ps.push(ps.forest.make_is({ name, kw, pat }));
+                    }
+                    else
+                    {
+                        ps.push(name);
+                    }
+                }
+                else if (v == TokenValue::EqEq and ps.delimiter_depth > 0)
+                {
+                    // -- Default value: name == expr.  Only valid inside
+                    // parenthesized parameter lists, not at top level
+                    // where == means a definition body.
+                    auto def = ps.current_index();
+                    ps.advance();
+                    auto name = ps.pop();
+                    if (parse_application(ps))
+                    {
+                        auto val = ps.pop();
+                        ps.push(ps.forest.make_default_value(
+                            { name, def, val }));
+                    }
+                    else
+                    {
+                        ps.push(name);
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        // -- Definitions
+        //
+        // Boot has three kinds of definitions:
+        //
+        //   macro name params == body
+        //     - Textual substitution macro.  Parameters are variables.
+        //
+        //   name params == body
+        //     - Function or constant definition (depending on
+        //       whether params are present).
+        //
+        //   namespace N == body
+        //     - Named namespace binding.
+        //
+        // The `==` operator separates the left-hand side (signature)
+        // from the right-hand side (body).  The body can be an
+        // inline expression or a pile (indented block):
+        //
+        //   factorial n ==
+        //     n = 0 => 1
+        //     n * factorial(n - 1)
+        //
+        // Definitions can be nested inside `where` clauses for
+        // local bindings.
+
+        // -- Parse a definition: macro, constant, or function.
+        bool parse_definition(ParserState& ps)
+        {
+            
+            auto v = ps.peek_value();
+
+            // -- Macro definition.
+            if (v == TokenValue::Macro)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                if (not parse_name(ps))
+                    return false;
+                auto name = ps.pop();
+                std::vector<NodeIndex> params;
+                while (parse_variable(ps))
+                    params.push_back(ps.pop());
+                auto definer = ps.require(TokenValue::EqEq, "'==' in macro");
+                if (not parse_where(ps))
+                    return false;
+                auto body = ps.pop();
+                auto span = ps.make_span(params);
+                ps.push(ps.forest.make_macro_def(
+                    { kw, name, span, definer, body }));
+                return true;
+            }
+
+            // -- Namespace directive followed by '=='.
+            if (v == TokenValue::Namespace)
+            {
+                auto snap = ps.save();
+                if (parse_namespace(ps))
+                {
+                    if (ps.peek_value() == TokenValue::EqEq)
+                    {
+                        auto definer = ps.current_index();
+                        ps.advance();
+                        auto lhs = ps.pop();
+                        if (not parse_where(ps))
+                            return false;
+                        auto body = ps.pop();
+                        ps.push(ps.forest.make_constant_def(
+                            { lhs, definer, body }));
+                        return true;
+                    }
+                    // -- Just a namespace directive.
+                    return true;
+                }
+                ps.restore(snap);
+            }
+
+            // -- Try to parse exit first (covers most expressions).
+            if (not parse_exit(ps))
+                return false;
+
+            v = ps.peek_value();
+
+            // -- Handle continuation: INDENT before == or ==>
+            // (Spad places == add on a half-indented line).
+            bool definition_continued = false;
+            if (v == TokenValue::Indent)
+            {
+                auto snap = ps.save();
+                ps.advance();
+                v = ps.peek_value();
+                if (v == TokenValue::EqEq or v == TokenValue::FatArrow)
+                    definition_continued = true;
+                else
+                {
+                    ps.restore(snap);
+                    v = ps.peek_value();
+                }
+            }
+
+            // -- Definition: ... == body.
+            if (v == TokenValue::EqEq)
+            {
+                auto definer = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                while (ps.peek_value() == TokenValue::Justify)
+                    ps.advance();
+                if (not parse_where(ps)
+                    and not parse_pile(ps, parse_definition_item))
+                    return false;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_constant_def(
+                    { lhs, definer, body }));
+                if (definition_continued)
+                    ps.match(TokenValue::Unindent);
+                return true;
+            }
+
+            // -- Spad: ... ==> expansion (macro definition).
+            if (v == TokenValue::FatArrow)
+            {
+                auto definer = ps.current_index();
+                ps.advance();
+                auto lhs = ps.pop();
+                if (not parse_where(ps))
+                    return false;
+                auto body = ps.pop();
+                ps.push(ps.forest.make_macro_def(
+                    { definer, lhs, ps.make_span({}), definer, body }));
+                if (definition_continued)
+                    ps.match(TokenValue::Unindent);
+                return true;
+            }
+
+            if (definition_continued)
+                ps.match(TokenValue::Unindent);
+            return true;
+        }
+
+        // -- Parse a definition item (for where-clauses and piles).
+        //
+        //    A definition item is either a simple `name == body`
+        //    form (tried first with tentative parsing) or a full
+        //    definition.  This two-phase approach allows local
+        //    definitions inside piles and where-clauses to use the
+        //    simpler syntax without ambiguity.
+        bool parse_definition_item(ParserState& ps)
+        {
+            auto snap = ps.save();
+            // -- Try name == body (simple definition).
+            if (parse_name(ps))
+            {
+                if (ps.peek_value() == TokenValue::EqEq)
+                {
+                    auto definer = ps.current_index();
+                    ps.advance();
+                    auto name = ps.pop();
+                    if (parse_where(ps) or parse_pile(ps, parse_definition_item))
+                    {
+                        auto body = ps.pop();
+                        ps.push(ps.forest.make_constant_def(
+                            { name, definer, body }));
+                        return true;
+                    }
+                }
+                // -- Name followed by params == body (compound def).
+                ps.restore(snap);
+            }
+            // -- Fall through to full definition parse.
+            // Use parse_where so that expression-level where-clauses
+            // (e.g. `(x := foo()) where bar() == ...`) are handled.
+            return parse_where(ps);
+        }
+
+        // -- Where clause
+        //
+        // The `where` keyword introduces local definitions that
+        // scope over the preceding expression:
+        //
+        //   result where
+        //     helper x == x + offset
+        //     offset == 42
+        //
+        // The local definitions can be in a pile (indented block),
+        // parenthesized, or a single inline definition.
+
+        // -- Parse: definition [ where local-defs ].
+        bool parse_where(ParserState& ps)
+        {
+            
+            if (not parse_definition(ps)
+                and not parse_pile(ps, parse_definition_item))
+                return false;
+
+            // -- Function application with Indent-pile argument.
+            //
+            // In Boot, a function name (or call) followed by a
+            // deeper-indented pile means the pile is the argument:
+            //
+            //     bcHt
+            //       $saturn => '" {\ttrarrow} "
+            //       '" -> "
+            //
+            // At this point all continuation operators (+, and, =>,
+            // etc.) have already been handled by the expression
+            // parser chain, so any remaining Indent is safe to
+            // consume as the function argument.
+            //
+            // Guard: only extend expressions, not definitions or
+            // where-clauses (which already consumed their bodies).
+            if (ps.peek_value() == TokenValue::Indent)
+            {
+                auto top = ps.stack.back();
+                auto k = kind(top);
+                if (k != Kind::ConstantDef
+                    and k != Kind::FunctionDef
+                    and k != Kind::MacroDef
+                    and k != Kind::Where
+                    and k != Kind::Pile)
+                {
+                    auto snap2 = ps.save();
+                    auto fn = ps.pop();
+                    if (parse_pile(ps, parse_semicolon))
+                    {
+                        push_apply(ps, fn);
+                    }
+                    else
+                    {
+                        ps.restore(snap2);
+                        ps.push(fn);
+                    }
+                }
+            }
+
+            // -- The `where` keyword may appear on a deeper continuation
+            // line (e.g. after a multi-line bracket expression),
+            // hidden behind an Indent token.  Tentatively skip it
+            // to check for `where`.
+            bool skipped_indent = false;
+            auto v = ps.peek_value();
+            if (v != TokenValue::Where and v == TokenValue::Indent)
+            {
+                auto snap = ps.save();
+                ps.advance();    // skip the Indent token
+                v = ps.peek_value();
+                if (v != TokenValue::Where)
+                {
+                    ps.restore(snap);
+                    return true;
+                }
+                skipped_indent = true;
+            }
+
+            if (v == TokenValue::Where)
+            {
+                auto kw = ps.current_index();
+                ps.advance();
+                auto body = ps.pop();
+                std::vector<NodeIndex> defs;
+                if (ps.peek_value() == TokenValue::Indent)
+                {
+                    if (parse_pile(ps, parse_definition_item))
+                        defs.push_back(ps.pop());
+                }
+                else if (parse_paren(ps, parse_definition_item))
+                {
+                    defs.push_back(ps.pop());
+                }
+                else if (parse_definition_item(ps))
+                {
+                    defs.push_back(ps.pop());
+                }
+                // -- If we skipped an Indent to find `where`, the
+                // matching Unindent follows the where-clause content.
+                // Consume it so the enclosing pile's Unindent isn't
+                // stolen.
+                if (skipped_indent)
+                    ps.match(TokenValue::Unindent);
+                auto span = ps.make_span(defs);
+                ps.push(ps.forest.make_where({ body, kw, span }));
+            }
+            return true;
+        }
+
+        // -- Semicolon sequences
+        //
+        // Semicolons separate statements within a single line or
+        // inside parentheses.  parse_semicolon wraps parse_comma
+        // in a semicolon-separated list.
+
+        bool parse_semicolon(ParserState& ps)
+        {
+            return parse_semi_list(ps, parse_comma);
+        }
+
+        // -- Module system
+        //
+        // Boot has a simple module system with three constructs:
+        //
+        //   module Name(export1, export2, ...) where
+        //     definitions...
+        //   - Declares a module with named exports and a body.
+        //
+        //   import Name: Type for LocalAlias
+        //   - Imports a name with an explicit type signature,
+        //     optionally renaming it with `for`.  The type can
+        //     span multiple lines (nesting is suppressed).
+        //
+        //   import namespace Name
+        //   - Imports all exports from a namespace.
+        //
+        //   namespace Name
+        //   - Declares or references a namespace.  `namespace .`
+        //     refers to the current namespace.
+
+        // -- Parse module declaration: module Name(exports) where body.
+        bool parse_module(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Module)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not parse_name(ps))
+                return false;
+            auto name = ps.pop();
+            NodeSpan exports = { 0, 0 };
+            if (ps.peek_value() == TokenValue::OpenParen)
+            {
+                ps.advance();
+                DelimiterGuard delim(ps);
+                std::vector<NodeIndex> export_list;
+                if (parse_name(ps))
+                {
+                    export_list.push_back(ps.pop());
+                    while (ps.match(TokenValue::Comma))
+                    {
+                        if (not parse_name(ps))
+                            break;
+                        export_list.push_back(ps.pop());
+                    }
+                }
+                ps.require(TokenValue::CloseParen, "')' in module exports");
+                exports = ps.make_span(export_list);
+            }
+            NodeSpan interface = { 0, 0 };
+            if (ps.match(TokenValue::Where))
+            {
+                std::vector<NodeIndex> items;
+                if (ps.peek_value() == TokenValue::Indent)
+                {
+                    if (parse_pile(ps, parse_definition))
+                        items.push_back(ps.pop());
+                }
+                else if (parse_definition(ps))
+                {
+                    items.push_back(ps.pop());
+                }
+                interface = ps.make_span(items);
+            }
+            ps.push(ps.forest.make_module({ kw, name, exports, interface }));
+            return true;
+        }
+
+        // -- Parse import: import name | import name: type [for alias]
+        //    | import namespace name.
+        //
+        //    The full import form with type signature uses nesting
+        //    suppression so that multi-line type expressions are
+        //    handled correctly.  After parsing, consumed Indent
+        //    tokens are matched by draining corresponding Unindents.
+        bool parse_import(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Import)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (ps.peek_value() == TokenValue::Namespace)
+            {
+                ps.advance();
+                if (not parse_name(ps))
+                    return false;
+                auto name = ps.pop();
+                auto ns = ps.forest.make_namespace({ kw, name });
+                ps.push(ps.forest.make_import({ kw, ns }));
+                return true;
+            }
+            // -- In Spad, the imported expression can be a full domain
+            // application (e.g. import DistinctDegreeFactorize(F,FP)
+            // or import PointPackage DoubleFloat).  Use
+            // parse_application so that parameterized domains and
+            // juxtaposition-style applications are captured fully.
+            // For Boot, parse_application on a bare name degenerates
+            // to parse_name, so both dialects are handled correctly.
+            if (not parse_application(ps))
+                return false;
+            auto what = ps.pop();
+            if (ps.peek_value() == TokenValue::Colon)
+            {
+                auto colon = ps.current_index();
+                ps.advance();
+                NodeIndex alias = NodeIndex::none;
+                NodeIndex provenance = NodeIndex::none;
+                NodeIndex sig;
+                if (not parse_typing(ps))
+                    throw ParseError("expected type after ':' in import");
+                auto type = ps.pop();
+                sig = ps.forest.make_signature({ what, colon, type });
+                if (ps.match(TokenValue::For))
+                {
+                    if (parse_name(ps))
+                        alias = ps.pop();
+                }
+                if (ps.match(TokenValue::From))
+                {
+                    if (parse_application(ps))
+                        provenance = ps.pop();
+                }
+                ps.push(ps.forest.make_import_signature(
+                    { kw, sig, alias, provenance }));
+                return true;
+            }
+            // -- Spad: bare import from Domain (no signature).
+            if (ps.peek_value() == TokenValue::From)
+            {
+                ps.advance();
+                if (not parse_application(ps))
+                    throw ParseError("expected domain after 'from' in import");
+                auto source = ps.pop();
+                ps.push(ps.forest.make_import({ kw, source }));
+                return true;
+            }
+            ps.push(ps.forest.make_import({ kw, what }));
+            return true;
+        }
+
+        // -- Parse namespace: namespace name | namespace .
+        //    The dot form refers to the current (enclosing) namespace.
+        bool parse_namespace(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Namespace)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            // -- 'namespace .' means the current namespace.
+            if (not parse_name(ps) and not parse_dot(ps))
+                return false;
+            auto name = ps.pop();
+            ps.push(ps.forest.make_namespace({ kw, name }));
+            return true;
+        }
+
+        // -- Structure and case
+        //
+        // Boot's `structure` keyword defines algebraic data types:
+        //
+        //   structure Pair ==
+        //     Record(first: %Thing, second: %Thing)
+        //
+        // The body after `==` is typically a pile of variant
+        // definitions.
+        //
+        // The `case` keyword provides multi-way dispatch:
+        //
+        //   case expr of
+        //     pattern1 => action1
+        //     pattern2 => action2
+        //     otherwise => default
+        //
+        // The `of` keyword introduces the branches, which are
+        // parsed as a pile of guard (exit) expressions.
+
+        // -- Parse an accessor definition: name == (.field)
+        bool parse_accessor_def(ParserState& ps)
+        {
+            if (not parse_name(ps))
+                return false;
+            auto name = ps.pop();
+            auto definer = ps.require(TokenValue::EqEq,
+                "'==' in accessor definition");
+            if (not parse_where(ps))
+                return false;
+            auto selector = ps.pop();
+            ps.push(ps.forest.make_accessor_def(
+                { name, definer, selector }));
+            return true;
+        }
+
+        // -- Parse structure: structure Name == variants.
+        bool parse_struct(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Structure)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not parse_name(ps))
+                return false;
+            auto name = ps.pop();
+            auto definer = ps.require(TokenValue::EqEq, "'==' in structure");
+            std::vector<NodeIndex> variants;
+            if (ps.peek_value() == TokenValue::Indent)
+            {
+                if (parse_pile(ps, parse_definition))
+                    variants.push_back(ps.pop());
+            }
+            else if (parse_definition(ps))
+            {
+                variants.push_back(ps.pop());
+            }
+
+            // -- Check for 'with' clause (Record accessors).
+            if (ps.peek_value() == TokenValue::With)
+            {
+                auto with_kw = ps.current_index();
+                ps.advance();
+                // -- Parse accessor definitions (pile or single).
+                std::vector<NodeIndex> fields;
+                std::vector<NodeIndex> accessors;
+                // -- Move existing variants to fields.
+                fields = std::move(variants);
+                variants.clear();
+                if (ps.peek_value() == TokenValue::Indent)
+                {
+                    // -- Pile of accessor definitions.
+                    if (ps.match(TokenValue::Indent))
+                    {
+                        if (parse_accessor_def(ps))
+                            accessors.push_back(ps.pop());
+                        while (ps.match(TokenValue::Justify))
+                        {
+                            if (parse_accessor_def(ps))
+                                accessors.push_back(ps.pop());
+                        }
+                        ps.match(TokenValue::Unindent);
+                    }
+                }
+                else if (parse_accessor_def(ps))
+                {
+                    accessors.push_back(ps.pop());
+                }
+                auto fields_span = ps.make_span(fields);
+                auto accessors_span = ps.make_span(accessors);
+                auto record = ps.forest.make_record(
+                    { with_kw, fields_span, accessors_span });
+                variants.push_back(record);
+            }
+
+            auto span = ps.make_span(variants);
+            ps.push(ps.forest.make_structure({ kw, name, definer, span }));
+            return true;
+        }
+
+        // -- Parse case expression: case expr [of branches].
+        //    Branches are a pile of guard expressions (cond => body).
+        //    If `of` is absent, this is a simple case wrapper.
+        bool parse_case_expr(ParserState& ps)
+        {
+            if (ps.peek_value() != TokenValue::Case)
+                return false;
+            auto kw = ps.current_index();
+            ps.advance();
+            if (not parse_where(ps))
+                return false;
+            auto expr = ps.pop();
+            // -- 'of' might not be present in all case expressions.
+            if (ps.match(TokenValue::Of))
+            {
+                std::vector<NodeIndex> branches;
+                if (ps.peek_value() == TokenValue::Indent)
+                {
+                    ps.advance();
+                    while (ps.peek_value() != TokenValue::Unindent
+                           and ps.peek_value() != TokenValue::EndOfStream)
+                    {
+                        if (parse_exit(ps))
+                            branches.push_back(ps.pop());
+                        ps.match(TokenValue::Justify);
+                    }
+                    ps.match(TokenValue::Unindent);
+                }
+                auto span = ps.make_span(branches);
+                ps.push(ps.forest.make_case({ kw, expr, span }));
+            }
+            else
+            {
+                // -- Simple case (expression after `case`).
+                ps.push(ps.forest.make_case(
+                    { kw, expr, ps.make_span({}) }));
+            }
+            return true;
+        }
+
+        // -- Spad: capsule and with-body parsers
+
+        // -- Parse a brace-delimited list of items separated by
+        //    semicolons and/or newlines (Justify tokens).
+        //    Returns the items; caller wraps in the appropriate node.
+        static std::vector<NodeIndex> parse_braced_items(
+            ParserState& ps,
+            bool (*parser)(ParserState&))
+        {
+            DelimiterGuard delim(ps);
+            std::vector<NodeIndex> items;
+            while (ps.peek_value() != TokenValue::CloseBrace
+                   and ps.peek_value() != TokenValue::EndOfStream)
+            {
+                if (parser(ps))
+                    items.push_back(ps.pop());
+                else
+                    break;
+                ps.match(TokenValue::Semicolon);
+                ps.match(TokenValue::Justify);
+            }
+            ps.require(TokenValue::CloseBrace, "'}'");
+            return items;
+        }
+
+        // -- Parse a capsule body: { items } | pile | single expr.
+        //
+        //    A capsule is the implementation body of a Spad domain,
+        //    appearing after 'add'.
+        bool parse_capsule(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::OpenBrace)
+            {
+                ps.advance();
+                auto items = parse_braced_items(ps, parse_comma);
+                auto span = ps.make_span(items);
+                ps.push(ps.forest.make_capsule({ span }));
+                return true;
+            }
+            // -- Pile or single expression.
+            if (v == TokenValue::Indent)
+            {
+                if (not parse_pile(ps, parse_comma))
+                    return false;
+                auto body = ps.pop();
+                auto span = ps.make_span({ body });
+                ps.push(ps.forest.make_capsule({ span }));
+                return true;
+            }
+            if (parse_comma(ps))
+            {
+                auto item = ps.pop();
+                auto span = ps.make_span({ item });
+                ps.push(ps.forest.make_capsule({ span }));
+                return true;
+            }
+            return false;
+        }
+
+        // -- Parse a with-body: { items } | pile | single expr.
+        //
+        //    The body of a category definition (after 'with').
+        bool parse_with_body(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::OpenBrace)
+            {
+                ps.advance();
+                auto items = parse_braced_items(ps, parse_comma);
+                if (items.size() == 1)
+                    ps.push(items[0]);
+                else
+                {
+                    auto span = ps.make_span(items);
+                    ps.push(ps.forest.make_sequence({ span }));
+                }
+                return true;
+            }
+            // -- Pile form.
+            if (v == TokenValue::Indent)
+                return parse_pile(ps, parse_comma);
+            // -- Single expression.
+            return parse_comma(ps);
+        }
+
+        // -- Comma (top-level)
+        //
+        // Comma is the loosest-binding operator in Boot.  At the
+        // top level, a comma separates elements in a tuple or
+        // parameter list.  The comma parser also dispatches to
+        // module-system constructs (module, import, namespace)
+        // because these can appear wherever a comma-expression can.
+        //
+        // Inside brackets, a variant (parse_bracket_comma) handles
+        // colon-prefixed items for list append syntax: [:rest].
+
+        // -- Parse a comma expression, or module/import/namespace.
+        bool parse_comma(ParserState& ps)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::Module)
+                return parse_module(ps);
+            if (v == TokenValue::Import)
+                return parse_import(ps);
+            if (v == TokenValue::Namespace)
+                return parse_namespace(ps);
+            return parse_tuple_of(ps, parse_where);
+        }
+
+    } // unnamed namespace
+
+    // -- Public API
+    //
+    // parse_toplevel: Parse one top-level form from the token
+    // stream.  Returns NodeIndex::none at end-of-stream.
+    //
+    // parse_boot: Parse an entire Boot source file.  Returns
+    // a vector of top-level AST node indices.  The parser
+    // skips stray formatting tokens (Justify, Indent, Unindent,
+    // Semicolon) between top-level forms, and reports errors
+    // for anything else that fails to parse.
+
+    NodeIndex parse_toplevel(ParserState& ps)
+    {
+        // -- Skip stray formatting tokens between top-level forms.
+        for (;;)
+        {
+            auto v = ps.peek_value();
+            if (v == TokenValue::Justify or v == TokenValue::Indent
+                or v == TokenValue::Unindent)
+                ps.advance();
+            else
+                break;
+        }
+        if (ps.peek_value() == TokenValue::EndOfStream)
+            return NodeIndex::none;
+        if (not parse_comma(ps))
+            return NodeIndex::none;
+        return ps.pop();
+    }
+
+    std::vector<NodeIndex> parse_boot(
+        const std::vector<Token>& tokens,
+        SyntaxForest& forest)
+    {
+        ParserState ps(tokens, forest);
+        std::vector<NodeIndex> forms;
+        while (true)
+        {
+            auto node = parse_toplevel(ps);
+            if (not Syntax::valid(node))
+                break;
+            forms.push_back(node);
+        }
+        return forms;
+    }
+
+    std::vector<NodeIndex> parse_spad(
+        const std::vector<Token>& tokens,
+        SyntaxForest& forest,
+        std::size_t* consumed)
+    {
+        ParserState ps(tokens, forest, Language::Spad);
+        std::vector<NodeIndex> forms;
+        while (true)
+        {
+            auto node = parse_toplevel(ps);
+            if (not Syntax::valid(node))
+                break;
+            forms.push_back(node);
+        }
+        if (consumed != nullptr)
+            *consumed = ps.position;
+        return forms;
+    }
+}
+
+// -- Legacy Boot-to-Lisp transpiler stub.
+//  Tokenizes a Boot source file and writes a formatted token dump.
 namespace {
    using namespace OpenAxiom;
 
-   using TokenSequence = std::vector<Token>;
-
-   struct ParsingContext {
-      explicit ParsingContext(const TokenSequence& ts)
-            : tokens{ ts }, position{ }
-      { }
-
-      bool exhausted() const {
-         return position >= tokens.size();
-      }
-
-      const Token* current_token() const {
-         if (exhausted())
-            return nullptr;
-         return &tokens[position];
-      }
-
-      void advance() { ++position; }
-
-   private:
-      const TokenSequence& tokens;
-      TokenSequence::size_type position;
-   };
-
-   const Token* next_token(ParsingContext& ctx) {
-      while (auto t = ctx.current_token()) {
-         switch (t->category) {
-         case TokenCategory::Whitespace:
-            break;
-
-         case TokenCategory::Comment:
-            if (t->value == TokenValue::Wisecrack)
-               break;
-
-         default:
-            return t;
-         }
-         ctx.advance();
-      }
-      return nullptr;
-   }
-
-   // Simple wrapper around standard file streams, along with the pathname
-   // to the file.
-   template<typename T>
-   struct FileAs {
+   struct OutputFile {
       const char* path;
-      T stream;
-      FileAs(const char* p, std::ios_base::openmode flags)
+      std::ofstream stream;
+      OutputFile(const char* p, std::ios_base::openmode flags)
             : path{ p }, stream{ p, flags }
       {
          if (!stream)
@@ -103,24 +3517,20 @@ namespace {
       }
    };
 
-   using InputFile = FileAs<std::ifstream>;
-   using OutputFile = FileAs<std::ofstream>;
-
    void format_text(const Fragment& f, const Token& t, std::ostream& os) {
       if (t.start.line == t.end.line) {
          auto& line = f(t.start);
-         std::copy(line.begin() + t.start.column, line.begin() + t.end.column,
-                   std::ostream_iterator<char>(os));
+         auto sv = std::u8string_view(line).substr(t.start.column,
+                                                   t.end.column - t.start.column);
+         os << sv;
       }
       else {
          auto& first_line = f(t.start);
-         std::copy(first_line.begin() + t.start.column, first_line.end(),
-                   std::ostream_iterator<char>(os));
+         os << std::u8string_view(first_line).substr(t.start.column);
          for (auto i = t.start.line + 1; i < t.end.line; ++i)
-            os << f[i];
+            os << std::u8string_view(f[i]);
          auto& last_line = f[t.end.line];
-         std::copy(last_line.begin(), last_line.begin() + t.end.column,
-                   std::ostream_iterator<char>(os));
+         os << std::u8string_view(last_line).substr(0, t.end.column);
       }
    }
 
@@ -142,13 +3552,16 @@ namespace {
       os << '}';
    }
 
-   // FIXME: This is just a stub to get a native parsing entry point
+   // -- FIXME: This is just a stub to get a native parsing entry point
    //        into the bootsys and interpsys images.
-   void transpile_boot_to_lisp(InputFile& in, OutputFile& out) {
-      out.stream << "## Input: " << in.path << '\n'
+   void transpile_boot_to_lisp(const char* in_path,
+                                Memory::FileMapping& in,
+                                OutputFile& out) {
+      out.stream << "## Input: " << in_path << '\n'
                  << "## Output: " << out.path << '\n';
 
-      for (auto& f : read_source(in.stream))
+      Utf8SourceView source { in.begin(), in.size() };
+      for (auto& f : read_source(source.view()))
       {
          out.stream << "================================================\n";
          out.stream << f;
@@ -159,8 +3572,8 @@ namespace {
                switch (t.category) {
                case TokenCategory::Junk:
                case TokenCategory::Unclassified:
-                  out.stream //<< f[t.start.line].sub_string(t.start.column, t.end.column)
-                     << " in file " << in.path
+                  out.stream
+                     << " in file " << in_path
                      << " at line " << t.start.line
                      << ", column " << t.start.column;
                   break;
@@ -171,14 +3584,14 @@ namespace {
             }
          }
          catch(const EndOfStringUnseen& e) {
-            std::cerr << in.path << ": syntax error: "
+            std::cerr << in_path << ": syntax error: "
                       << "premature end of line before matching quote "
                       << "of string literal on line " << e.line
                       << " at column " << e.column
                       << std::endl;
          }
          catch (const MissingExponent& e) {
-            std::cerr << in.path << ": syntax error: "
+            std::cerr << in_path << ": syntax error: "
                       << "missing exponent of floating point constant "
                       << "on line " << e.line
                       << ", column " << e.column
@@ -191,11 +3604,10 @@ namespace {
 }
 
 namespace OpenAxiom {
-
    int boot_to_lisp(const char* boot_path, const char* lisp_path) try {
-      InputFile in { boot_path, std::ios_base::binary };
+      Memory::FileMapping in { boot_path };
       OutputFile out { lisp_path, std::ios_base::binary };
-      transpile_boot_to_lisp(in, out);
+      transpile_boot_to_lisp(boot_path, in, out);
       return 0;
    }
    catch (const Error::CannotOpenFile& e) {

--- a/src/syntax/boot-ast.cxx
+++ b/src/syntax/boot-ast.cxx
@@ -1,0 +1,621 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   CST-to-AST lowering.  Converts a SyntaxForest CST node
+// --%   into a Lisp value matching the old Boot translator's %Ast
+// --%   representation:
+// --%     (CONS '%Tag (LIST arg1 arg2 ...))
+// --%   Atoms (names, literals) become symbols, integers, floats,
+// --%   or strings directly.
+
+#include <stdexcept>
+#include <open-axiom/BootAst>
+#include <open-axiom/SyntaxPrint>
+
+namespace OpenAxiom::Boot {
+
+    using namespace Syntax;
+    using namespace Lisp;
+
+    // -- Forward declaration.
+    Value lower(NodeIndex node, LoweringContext& ctx);
+
+    // -- Extract the source text of a token and return a Lisp symbol.
+    // -- Process Boot underscore-escape sequences.
+    //    In Boot, `_` is an escape character:
+    //    - `_x` (where x is a non-whitespace char) includes x
+    //      literally in the identifier.  So `_-` > `-`, `_*` > `*`.
+    //    - `_` followed by whitespace (space, tab, newline) is a
+    //      line continuation: skip the underscore and all following
+    //      whitespace.
+    std::u8string unescape_boot_id(std::u8string_view text)
+    {
+        std::u8string result;
+        result.reserve(text.size());
+        for (size_t i = 0; i < text.size(); ++i)
+        {
+            if (text[i] == u8'_' and i + 1 < text.size())
+            {
+                ++i;
+                if (text[i] == u8' ' or text[i] == u8'\t'
+                    or text[i] == u8'\n' or text[i] == u8'\r')
+                {
+                    // -- Line continuation: skip all whitespace.
+                    while (i < text.size()
+                        and (text[i] == u8' ' or text[i] == u8'\t'
+                            or text[i] == u8'\n'
+                            or text[i] == u8'\r'))
+                        ++i;
+                    --i; // will be incremented by the for loop
+                }
+                else
+                {
+                    result += text[i];
+                }
+            }
+            else
+            {
+                result += text[i];
+            }
+        }
+        return result;
+    }
+
+    static Value tok_sym(TokenIndex ti, LoweringContext& ctx)
+    {
+        auto text = Syntax::token_text(ti, ctx.tokens, ctx.fragment);
+        // -- Process underscore escapes for identifiers.
+        if (text.find(u8'_') != std::u8string_view::npos)
+        {
+            auto clean = unescape_boot_id(text);
+            return ctx.arena.make_symbol(clean);
+        }
+        return ctx.arena.make_symbol(text);
+    }
+
+    // -- Lower a span of children to a Lisp list.
+    Value lower_span(NodeSpan span, LoweringContext& ctx)
+    {
+        Value result = nil;
+        for (auto i = span.count; i > 0; --i)
+            result = ctx.arena.cons(
+                lower(ctx.forest.child(span, i - 1), ctx), result);
+        return result;
+    }
+
+    // -- Construct a tagged AST node: (CONS tag (LIST args...))
+    //    which is (%Tag arg1 arg2 ...).
+    static Value tagged(LoweringContext& ctx, std::u8string_view tag,
+                    std::initializer_list<Value> args)
+    {
+        return ctx.arena.cons(ctx.arena.make_symbol(tag),
+                              ctx.arena.list(args));
+    }
+
+    // -- The main lowering function.
+    Value lower(NodeIndex node, LoweringContext& ctx)
+    {
+        if (not valid(node))
+            return nil;
+
+        auto k = kind(node);
+        auto idx = index(node);
+
+        auto& forest = ctx.forest;
+
+        switch (k) {
+
+        // -- Atoms: become Lisp values directly.
+        case Kind::Literal: {
+            auto& n = forest.literal(idx);
+            auto text = Syntax::token_text(n.token, ctx.tokens, ctx.fragment);
+            // -- Determine if it's an integer, float, or string.
+            if (not text.empty() and text[0] == u8'"')
+                return ctx.arena.make_string(text.substr(1, text.size() - 2));
+            // -- Try integer.
+            bool all_digits = true;
+            bool has_sign = false;
+            for (std::size_t i = 0; i < text.size(); ++i)
+            {
+                char8_t c = text[i];
+                if (i == 0 and (c == u8'+' or c == u8'-'))
+                {
+                    has_sign = true;
+                    continue;
+                }
+                if (c < u8'0' or c > u8'9')
+                {
+                    all_digits = false;
+                    break;
+                }
+            }
+            if (all_digits and (not has_sign or text.size() > 1))
+            {
+                try
+                {
+                    return ctx.arena.make_integer(std::stoll(std::string(as_chars(text))));
+                }
+                catch (const std::out_of_range&) { }
+                catch (const std::invalid_argument&) { }
+            }
+            // -- Try float.
+            bool has_dot = false;
+            for (char8_t c : text)
+            {
+                if (c == u8'.' or c == u8'e' or c == u8'E')
+                {
+                    has_dot = true;
+                    break;
+                }
+            }
+            if (has_dot)
+            {
+                try
+                {
+                    return ctx.arena.make_float(std::stod(std::string(as_chars(text))));
+                }
+                catch (const std::out_of_range&) { }
+                catch (const std::invalid_argument&) { }
+            }
+            // -- Fallback: treat as a symbol.
+            return ctx.arena.make_symbol(text);
+        }
+
+        case Kind::Name: {
+            auto& n = forest.name(idx);
+            return tok_sym(n.token, ctx);
+        }
+
+        // -- Module system --
+        case Kind::QualifiedName: {
+            auto& n = forest.qualified_name(idx);
+            return tagged(ctx, u8"%QualifiedName",
+                { lower(n.qualifier, ctx),
+                  lower(n.name, ctx) });
+        }
+
+        case Kind::Module: {
+            auto& n = forest.module(idx);
+            return tagged(ctx, u8"%Module",
+                { lower(n.name, ctx),
+                  lower_span(n.exports, ctx),
+                  lower_span(n.interface, ctx) });
+        }
+
+        case Kind::Namespace: {
+            auto& n = forest.namespace_node(idx);
+            return tagged(ctx, u8"%Namespace",
+                { lower(n.name, ctx) });
+        }
+
+        case Kind::Import: {
+            auto& n = forest.import_node(idx);
+            return tagged(ctx, u8"%Import",
+                { lower(n.what, ctx) });
+        }
+
+        case Kind::ImportSignature: {
+            auto& n = forest.import_signature(idx);
+            return tagged(ctx, u8"%ImportSignature",
+                { lower(n.signature, ctx),
+                  lower(n.name, ctx),
+                  lower(n.provenance, ctx) });
+        }
+
+        // -- Definitions --
+        case Kind::ConstantDef: {
+            auto& n = forest.constant_def(idx);
+            return tagged(ctx, u8"%ConstantDefinition",
+                { lower(n.name, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        case Kind::FunctionDef: {
+            auto& n = forest.function_def(idx);
+            return tagged(ctx, u8"%Definition",
+                { lower(n.name, ctx),
+                  lower_span(n.parameters, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        case Kind::MacroDef: {
+            auto& n = forest.macro_def(idx);
+            return tagged(ctx, u8"%Macro",
+                { lower(n.name, ctx),
+                  lower_span(n.parameters, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        case Kind::TypeAlias: {
+            auto& n = forest.type_alias(idx);
+            return tagged(ctx, u8"%TypeAlias",
+                { lower(n.name, ctx),
+                  lower(n.type, ctx) });
+        }
+
+        case Kind::Signature: {
+            auto& n = forest.signature(idx);
+            return tagged(ctx, u8"%Signature",
+                { lower(n.name, ctx),
+                  lower(n.type, ctx) });
+        }
+
+        // -- Expressions --
+        case Kind::Apply: {
+            auto& n = forest.apply(idx);
+            // -- The old AST: %Call(fun, %Sequence args)
+            // where args is a list wrapped in (CONS '%Sequence args).
+            // Actually, looking at the ast.boot definition:
+            //   %Call(%Ast, %Sequence)
+            // The second arg is the argument list as a sequence.
+            auto fun = lower(n.function, ctx);
+            auto args = lower_span(n.arguments, ctx);
+            return tagged(ctx, u8"%Call", { fun, args });
+        }
+
+        case Kind::InfixExpr: {
+            auto& n = forest.infix_expr(idx);
+            return tagged(ctx, u8"%InfixExpr",
+                { tok_sym(n.op, ctx),
+                  lower(n.lhs, ctx),
+                  lower(n.rhs, ctx) });
+        }
+
+        case Kind::PrefixExpr: {
+            auto& n = forest.prefix_expr(idx);
+            return tagged(ctx, u8"%PrefixExpr",
+                { tok_sym(n.op, ctx),
+                  lower(n.operand, ctx) });
+        }
+
+        case Kind::SuffixDot: {
+            auto& n = forest.suffix_dot(idx);
+            return tagged(ctx, u8"%SuffixDot",
+                { lower(n.operand, ctx) });
+        }
+
+        case Kind::Restrict: {
+            auto& n = forest.restrict_node(idx);
+            return tagged(ctx, u8"%Restrict",
+                { lower(n.expr, ctx),
+                  lower(n.type, ctx) });
+        }
+
+        case Kind::Coerce: {
+            // -- The old AST doesn't have %Coerce.
+            // Coerce (::) is parsed as a type restriction in old Boot.
+            // We map it to %Restrict for now.
+            auto& n = forest.coerce(idx);
+            return tagged(ctx, u8"%Restrict",
+                { lower(n.expr, ctx),
+                  lower(n.type, ctx) });
+        }
+
+        case Kind::Quote: {
+            auto& n = forest.quote(idx);
+            return tagged(ctx, u8"%Quote",
+                { lower(n.expr, ctx) });
+        }
+
+        case Kind::Bracket: {
+            auto& n = forest.bracket(idx);
+            return tagged(ctx, u8"%Bracket",
+                { lower_span(n.elements, ctx) });
+        }
+
+        case Kind::Tuple: {
+            auto& n = forest.tuple(idx);
+            return tagged(ctx, u8"%Tuple",
+                { lower_span(n.elements, ctx) });
+        }
+
+        case Kind::Sequence: {
+            auto& n = forest.sequence(idx);
+            return ctx.arena.cons(
+                ctx.arena.make_symbol(u8"APPEND"),
+                lower_span(n.statements, ctx));
+        }
+
+        case Kind::Pile: {
+            auto& n = forest.pile(idx);
+            return tagged(ctx, u8"%Pile",
+                { lower_span(n.items, ctx) });
+        }
+
+        // -- Types --
+        case Kind::Mapping: {
+            auto& n = forest.mapping(idx);
+            return tagged(ctx, u8"%Mapping",
+                { lower(n.target, ctx),
+                  lower_span(n.sources, ctx) });
+        }
+
+        case Kind::Forall: {
+            auto& n = forest.forall(idx);
+            return tagged(ctx, u8"%Forall",
+                { lower_span(n.variables, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        // -- Control flow --
+        case Kind::IfExpr: {
+            // -- The old parser doesn't produce %If directly;
+            // it produces COND-like structures via bfIf.
+            // But at AST level before translation, the parser
+            // produces a form that bfIf turns into COND.
+            // For our CST>AST, we preserve the conditional structure.
+            auto& n = forest.if_expr(idx);
+            auto cond = lower(n.condition, ctx);
+            auto consq = lower(n.consequent, ctx);
+            auto alt = lower(n.alternate, ctx);
+            // -- If there's an alternate, produce bfIf(cond,consq,alt)
+            // Otherwise, bfIfThenOnly(cond,consq)
+            if (not valid(n.alternate))
+                return tagged(ctx, u8"%Implies", { cond, consq });
+            return ctx.arena.list({
+                ctx.arena.make_symbol(u8"IF"), cond, consq, alt });
+        }
+
+        case Kind::Return: {
+            auto& n = forest.return_node(idx);
+            return tagged(ctx, u8"%Return",
+                { lower(n.value, ctx) });
+        }
+
+        case Kind::Leave: {
+            auto& n = forest.leave(idx);
+            return tagged(ctx, u8"%Leave",
+                { lower(n.value, ctx) });
+        }
+
+        case Kind::Implies: {
+            auto& n = forest.implies(idx);
+            return tagged(ctx, u8"%Implies",
+                { lower(n.condition, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        // -- Loops --
+        case Kind::While: {
+            auto& n = forest.while_node(idx);
+            return tagged(ctx, u8"%While",
+                { lower(n.condition, ctx) });
+        }
+
+        case Kind::Until: {
+            auto& n = forest.until_node(idx);
+            return tagged(ctx, u8"%Until",
+                { lower(n.condition, ctx) });
+        }
+
+        case Kind::ForIn: {
+            auto& n = forest.for_in(idx);
+            return tagged(ctx, u8"%For",
+                { lower(n.variable, ctx),
+                  lower(n.sequence, ctx),
+                  lower(n.step, ctx) });
+        }
+
+        case Kind::SuchThat: {
+            auto& n = forest.such_that(idx);
+            return tagged(ctx, u8"%SuchThat",
+                { lower(n.predicate, ctx) });
+        }
+
+        case Kind::Iterators: {
+            auto& n = forest.iterators(idx);
+            return tagged(ctx, u8"%Iterators",
+                { lower_span(n.clauses, ctx) });
+        }
+
+        case Kind::Cross: {
+            auto& n = forest.cross(idx);
+            return tagged(ctx, u8"%Cross",
+                { lower_span(n.factors, ctx) });
+        }
+
+        case Kind::Repeat: {
+            auto& n = forest.repeat(idx);
+            return tagged(ctx, u8"%Repeat",
+                { lower(n.iterators, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        // -- Pattern matching --
+        case Kind::Is: {
+            auto& n = forest.is_test(idx);
+            return tagged(ctx, u8"%Is",
+                { lower(n.expr, ctx),
+                  lower(n.pattern, ctx) });
+        }
+
+        case Kind::Isnt: {
+            auto& n = forest.isnt_test(idx);
+            return tagged(ctx, u8"%Isnt",
+                { lower(n.expr, ctx),
+                  lower(n.pattern, ctx) });
+        }
+
+        case Kind::EqualPattern: {
+            auto& n = forest.equal_pattern(idx);
+            return tagged(ctx, u8"%EqualPattern",
+                { lower(n.expr, ctx) });
+        }
+
+        case Kind::ColonAppend: {
+            auto& n = forest.colon_append(idx);
+            return tagged(ctx, u8"%ColonAppend",
+                { lower_span(n.head, ctx),
+                  lower(n.rest, ctx) });
+        }
+
+        // -- Assignment & binding --
+        case Kind::Assignment: {
+            auto& n = forest.assignment(idx);
+            return tagged(ctx, u8"%Assignment",
+                { lower(n.target, ctx),
+                  lower(n.value, ctx) });
+        }
+
+        case Kind::Lambda: {
+            auto& n = forest.lambda(idx);
+            return tagged(ctx, u8"%Lambda",
+                { lower_span(n.parameters, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        case Kind::DefaultValue: {
+            auto& n = forest.default_value(idx);
+            return tagged(ctx, u8"%DefaultValue",
+                { lower(n.name, ctx),
+                  lower(n.value, ctx) });
+        }
+
+        case Kind::KeyArg: {
+            auto& n = forest.key_arg(idx);
+            return tagged(ctx, u8"%Key",
+                { lower(n.key, ctx),
+                  lower(n.value, ctx) });
+        }
+
+        // -- Segments --
+        case Kind::BoundedSegment: {
+            auto& n = forest.bounded_segment(idx);
+            return tagged(ctx, u8"%BoundedSegment",
+                { lower(n.lo, ctx),
+                  lower(n.hi, ctx) });
+        }
+
+        case Kind::UnboundedSegment: {
+            auto& n = forest.unbounded_segment(idx);
+            return tagged(ctx, u8"%UnboundedSegment",
+                { lower(n.lo, ctx) });
+        }
+
+        // -- Reduce --
+        case Kind::Reduce: {
+            auto& n = forest.reduce(idx);
+            return tagged(ctx, u8"%Reduce",
+                { lower(n.op, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        // -- Structural --
+        case Kind::Structure: {
+            auto& n = forest.structure(idx);
+            return tagged(ctx, u8"%Structure",
+                { lower(n.name, ctx),
+                  lower_span(n.variants, ctx) });
+        }
+
+        case Kind::Record: {
+            auto& n = forest.record(idx);
+            return tagged(ctx, u8"%Record",
+                { lower_span(n.fields, ctx),
+                  lower_span(n.accessors, ctx) });
+        }
+
+        case Kind::AccessorDef: {
+            auto& n = forest.accessor_def(idx);
+            return tagged(ctx, u8"%AccessorDef",
+                { lower(n.name, ctx),
+                  lower(n.selector, ctx) });
+        }
+
+        case Kind::Case: {
+            auto& n = forest.case_node(idx);
+            return tagged(ctx, u8"%Case",
+                { lower(n.expr, ctx),
+                  lower_span(n.branches, ctx) });
+        }
+
+        // -- Exception handling --
+        case Kind::Throw: {
+            auto& n = forest.throw_node(idx);
+            return tagged(ctx, u8"%Throw",
+                { lower(n.expr, ctx) });
+        }
+
+        case Kind::Catch: {
+            auto& n = forest.catch_node(idx);
+            return tagged(ctx, u8"%Catch",
+                { lower(n.signature, ctx),
+                  lower(n.body, ctx) });
+        }
+
+        case Kind::Finally: {
+            auto& n = forest.finally_node(idx);
+            return tagged(ctx, u8"%Finally",
+                { lower(n.body, ctx) });
+        }
+
+        case Kind::Try: {
+            auto& n = forest.try_node(idx);
+            return tagged(ctx, u8"%Try",
+                { lower(n.body, ctx),
+                  lower_span(n.handlers, ctx) });
+        }
+
+        // -- Scoping --
+        case Kind::Where: {
+            auto& n = forest.where(idx);
+            return tagged(ctx, u8"%Where",
+                { lower(n.body, ctx),
+                  lower_span(n.definitions, ctx) });
+        }
+
+        case Kind::Dynamic: {
+            auto& n = forest.dynamic(idx);
+            return tagged(ctx, u8"%Dynamic",
+                { lower(n.expr, ctx) });
+        }
+
+        // -- Embedded Lisp --
+        case Kind::LispExpr: {
+            auto& n = forest.lisp_expr(idx);
+            auto text = Syntax::token_text(n.token, ctx.tokens, ctx.fragment);
+            return tagged(ctx, u8"%Lisp",
+                { ctx.arena.make_string(text) });
+        }
+
+        // -- Fallback --
+        case Kind::Unparsed:
+            return nil;
+
+        default:
+            return nil;
+        }
+    }
+}

--- a/src/syntax/boot-translator.cxx
+++ b/src/syntax/boot-translator.cxx
@@ -1,0 +1,3378 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Boot-to-Lisp translator implementation.
+
+#include <iostream>
+
+#include <open-axiom/BootTranslator>
+#include <open-axiom/BootAst>
+
+namespace OpenAxiom::Boot {
+
+    using namespace Lisp;
+
+    // -- Abbreviations
+
+    static Value sym(Arena& a, std::u8string_view s) { return a.make_symbol(s); }
+    static Value str(Arena& a, std::u8string_view s) { return a.make_string(s); }
+
+    // -- TranslationUnit
+
+    Value TranslationUnit::fresh_symbol(std::u8string_view prefix, int& counter)
+    {
+        ++counter;
+        auto name = std::u8string(prefix);
+        auto suffix = std::to_string(counter);
+        name.append(suffix.begin(), suffix.end());
+        return arena.make_symbol(name);
+    }
+
+    Value TranslationUnit::gensym()
+    {
+        return fresh_symbol(u8"bfVar#", gensym_counter);
+    }
+
+    Value TranslationUnit::let_var()
+    {
+        return fresh_symbol(u8"LETTMP#", let_var_counter);
+    }
+
+    Value TranslationUnit::is_var()
+    {
+        return fresh_symbol(u8"ISTMP#", is_var_counter);
+    }
+
+    // -- List utilities
+
+    // -- Append two lists.
+    static Value append_lists(Arena& a, Value xs, Value ys)
+    {
+        if (null(xs)) return ys;
+        return a.cons(car(xs), append_lists(a, cdr(xs), ys));
+    }
+
+    // -- Last element of a list.
+    static Value last_elem(Value lst)
+    {
+        if (null(lst)) return nil;
+        while (consp(cdr(lst))) lst = cdr(lst);
+        return car(lst);
+    }
+
+    // -- All elements except the last.
+    static Value but_last(Arena& a, Value lst)
+    {
+        if (null(lst) or null(cdr(lst))) return nil;
+        return a.cons(car(lst), but_last(a, cdr(lst)));
+    }
+
+    // -- Helper predicates matching the old translator
+
+    // -- Check if a parameter list (raw AST args) contains any
+    // string-literal ("double-quoted") parameters, which Boot
+    // uses for lazy evaluation.  Such functions get a ,LAM
+    // suffix in their DEFUN name.
+    // We must not recurse into %Bracket (destructuring patterns)
+    // or %Is (type tests) which may contain string constants.
+    static bool lazy_param_p(Value p)
+    {
+        if (stringp(p))
+            return true;
+        if (not consp(p))
+            return false;
+        auto tag = car(p);
+        if (not symbolp(tag))
+        {
+            // -- Plain list: check each element.
+            for (Value e = p; consp(e); e = cdr(e))
+                if (lazy_param_p(car(e)))
+                    return true;
+            return false;
+        }
+        auto name = symbol_name(tag);
+        // -- %PrefixExpr for rest-args like (: "args")
+        if (name == u8"%PrefixExpr")
+            return stringp(caddr(p));
+        // -- %Tuple for multi-arg like ("functor" "opname")
+        if (name == u8"%Tuple")
+        {
+            for (Value e = cdr(p); consp(e); e = cdr(e))
+                if (lazy_param_p(car(e)))
+                    return true;
+            return false;
+        }
+        // -- Do not recurse into %Bracket, %Is, etc.
+        return false;
+    }
+
+    static bool lazy_params_p(Value raw_args)
+    {
+        for (Value e = raw_args; consp(e); e = cdr(e))
+            if (lazy_param_p(car(e)))
+                return true;
+        return false;
+    }
+
+    static bool keywordp(Value x)
+    {
+        // -- Keywords in Common Lisp start with :
+        return symbolp(x) and not symbol_name(x).empty()
+            and symbol_name(x)[0] == ':';
+    }
+
+    static bool dollar_prefixed(Value x)
+    {
+        return symbolp(x) and not symbol_name(x).empty()
+            and symbol_name(x)[0] == '$';
+    }
+
+    // -- Core bf* functions (expression-level translation)
+
+    // -- Forward declarations.
+    static Value translate(TranslationUnit& tu, Value ast);
+    static Value bf_sequence(TranslationUnit& tu, Value lst);
+    static Value bf_mkprogn(Arena& a, Value lst);
+    static Value bf_lp(TranslationUnit& tu, Value iters, Value body);
+    static Value bf_is1(TranslationUnit& tu, Value lhs, Value rhs);
+
+    // -- Translate each element of a list, return a new list.
+    static Value tx_list(TranslationUnit& tu, Value lst)
+    {
+        std::vector<Value> result;
+        for (Value e = lst; consp(e); e = cdr(e))
+            result.push_back(translate(tu, car(e)));
+        return tu.arena.list(result);
+    }
+
+    // -- bfFlatten(op, x): if x is (op ...) return (cdr x), else (list x)
+    static Value bf_flatten(Arena& a, Value op, Value x)
+    {
+        if (consp(x) and symbolp(car(x)) and symbolp(op)
+            and symbol_name(car(x)) == symbol_name(op))
+            return cdr(x);
+        return a.cons(x, nil);
+    }
+
+    // -- bfFlattenSeq(l): flatten nested PROGNs
+    static Value bf_flatten_seq(Arena& a, Value lst)
+    {
+        if (null(lst)) return nil;
+        auto first = car(lst);
+        auto rest = bf_flatten_seq(a, cdr(lst));
+        if (consp(first) and is_symbol(car(first), u8"PROGN"))
+            return append_lists(a, cdr(first), rest);
+        return a.cons(first, rest);
+    }
+
+    // -- bfMKPROGN(l): flatten and wrap in PROGN if needed.
+    static Value bf_mkprogn(Arena& a, Value lst)
+    {
+        lst = bf_flatten_seq(a, lst);
+        if (null(lst)) return nil;
+        if (null(cdr(lst))) return car(lst);
+        return a.cons(sym(a, u8"PROGN"), lst);
+    }
+
+    // -- Unwrap PROGN: (PROGN e1 e2 ...) > (e1 e2 ...); x > (x).
+    static Value unwrap_progn(Arena& a, Value x)
+    {
+        if (consp(x) and is_symbol(car(x), u8"PROGN"))
+            return cdr(x);
+        return a.cons(x, nil);
+    }
+
+    // -- bfNOT(x): (NOT x) with double-negation elimination.
+
+    static Value bf_not(Arena& a, Value x)
+    {
+        if (consp(x) and is_symbol(car(x), u8"NOT") and consp(cdr(x))
+            and null(cddr(x)))
+            return cadr(x);
+        if (consp(x) and is_symbol(car(x), u8"NULL") and consp(cdr(x))
+            and null(cddr(x)))
+            return cadr(x);
+        return a.list({ sym(a, u8"NOT"), x });
+    }
+
+    // -- Flatten a logical connective list (AND/OR).
+    static Value bf_logical(Arena& a, const char8_t* op, Value identity, Value lst)
+    {
+        if (null(lst)) return identity;
+        if (null(cdr(lst))) return car(lst);
+        auto op_sym = sym(a, op);
+        std::vector<Value> elems;
+        for (Value cur = lst; consp(cur); cur = cdr(cur))
+        {
+            Value flat = bf_flatten(a, op_sym, car(cur));
+            for (Value f = flat; consp(f); f = cdr(f))
+                elems.push_back(car(f));
+        }
+        return a.cons(op_sym, a.list(elems));
+    }
+
+    // -- bfAND(l): (AND ...) with flattening.
+    static Value bf_and(Arena& a, Value lst)
+    {
+        return bf_logical(a, u8"AND", a.T, lst);
+    }
+
+    // -- bfOR(l): (OR ...) with flattening.
+    static Value bf_or(Arena& a, Value lst)
+    {
+        return bf_logical(a, u8"OR", nil, lst);
+    }
+
+    // -- Shared equality test logic used by both bf_q and bf_is1.
+    //    Dispatches on the type of `r` to choose EQ/EQL/EQUAL/STRING=.
+    static Value equality_test(Arena& a, Value l, Value r)
+    {
+        if (null(r)) return a.list({ sym(a, u8"NULL"), l });
+        if (symbolp(r) and symbol_name(r) == u8"T")
+            return a.list({ sym(a, u8"EQ"), l, r });
+        if (stringp(r))
+            return bf_and(a, a.list({
+                a.list({ sym(a, u8"STRINGP"), l }),
+                a.list({ sym(a, u8"STRING="), l, r }) }));
+        if (integerp(r))
+            return a.list({ sym(a, u8"EQL"), l, r });
+        if (consp(r) and is_symbol(car(r), u8"QUOTE") and consp(cdr(r)))
+        {
+            auto val = cadr(r);
+            if (symbolp(val)) return a.list({ sym(a, u8"EQ"), l, r });
+            if (stringp(val))
+                return bf_and(a, a.list({
+                    a.list({ sym(a, u8"STRINGP"), l }),
+                    a.list({ sym(a, u8"STRING="), l, val }) }));
+            return a.list({ sym(a, u8"EQUAL"), l, r });
+        }
+        return a.list({ sym(a, u8"EQUAL"), l, r });
+    }
+
+    // -- bfQ(l, r): equality test.
+    static Value bf_q(Arena& a, Value l, Value r)
+    {
+        return equality_test(a, l, r);
+    }
+
+    // -- bfLessp(l, r): numeric less-than.
+    static Value bf_lessp(Arena& a, Value l, Value r)
+    {
+        return a.list({ sym(a, u8"<"), l, r });
+    }
+
+    // -- bfMember(l, r): membership test.
+    static Value bf_member(Arena& a, Value l, Value r)
+    {
+        return a.list({ sym(a, u8"MEMBER"), l, r });
+    }
+
+    // -- bfInfApplication(op, left, right): infix operator translation.
+    static Value bf_inf_application(Arena& a, Value op, Value left, Value right)
+    {
+        auto name = symbolp(op) ? symbol_name(op) : std::u8string_view(u8"");
+        if (name == u8"=" or name == u8"EQUAL")
+            return bf_q(a, left, right);
+        if (name == u8"/=" or name == u8"~=")
+            return bf_not(a, bf_q(a, left, right));
+        if (name == u8">")
+            return bf_lessp(a, right, left);
+        if (name == u8"<")
+            return bf_lessp(a, left, right);
+        if (name == u8"<=")
+            return bf_not(a, bf_lessp(a, right, left));
+        if (name == u8">=")
+            return bf_not(a, bf_lessp(a, left, right));
+        if (name == u8"or" or name == u8"OR")
+            return bf_or(a, a.list({ left, right }));
+        if (name == u8"and" or name == u8"AND")
+            return bf_and(a, a.list({ left, right }));
+        if (name == u8"in" or name == u8"IN")
+            return bf_member(a, left, right);
+        return a.list({ op, left, right });
+    }
+
+    // -- bfTupleP(x): is x a TUPLE form?
+    static bool bf_tuple_p(Value x)
+    {
+        return consp(x) and is_symbol(car(x), u8"TUPLE");
+    }
+
+    // -- bfMakeCons(l): Build a LIST/CONS form from a list of elements.
+    static Value bf_make_cons(Arena& a, Value lst)
+    {
+        if (null(lst)) return nil;
+        if (null(cdr(lst)))
+        {
+            auto x = car(lst);
+            // -- Check for :x (colon/rest)
+            if (consp(x) and is_symbol(car(x), u8"COLON") and consp(cdr(x)))
+                return cadr(x);
+            return a.list({ sym(a, u8"LIST"), x });
+        }
+        auto x = car(lst);
+        auto rest = bf_make_cons(a, cdr(lst));
+        if (consp(x) and is_symbol(car(x), u8"COLON") and consp(cdr(x)))
+            return a.list({ sym(a, u8"APPEND"), cadr(x), rest });
+        if (consp(rest) and is_symbol(car(rest), u8"LIST"))
+            return a.cons(sym(a, u8"LIST"), a.cons(x, cdr(rest)));
+        return a.list({ sym(a, u8"CONS"), x, rest });
+    }
+
+    // -- bfConstruct(b): bracket/list construction.
+    // bfTupleConstruct: bracket list construction.
+    // If no element is a COLON form (splice), produce (LIST a b c).
+    // Otherwise, use bfMakeCons for nested CONS with splice handling.
+    static Value bf_tuple_construct(Arena& a, Value b)
+    {
+        Value elems;
+        if (bf_tuple_p(b))
+            elems = cdr(b);
+        else
+            elems = a.cons(b, nil);
+
+        // -- Check if any element is a COLON/splice form.
+        bool has_splice = false;
+        for (Value e = elems; consp(e); e = cdr(e))
+        {
+            auto elem = car(e);
+            if (consp(elem) and is_symbol(car(elem), u8"COLON"))
+            {
+                has_splice = true;
+                break;
+            }
+        }
+
+        if (has_splice)
+            return bf_make_cons(a, elems);
+
+        // -- No splices > (LIST elem1 elem2 ...)
+        return a.cons(sym(a, u8"LIST"), elems);
+    }
+
+    // -- bfConstruct: used for pattern brackets.
+    // Always produces nested CONS.
+    static Value bf_construct(Arena& a, Value b)
+    {
+        Value elems;
+        if (bf_tuple_p(b))
+            elems = cdr(b);
+        else
+            elems = a.cons(b, nil);
+        return bf_make_cons(a, elems);
+    }
+
+    // -- bfLetForm(lhs, rhs): simple let binding.
+    static Value bf_let_form(Arena& a, Value lhs, Value rhs)
+    {
+        return a.list({ sym(a, u8"L%T"), lhs, rhs });
+    }
+
+    // -- bfIf(a, b, c): conditional > COND.
+    static Value bf_if(Arena& a, Value cond, Value consq, Value alt)
+    {
+        auto b1 = unwrap_progn(a, consq);
+
+        // -- If alternate is already a COND, merge.
+        if (consp(alt) and is_symbol(car(alt), u8"COND"))
+            return a.cons(sym(a, u8"COND"),
+                          a.cons(a.cons(cond, b1), cdr(alt)));
+
+        auto c1 = unwrap_progn(a, alt);
+
+        return a.list({
+            sym(a, u8"COND"),
+            a.cons(cond, b1),
+            a.cons(a.T, c1) });
+    }
+
+    // -- bfIfThenOnly(a, b): one-armed conditional.
+    static Value bf_if_then_only(Arena& a, Value cond, Value consq)
+    {
+        return a.list({ sym(a, u8"COND"),
+            a.cons(cond, unwrap_progn(a, consq)) });
+    }
+
+    // -- bfExit(a, b): exit/implies > COND with IDENTITY.
+    static Value bf_exit(Arena& a, Value cond, Value body)
+    {
+        return a.list({
+            sym(a, u8"COND"),
+            a.list({ cond, a.list({ sym(a, u8"IDENTITY"), body }) }) });
+    }
+
+    // -- bfSuffixDot(x): (x "DOT")
+    static Value bf_suffix_dot(Arena& a, Value x)
+    {
+        return a.list({ x, str(a, u8"DOT") });
+    }
+
+    // -- bfReturnNoName(x): (RETURN x)
+    static Value bf_return(Arena& a, Value x)
+    {
+        return a.list({ sym(a, u8"RETURN"), x });
+    }
+
+    // -- bfLeave(x): (%Leave x) - stays until shoeCompTran1.
+    static Value bf_leave(Arena& a, Value x)
+    {
+        return a.list({ sym(a, u8"%Leave"), x });
+    }
+
+    // -- bfEqual(x): (EQUAL x) - pattern matching equality.
+    static Value bf_equal(Arena& a, Value x)
+    {
+        return a.list({ sym(a, u8"EQUAL"), x });
+    }
+
+    // -- bfSignature(a, b): type signature.
+    static Value bf_signature(Arena& a, Value name, Value type)
+    {
+        if (is_symbol(type, u8"local"))
+        {
+            // -- compFluid: (%Dynamic name)
+            return a.list({ sym(a, u8"%Dynamic"), name });
+        }
+        return a.list({ sym(a, u8"%Signature"), name, type });
+    }
+
+    // -- bfSegment1(lo): (SEGMENT lo NIL)
+    static Value bf_segment1(Arena& a, Value lo)
+    {
+        return a.list({ sym(a, u8"SEGMENT"), lo, nil });
+    }
+
+    // -- bfSegment2(lo, hi): (SEGMENT lo hi)
+    static Value bf_segment2(Arena& a, Value lo, Value hi)
+    {
+        return a.list({ sym(a, u8"SEGMENT"), lo, hi });
+    }
+
+    // -- bfRestrict(x, t): (THE t x)
+    static Value bf_restrict(Arena& a, Value x, Value t)
+    {
+        return a.list({ sym(a, u8"THE"), t, x });
+    }
+
+    // -- bfAssign(tu, l, r): assignment translation.
+    static Value bf_assign(TranslationUnit& tu, Value l, Value r)
+    {
+        if (bf_tuple_p(l))
+        {
+            // -- Tuple assignment > SETELT form.
+            // Simplified: just produce SETF.
+            return tu.arena.list({ sym(tu.arena, u8"SETF"), l, r });
+        }
+        if (consp(l) and is_symbol(car(l), u8"%Place"))
+        {
+            return tu.arena.list({ sym(tu.arena, u8"SETF"), cdr(l), r });
+        }
+        // -- Simple assignment > L%T.
+        return bf_let_form(tu.arena, l, r);
+    }
+
+    // -- Iterator translation
+
+    // -- Iterator format (internal representation matching old Boot):
+    //   (vars inits sucs filters exits value)
+    // Each field is a list.
+
+    // -- bfWhile(p): iterator that checks condition.
+    static Value bf_while(TranslationUnit& tu, Value p)
+    {
+        auto& a = tu.arena;
+        // -- ((NIL NIL NIL NIL (NOT-p) NIL))
+        return a.list({
+            a.list({
+                nil, nil, nil, nil,
+                a.cons(bf_not(a, p), nil),
+                nil }) });
+    }
+
+    // -- bfUntil(p): iterator that checks exit condition.
+    static Value bf_until(TranslationUnit& tu, Value p)
+    {
+        auto& a = tu.arena;
+        auto g = tu.gensym();
+        return a.list({
+            a.list({
+                a.cons(g, nil),              // vars
+                a.cons(nil, nil),             // inits
+                a.cons(a.list({ sym(a, u8"SETQ"), g, p }), nil),  // sucs
+                nil,                          // filters
+                a.cons(g, nil),               // exits
+                nil }) });                    // value
+    }
+
+    // -- bfSuchthat(p): filter iterator.
+    static Value bf_suchthat(TranslationUnit& tu, Value p)
+    {
+        auto& a = tu.arena;
+        return a.list({
+            a.list({ nil, nil, nil, a.cons(p, nil), nil, nil }) });
+    }
+
+    // -- bfIN(tu, x, e): list iteration (IN).
+    static Value bf_in(TranslationUnit& tu, Value x, Value e)
+    {
+        auto& a = tu.arena;
+        auto g = tu.gensym();
+        auto vars = a.cons(g, nil);
+        auto inits = a.cons(e, nil);
+        auto exit_cond = a.list({ sym(a, u8"NOT"),
+                                  a.list({ sym(a, u8"CONSP"), g }) });
+        Value suc = a.list({ sym(a, u8"SETQ"), g,
+                         a.list({ sym(a, u8"CDR"), g }) });
+
+        if (not is_symbol(x, u8"DOT"))
+        {
+            vars = a.list({ g, x });
+            inits = a.list({ e, nil });
+            exit_cond = a.list({
+                sym(a, u8"OR"), exit_cond,
+                a.list({ sym(a, u8"PROGN"),
+                         a.list({ sym(a, u8"SETQ"), x,
+                                  a.list({ sym(a, u8"CAR"), g }) }),
+                         sym(a, u8"NIL") }) });
+        }
+
+        return a.list({
+            a.list({
+                vars, inits,
+                a.cons(suc, nil),
+                nil,
+                a.cons(exit_cond, nil),
+                nil }) });
+    }
+
+    // -- bfON(tu, x, e): tail iteration (ON).
+    static Value bf_on(TranslationUnit& tu, Value x, Value e)
+    {
+        auto& a = tu.arena;
+        if (is_symbol(x, u8"DOT"))
+            x = tu.gensym();
+
+        Value vars = nil;
+        Value inits = nil;
+        if (not symbolp(e) or not (symbolp(x) and symbol_name(x) == symbol_name(e)))
+        {
+            vars = a.cons(x, nil);
+            inits = a.cons(e, nil);
+        }
+
+        auto suc = a.list({ sym(a, u8"SETQ"), x,
+                            a.list({ sym(a, u8"CDR"), x }) });
+        auto exit_cond = a.list({ sym(a, u8"NOT"),
+                                  a.list({ sym(a, u8"CONSP"), x }) });
+
+        return a.list({
+            a.list({
+                vars, inits,
+                a.cons(suc, nil),
+                nil,
+                a.cons(exit_cond, nil),
+                nil }) });
+    }
+
+    // -- bfSTEP(tu, id, fst, step, lst): numeric stepping.
+    static Value bf_step(TranslationUnit& tu, Value id, Value fst, Value step, Value lst)
+    {
+        auto& a = tu.arena;
+        if (is_symbol(id, u8"DOT"))
+            id = tu.gensym();
+
+        auto initvar = a.cons(id, nil);
+        auto initval = a.cons(fst, nil);
+        Value inc = step;
+        Value final_val = lst;
+
+        if (consp(step))
+        {
+            auto g1 = tu.gensym();
+            initvar = a.cons(g1, initvar);
+            initval = a.cons(step, initval);
+            inc = g1;
+        }
+
+        if (consp(lst))
+        {
+            auto g2 = tu.gensym();
+            initvar = a.cons(g2, initvar);
+            initval = a.cons(lst, initval);
+            final_val = g2;
+        }
+
+        Value exits = nil;
+        if (not null(lst))
+        {
+            if (integerp(inc))
+            {
+                auto pred = (integer_value(inc) < 0)
+                    ? sym(a, u8"<") : sym(a, u8">");
+                exits = a.cons(a.list({ pred, id, final_val }), nil);
+            }
+            else
+            {
+                exits = a.cons(
+                    a.list({
+                        sym(a, u8"COND"),
+                        a.list({ a.list({ sym(a, u8"MINUSP"), inc }),
+                                 a.list({ sym(a, u8"<"), id, final_val }) }),
+                        a.list({ a.T,
+                                 a.list({ sym(a, u8">"), id, final_val }) }) }),
+                    nil);
+            }
+        }
+
+        auto suc = a.list({ sym(a, u8"SETQ"), id,
+                            a.list({ sym(a, u8"+"), id, inc }) });
+
+        return a.list({
+            a.list({
+                initvar, initval,
+                a.cons(suc, nil),
+                nil,
+                exits,
+                nil }) });
+    }
+
+    // -- bfFor(tu, lhs, u, step): dispatch for-in iteration.
+    static Value bf_for(TranslationUnit& tu, Value lhs, Value u, Value step)
+    {
+        auto& a = tu.arena;
+        if (consp(u) and is_symbol(car(u), u8"tails"))
+            return bf_on(tu, lhs, cadr(u));
+        if (consp(u) and is_symbol(car(u), u8"SEGMENT"))
+            return bf_step(tu, lhs, cadr(u), step, caddr(u));
+        // -- Default: IN iteration.
+        // For structured lhs (destructuring), use bfForTree.
+        if (symbolp(lhs))
+            return bf_in(tu, lhs, u);
+        // -- bfForTree: structured LHS.
+        auto g = tu.gensym();
+        auto in_iter = bf_in(tu, g, u);
+        auto suchthat = bf_suchthat(tu,
+            bf_is1(tu, g, lhs));
+        return append_lists(a, in_iter, suchthat);
+    }
+
+    // -- bfIterators(l): wrap iterator list.
+    static Value bf_iterators(Arena& a, Value lst)
+    {
+        return a.cons(sym(a, u8"ITERATORS"), lst);
+    }
+
+    // -- bfCross(l): wrap cross-product iterator list.
+    static Value bf_cross(Arena& a, Value lst)
+    {
+        return a.cons(sym(a, u8"CROSS"), lst);
+    }
+
+    // -- bfSep(iterators): separate iterator fields.
+    //    Each iterator is ((vars inits sucs filters exits value)).
+    //    Returns (all-vars all-inits all-sucs all-filters all-exits all-values).
+    static Value bf_sep(Arena& a, Value iters)
+    {
+        std::vector<Value> all_vars, all_inits, all_sucs, all_filters,
+                       all_exits, all_values;
+
+        for (Value it = iters; consp(it); it = cdr(it))
+        {
+            auto iter = car(it);
+            if (not consp(iter)) continue;
+            auto entry = car(iter);
+            if (not consp(entry)) continue;
+
+            // -- entry = (vars inits sucs filters exits value)
+            auto vars = car(entry);
+            auto inits = (consp(cdr(entry))) ? cadr(entry) : nil;
+            auto sucs = (consp(cddr(entry))) ? caddr(entry) : nil;
+            auto filters_v = nil;
+            auto exits_v = nil;
+            auto value_v = nil;
+            if (consp(cddr(entry)))
+            {
+                auto rest3 = cddr(entry);
+                if (consp(cdr(rest3))) filters_v = cadr(rest3);
+                if (consp(cddr(rest3))) exits_v = car(cddr(rest3));
+                if (consp(cdr(cddr(rest3)))) value_v = cadr(cddr(rest3));
+            }
+
+            for (Value v = vars; consp(v); v = cdr(v))
+                all_vars.push_back(car(v));
+            for (Value v = inits; consp(v); v = cdr(v))
+                all_inits.push_back(car(v));
+            for (Value v = sucs; consp(v); v = cdr(v))
+                all_sucs.push_back(car(v));
+            for (Value v = filters_v; consp(v); v = cdr(v))
+                all_filters.push_back(car(v));
+            for (Value v = exits_v; consp(v); v = cdr(v))
+                all_exits.push_back(car(v));
+            for (Value v = value_v; consp(v); v = cdr(v))
+                all_values.push_back(car(v));
+        }
+
+        return a.list({
+            a.list(all_vars),
+            a.list(all_inits),
+            a.list(all_sucs),
+            a.list(all_filters),
+            a.list(all_exits),
+            a.list(all_values) });
+    }
+
+    // -- bfLp1(tu, iters, body): build a LOOP form.
+    static Value bf_lp1(TranslationUnit& tu, Value iters, Value body)
+    {
+        auto& a = tu.arena;
+        auto sep = bf_sep(a, iters);
+        auto vars = car(sep);
+        auto inits = cadr(sep);
+        auto sucs = caddr(sep);
+        auto rest3 = cddr(sep);
+        auto filters = (consp(cdr(rest3))) ? cadr(rest3) : nil;
+        auto exits = (consp(cddr(rest3))) ? car(cddr(rest3)) : nil;
+        auto values = (consp(cdr(cddr(rest3)))) ? cadr(cddr(rest3)) : nil;
+
+        // -- Apply filters to body.
+        Value nbody = body;
+        if (not null(filters))
+        {
+            auto combined = append_lists(a, filters, a.cons(body, nil));
+            nbody = bf_and(a, combined);
+        }
+
+        // -- Value defaults to NIL.
+        Value value = null(values) ? nil : car(values);
+
+        // -- Apply exit conditions.
+        Value loop_body;
+        if (null(exits))
+            loop_body = nbody;
+        else
+            loop_body = bf_if(a,
+                bf_or(a, exits),
+                a.list({ sym(a, u8"RETURN"), value }),
+                nbody);
+
+        // -- Build LOOP form.
+        Value loop_form = a.cons(sym(a, u8"LOOP"),
+                             a.cons(loop_body, sucs));
+
+        // -- Wrap in LET if there are variables.
+        if (not null(vars))
+        {
+            // -- Build bindings: ((v1 i1) (v2 i2) ...)
+            std::vector<Value> bindings;
+            Value vp = vars, ip = inits;
+            while (consp(vp) and consp(ip))
+            {
+                bindings.push_back(a.list({ car(vp), car(ip) }));
+                vp = cdr(vp);
+                ip = cdr(ip);
+            }
+            loop_form = a.list({
+                sym(a, u8"LET"),
+                a.list(bindings),
+                loop_form });
+        }
+
+        return loop_form;
+    }
+
+    // -- bfLp(tu, iters, body): dispatch on iterator type.
+    static Value bf_lp(TranslationUnit& tu, Value iters, Value body)
+    {
+        if (consp(iters) and is_symbol(car(iters), u8"ITERATORS"))
+            return bf_lp1(tu, cdr(iters), body);
+        // -- CROSS: handle crossed iterators.
+        // For now, handle as ITERATORS.
+        if (consp(iters) and is_symbol(car(iters), u8"CROSS"))
+        {
+            // -- Cross-product iteration: nested loops.
+            // Simplified: just use first factor.
+            auto factors = cdr(iters);
+            if (null(factors)) return body;
+            if (null(cdr(factors)))
+            {
+                auto factor = car(factors);
+                if (consp(factor) and is_symbol(car(factor), u8"ITERATORS"))
+                    return bf_lp1(tu, cdr(factor), body);
+            }
+            // -- Multiple factors: nest them.
+            Value result = body;
+            for (Value f = factors; consp(f); f = cdr(f))
+            {
+                auto factor = car(f);
+                if (consp(factor) and is_symbol(car(factor), u8"ITERATORS"))
+                    result = bf_lp1(tu, cdr(factor), result);
+            }
+            return result;
+        }
+        return body;
+    }
+
+    // -- bfMakeCollectInsn: build the collect loop body.
+    static Value bf_make_collect_insn(Arena& a, Value expr, Value prev, Value head, Value adv)
+    {
+        auto first_time = bf_mkprogn(a, a.list({
+            a.list({ sym(a, u8"SETQ"), head, expr }),
+            a.list({ sym(a, u8"SETQ"), prev,
+                     is_symbol(adv, u8"CDR") ? head
+                         : a.list({ adv, head }) }) }));
+        auto other_time = bf_mkprogn(a, a.list({
+            a.list({ sym(a, u8"RPLACD"), prev, expr }),
+            a.list({ sym(a, u8"SETQ"), prev,
+                     a.list({ adv, prev }) }) }));
+        return bf_if(a, a.list({ sym(a, u8"NULL"), head }),
+                     first_time, other_time);
+    }
+
+    // -- bfDoCollect: build a collect loop.
+    static Value bf_do_collect(TranslationUnit& tu, Value expr, Value itl,
+                           Value adv, Value skip_nil)
+    {
+        auto& a = tu.arena;
+        auto head = tu.gensym();
+        auto prev = tu.gensym();
+
+        Value body;
+        if (not null(skip_nil))
+        {
+            auto x = tu.gensym();
+            body = a.list({
+                sym(a, u8"LET"),
+                a.list({ a.list({ x, expr }) }),
+                bf_if(a, a.list({ sym(a, u8"NULL"), x }), nil,
+                      bf_make_collect_insn(a, x, prev, head, adv)) });
+        }
+        else
+        {
+            body = bf_make_collect_insn(a, expr, prev, head, adv);
+        }
+
+        auto extrait = a.list({
+            a.list({
+                a.list({ head, prev }),
+                a.list({ nil, nil }),
+                nil, nil, nil,
+                a.cons(head, nil) }) });
+
+        // -- bfLp2
+        Value iters;
+        if (consp(itl) and is_symbol(car(itl), u8"ITERATORS"))
+            iters = bf_iterators(a,
+                a.cons(extrait, cdr(itl)));
+        else if (consp(itl) and is_symbol(car(itl), u8"CROSS"))
+        {
+            auto factors = cdr(itl);
+            iters = bf_cross(a,
+                a.cons(bf_iterators(a, a.cons(extrait, 
+                    consp(car(factors)) ? cdr(car(factors)) : nil)),
+                    cdr(factors)));
+        }
+        else
+            iters = bf_iterators(a, a.cons(extrait, nil));
+
+        return bf_lp(tu, iters, body);
+    }
+
+    // -- bfCollect: translate a collect form.
+    static Value bf_collect(TranslationUnit& tu, Value y, Value itl)
+    {
+        auto& a = tu.arena;
+        // -- Check for :x (append collect).
+        if (consp(y) and is_symbol(car(y), u8"COLON") and consp(cdr(y)))
+        {
+            auto body = cadr(y);
+            if ((consp(body) and is_symbol(car(body), u8"CONS"))
+                or (consp(body) and is_symbol(car(body), u8"LIST")))
+            {
+                return bf_do_collect(tu, body, itl,
+                                     sym(a, u8"lastNode"),
+                                     sym(a, u8"skipNil"));
+            }
+            return bf_do_collect(tu,
+                a.list({ sym(a, u8"copyList"), body }),
+                itl, sym(a, u8"lastNode"), sym(a, u8"skipNil"));
+        }
+        if (consp(y) and is_symbol(car(y), u8"TUPLE"))
+        {
+            return bf_do_collect(tu, bf_construct(a, y), itl,
+                                 sym(a, u8"lastNode"),
+                                 sym(a, u8"skipNil"));
+        }
+        // -- Default: simple collect.
+        return bf_do_collect(tu,
+            a.list({ sym(a, u8"CONS"), y, nil }),
+            itl, sym(a, u8"CDR"), nil);
+    }
+
+    // -- bfReduce: translate a reduce form.
+    static Value bf_reduce(TranslationUnit& tu, Value op, Value y)
+    {
+        auto& a = tu.arena;
+        // -- Extract the actual operator name.
+        Value actual_op = op;
+        if (consp(op) and is_symbol(car(op), u8"QUOTE"))
+            actual_op = cadr(op);
+
+        auto g = tu.gensym();
+        auto g1 = tu.gensym();
+        auto body = a.list({ sym(a, u8"SETQ"), g,
+                             a.list({ actual_op, g, g1 }) });
+
+        // -- Simple case: no initial value, iterate with first element.
+        auto g2 = tu.gensym();
+        auto init = a.list({ sym(a, u8"CAR"), g2 });
+        auto ny = a.list({ sym(a, u8"CDR"), g2 });
+        auto iter_g = a.list({
+            a.list({
+                a.cons(g, nil),
+                a.cons(init, nil),
+                nil, nil, nil,
+                a.cons(g, nil) }) });
+        auto iter_g1 = bf_in(tu, g1, ny);
+        auto iters = bf_iterators(a,
+            a.list({ iter_g, iter_g1 }));
+        return bf_mkprogn(a, a.list({
+            a.list({ sym(a, u8"L%T"), g2, y }),
+            bf_lp(tu, iters, body) }));
+    }
+
+    // -- Pattern matching (bfIS / bfIS1)
+
+    // -- Convert AST pattern to CONS-cell representation suitable
+    // for bfIS1. A bracket pattern ['%Key, k, v] becomes
+    // (CONS (QUOTE |%Key|) (CONS |k| (CONS |v| NIL))).
+    static Value tx_pattern(TranslationUnit& tu, Value ast)
+    {
+        auto& a = tu.arena;
+
+        if (null(ast)) return nil;
+        if (not consp(ast))
+        {
+            // -- Symbols and literals pass through.
+            return ast;
+        }
+
+        auto tag_v = car(ast);
+        if (not symbolp(tag_v))
+            return ast;
+        auto tag = symbol_name(tag_v);
+
+        // -- %Quote pattern: ('x) > (QUOTE x).
+        if (tag == u8"%Quote")
+            return a.list({ sym(a, u8"QUOTE"), cadr(ast) });
+
+        // -- %EqualPattern: (= x) > (EQUAL x).
+        if (tag == u8"%EqualPattern")
+        {
+            auto expr = translate(tu, cadr(ast));
+            return a.list({ sym(a, u8"EQUAL"), expr });
+        }
+
+        // -- %Bracket: [a, b, c] > (CONS a' (CONS b' (CONS c' NIL)))
+        // If single element is a Tuple, expand it directly.
+        if (tag == u8"%Bracket")
+        {
+            auto elems_list = cadr(ast);
+            // -- Single-element Tuple > expand directly.
+            if (consp(elems_list) and null(cdr(elems_list)))
+            {
+                auto elem = car(elems_list);
+                if (consp(elem) and symbolp(car(elem))
+                    and symbol_name(car(elem)) == u8"%Tuple")
+                {
+                    return tx_pattern(tu, elem);
+                }
+                // -- Single non-tuple element.
+                return tx_pattern(tu, elem);
+            }
+            // -- Multiple elements > CONS chain.
+            Value result = nil;
+            std::vector<Value> elems;
+            for (Value e = elems_list; consp(e); e = cdr(e))
+                elems.push_back(tx_pattern(tu, car(e)));
+            for (int i = static_cast<int>(elems.size()) - 1;
+                 i >= 0; --i)
+            {
+                result = a.list({ sym(a, u8"CONS"),
+                                  elems[i], result });
+            }
+            return result;
+        }
+
+        // -- %Tuple: (a, b, c) > (CONS a' (CONS b' (CONS c' NIL)))
+        if (tag == u8"%Tuple")
+        {
+            auto elems_list = cadr(ast);
+            Value result = nil;
+            std::vector<Value> elems;
+            for (Value e = elems_list; consp(e); e = cdr(e))
+                elems.push_back(tx_pattern(tu, car(e)));
+            for (int i = static_cast<int>(elems.size()) - 1;
+                 i >= 0; --i)
+            {
+                result = a.list({ sym(a, u8"CONS"),
+                                  elems[i], result });
+            }
+            return result;
+        }
+
+        // -- %ColonAppend: [:a, rest] in pattern > DOT
+        if (tag == u8"%ColonAppend")
+        {
+            auto head_list = cadr(ast);
+            auto rest_ast = caddr(ast);
+            // -- Translate head elements and rest.
+            std::vector<Value> heads;
+            for (Value e = head_list; consp(e); e = cdr(e))
+                heads.push_back(tx_pattern(tu, car(e)));
+            Value tail = null(rest_ast)
+                ? sym(a, u8"DOT")
+                : tx_pattern(tu, rest_ast);
+            Value result = tail;
+            for (int i = static_cast<int>(heads.size()) - 1;
+                 i >= 0; --i)
+            {
+                result = a.list({ sym(a, u8"CONS"),
+                                  heads[i], result });
+            }
+            return result;
+        }
+
+        // -- %Call in pattern context: translate the expression.
+        if (tag == u8"%Call")
+        {
+            auto fun = translate(tu, cadr(ast));
+            auto args_list = caddr(ast);
+            std::vector<Value> targs;
+            for (Value e = args_list; consp(e); e = cdr(e))
+                targs.push_back(translate(tu, car(e)));
+            if (targs.empty())
+                return fun;
+            return a.cons(fun, a.list(targs));
+        }
+
+        // -- Default: translate as expression.
+        return translate(tu, ast);
+    }
+
+    // -- bfIS(tu, lhs, rhs): pattern match with variable counter save.
+    static Value bf_is(TranslationUnit& tu, Value lhs, Value rhs)
+    {
+        auto saved_isno = tu.is_var_counter;
+        tu.is_var_counter = 0;
+        auto result = bf_is1(tu, lhs, rhs);
+        tu.is_var_counter = saved_isno;
+        return result;
+    }
+
+    // -- bfIS1: the core pattern matching logic.
+    static Value bf_is1(TranslationUnit& tu, Value lhs, Value rhs)
+    {
+        auto& a = tu.arena;
+
+        // -- Atoms handled by shared equality_test.
+        if (null(rhs) or (symbolp(rhs) and symbol_name(rhs) == u8"T")
+            or stringp(rhs) or integerp(rhs))
+            return equality_test(a, lhs, rhs);
+
+        // -- Keyword pattern.
+        if (keywordp(rhs))
+            return a.list({ sym(a, u8"EQ"), lhs, rhs });
+
+        // -- Simple variable binding.
+        if (not consp(rhs))
+        {
+            return a.list({ sym(a, u8"PROGN"),
+                            bf_let_form(a, rhs, lhs), a.T });
+        }
+
+        // -- QUOTE pattern - use shared equality_test.
+        if (is_symbol(car(rhs), u8"QUOTE"))
+            return equality_test(a, lhs, rhs);
+
+        // -- L%T pattern (let in pattern).
+        if (is_symbol(car(rhs), u8"L%T"))
+        {
+            auto c = cadr(rhs);
+            auto d = caddr(rhs);
+            return bf_and(a, a.list({
+                bf_is1(tu, lhs, d),
+                bf_mkprogn(a, a.list({
+                    bf_let_form(a, c, lhs), a.T })) }));
+        }
+
+        // -- EQUAL pattern.
+        if (is_symbol(car(rhs), u8"EQUAL") and consp(cdr(rhs))
+            and null(cddr(rhs)))
+        {
+            return bf_q(a, lhs, cadr(rhs));
+        }
+
+        // -- CONS pattern (destructuring).
+        if (is_symbol(car(rhs), u8"CONS") and consp(cdr(rhs)))
+        {
+            auto head = cadr(rhs);
+            auto tail = caddr(rhs);
+
+            // -- (CONS DOT DOT) > just CONSP.
+            if (is_symbol(head, u8"DOT") and is_symbol(tail, u8"DOT"))
+                return a.list({ sym(a, u8"CONSP"), lhs });
+
+            // -- Complex LHS > bind to temp var.
+            if (consp(lhs))
+            {
+                auto g = tu.is_var();
+                return bf_mkprogn(a, a.list({
+                    bf_let_form(a, g, lhs),
+                    bf_is1(tu, g, rhs) }));
+            }
+
+            // -- (CONS DOT tail)
+            if (is_symbol(head, u8"DOT"))
+            {
+                if (null(tail))
+                    return bf_and(a, a.list({
+                        a.list({ sym(a, u8"CONSP"), lhs }),
+                        a.list({ sym(a, u8"NULL"),
+                                 a.list({ sym(a, u8"CDR"), lhs }) }) }));
+                if (is_symbol(tail, u8"DOT"))
+                    return a.list({ sym(a, u8"CONSP"), lhs });
+                return bf_and(a, a.list({
+                    a.list({ sym(a, u8"CONSP"), lhs }),
+                    bf_is1(tu, a.list({ sym(a, u8"CDR"), lhs }), tail) }));
+            }
+
+            // -- (CONS head NIL)
+            if (null(tail))
+                return bf_and(a, a.list({
+                    a.list({ sym(a, u8"CONSP"), lhs }),
+                    a.list({ sym(a, u8"NULL"),
+                             a.list({ sym(a, u8"CDR"), lhs }) }),
+                    bf_is1(tu, a.list({ sym(a, u8"CAR"), lhs }), head) }));
+
+            // -- (CONS head DOT) > just car matters.
+            if (is_symbol(tail, u8"DOT"))
+                return bf_and(a, a.list({
+                    a.list({ sym(a, u8"CONSP"), lhs }),
+                    bf_is1(tu, a.list({ sym(a, u8"CAR"), lhs }), head) }));
+
+            // -- General case: match both car and cdr.
+            return bf_and(a, a.list({
+                a.list({ sym(a, u8"CONSP"), lhs }),
+                bf_is1(tu, a.list({ sym(a, u8"CAR"), lhs }), head),
+                bf_is1(tu, a.list({ sym(a, u8"CDR"), lhs }), tail) }));
+        }
+
+        // -- Default: error/unhandled.
+        return a.list({ sym(a, u8"EQUAL"), lhs, rhs });
+    }
+
+    // -- bfLET / bfLET1: let-binding with destructuring
+
+    // -- bfCONTAINED: check if symbol x appears in tree y.
+    static bool bf_contained(Value x, Value y)
+    {
+        if (null(y)) return false;
+        if (symbolp(y))
+            return symbolp(x) and symbol_name(x) == symbol_name(y);
+        if (not consp(y)) return false;
+        return bf_contained(x, car(y)) or bf_contained(x, cdr(y));
+    }
+
+    // -- bfLET2: destructuring let for cons patterns.
+    static Value bf_let2(TranslationUnit& tu, Value lhs, Value rhs)
+    {
+        auto& a = tu.arena;
+        if (not consp(lhs)) return bf_let_form(a, lhs, rhs);
+
+        if (is_symbol(car(lhs), u8"CONS") and consp(cdr(lhs)))
+        {
+            auto h = cadr(lhs);
+            auto t = caddr(lhs);
+            Value r1, r2;
+            if (null(t))
+            {
+                r1 = bf_let2(tu, h, a.list({ sym(a, u8"CAR"), rhs }));
+                return r1;
+            }
+            if (null(h) or is_symbol(h, u8"DOT"))
+            {
+                r2 = bf_let2(tu, t, a.list({ sym(a, u8"CDR"), rhs }));
+                return r2;
+            }
+            r1 = bf_let2(tu, h, a.list({ sym(a, u8"CAR"), rhs }));
+            r2 = bf_let2(tu, t, a.list({ sym(a, u8"CDR"), rhs }));
+            if (consp(r2) and is_symbol(car(r2), u8"PROGN"))
+                return bf_mkprogn(a, a.cons(r1, cdr(r2)));
+            return bf_mkprogn(a, a.list({ r1, r2 }));
+        }
+        return bf_let_form(a, lhs, rhs);
+    }
+
+    // -- bfLET1: let-binding with destructuring.
+    static Value bf_let1(TranslationUnit& tu, Value lhs, Value rhs)
+    {
+        auto& a = tu.arena;
+        // -- Simple symbol.
+        if (symbolp(lhs)) return bf_let_form(a, lhs, rhs);
+
+        // -- %Dynamic or %Signature.
+        if (consp(lhs) and (is_symbol(car(lhs), u8"%Dynamic")
+            or is_symbol(car(lhs), u8"%Signature")))
+            return bf_let_form(a, lhs, rhs);
+
+        // -- Simple rhs (symbol) not contained in lhs.
+        if (symbolp(rhs) and not bf_contained(rhs, lhs))
+            return bf_let2(tu, lhs, rhs);
+
+        // -- General case: bind rhs to a temp var.
+        auto g = tu.let_var();
+        auto r = bf_let_form(a, g, rhs);
+        auto l = bf_let1(tu, lhs, g);
+        if (consp(l) and is_symbol(car(l), u8"PROGN"))
+            return bf_mkprogn(a, a.cons(r, cdr(l)));
+        return bf_mkprogn(a, a.list({ r, l, g }));
+    }
+
+    // -- bfLET: let-binding with counter save/restore.
+    static Value bf_let(TranslationUnit& tu, Value lhs, Value rhs)
+    {
+        auto saved = tu.let_var_counter;
+        tu.let_var_counter = 0;
+        auto result = bf_let1(tu, lhs, rhs);
+        tu.let_var_counter = saved;
+        return result;
+    }
+
+    // -- Main expression translator
+
+    // -- translate: translate an expression-level AST node.
+    static Value translate(TranslationUnit& tu, Value ast)
+    {
+        auto& a = tu.arena;
+
+        // -- NIL stays NIL.
+        if (null(ast)) return nil;
+
+        // -- Atoms pass through.
+        if (atomp(ast))
+        {
+            // -- Map Boot false/true/nil to Lisp.
+            if (symbolp(ast))
+            {
+                auto name = symbol_name(ast);
+                if (name == u8"false") return nil;
+                if (name == u8"true") return a.T;
+                if (name == u8"nil") return nil;
+            }
+            return ast;
+        }
+
+        // -- Tagged AST node: dispatch on the tag.
+        if (not consp(ast)) return ast;
+
+        auto tag_v = car(ast);
+        if (not symbolp(tag_v)) return ast;
+        auto tag = symbol_name(tag_v);
+
+        // -- Function call.
+        if (tag == u8"%Call")
+        {
+            auto fun = translate(tu, cadr(ast));
+            auto args_list = caddr(ast);
+            // -- Translate each argument.
+            std::vector<Value> targs;
+            for (Value e = args_list; consp(e); e = cdr(e))
+                targs.push_back(translate(tu, car(e)));
+            auto targ_list = a.list(targs);
+
+            // -- If there's a single %Tuple arg, expand it.
+            if (targs.size() == 1 and bf_tuple_p(targs[0]))
+                return tu.arena.cons(fun, cdr(targs[0]));
+            return tu.arena.cons(fun, targ_list);
+        }
+
+        // -- Infix expression.
+        if (tag == u8"%InfixExpr")
+        {
+            auto op = translate(tu, cadr(ast));
+            auto lhs = translate(tu, caddr(ast));
+            auto rhs = translate(tu, car(cddr(cdr(ast))));
+            return bf_inf_application(a, op, lhs, rhs);
+        }
+
+        // -- Prefix expression.
+        if (tag == u8"%PrefixExpr")
+        {
+            auto op = translate(tu, cadr(ast));
+            auto operand = translate(tu, caddr(ast));
+            // -- Special case: 'not' > NOT.
+            if (is_symbol(op, u8"not") or is_symbol(op, u8"NOT"))
+                return bf_not(a, operand);
+            return a.list({ op, operand });
+        }
+
+        // -- Quote.
+        if (tag == u8"%Quote")
+        {
+            auto expr = cadr(ast);
+            // -- Don't translate the quoted expression.
+            return a.list({ sym(a, u8"QUOTE"), expr });
+        }
+
+        // -- Bracket (list construction).
+        if (tag == u8"%Bracket")
+        {
+            auto elems_list = cadr(ast);
+            // -- If bracket has single element that is a Tuple,
+            // extract tuple elements and check for splices.
+            if (consp(elems_list) and null(cdr(elems_list)))
+            {
+                auto elem = car(elems_list);
+                if (consp(elem) and symbolp(car(elem))
+                    and symbol_name(car(elem)) == u8"%Tuple")
+                {
+                    auto tuple_elems = cadr(elem);
+                    std::vector<Value> telems;
+                    for (Value e = tuple_elems; consp(e); e = cdr(e))
+                    {
+                        auto te = car(e);
+                        if (consp(te) and symbolp(car(te))
+                            and symbol_name(car(te)) == u8"%PrefixExpr"
+                            and consp(cdr(te))
+                            and symbolp(cadr(te))
+                            and symbol_name(cadr(te)) == u8":")
+                        {
+                            auto operand = translate(tu, caddr(te));
+                            telems.push_back(
+                                a.list({ sym(a, u8"COLON"),
+                                         operand }));
+                        }
+                        else
+                        {
+                            telems.push_back(translate(tu, te));
+                        }
+                    }
+                    Value arg;
+                    if (telems.size() == 1)
+                        arg = telems[0];
+                    else
+                        arg = a.cons(sym(a, u8"TUPLE"),
+                                     a.list(telems));
+                    return bf_tuple_construct(a, arg);
+                }
+            }
+            // -- Non-tuple bracket: translate elements directly.
+            std::vector<Value> telems;
+            for (Value e = elems_list; consp(e); e = cdr(e))
+            {
+                auto elem = car(e);
+                if (consp(elem) and symbolp(car(elem))
+                    and symbol_name(car(elem)) == u8"%PrefixExpr"
+                    and consp(cdr(elem)) and symbolp(cadr(elem))
+                    and symbol_name(cadr(elem)) == u8":")
+                {
+                    auto operand = translate(tu, caddr(elem));
+                    telems.push_back(
+                        a.list({ sym(a, u8"COLON"), operand }));
+                }
+                else
+                {
+                    telems.push_back(translate(tu, elem));
+                }
+            }
+            Value arg;
+            if (telems.size() == 1)
+                arg = telems[0];
+            else
+                arg = a.cons(sym(a, u8"TUPLE"),
+                             a.list(telems));
+            return bf_tuple_construct(a, arg);
+        }
+
+        // -- Tuple.
+        if (tag == u8"%Tuple")
+        {
+            return a.cons(sym(a, u8"TUPLE"),
+                          tx_list(tu, cadr(ast)));
+        }
+
+        // -- Pile (sequence of statements).
+        if (tag == u8"%Pile")
+        {
+            return bf_sequence(tu, tx_list(tu, cadr(ast)));
+        }
+
+        // -- Conditional.
+        if (tag == u8"IF")
+        {
+            auto cond_v = translate(tu, cadr(ast));
+            auto consq = translate(tu, caddr(ast));
+            auto alt_v = translate(tu, car(cddr(cdr(ast))));
+            return bf_if(a, cond_v, consq, alt_v);
+        }
+
+        // -- Implies (one-armed conditional / exit).
+        if (tag == u8"%Implies")
+        {
+            auto cond_v = translate(tu, cadr(ast));
+            auto body_v = translate(tu, caddr(ast));
+            return bf_exit(a, cond_v, body_v);
+        }
+
+        // -- Assignment (expression-level).
+        if (tag == u8"%Assignment")
+        {
+            auto target = translate(tu, cadr(ast));
+            auto value = translate(tu, caddr(ast));
+            return bf_assign(tu, target, value);
+        }
+
+        // -- Is (pattern matching).
+        if (tag == u8"%Is")
+        {
+            auto lhs_v = translate(tu, cadr(ast));
+            auto rhs_v = tx_pattern(tu, caddr(ast));
+            return bf_is(tu, lhs_v, rhs_v);
+        }
+
+        // -- Isnt (negated pattern matching).
+        if (tag == u8"%Isnt")
+        {
+            auto lhs_v = translate(tu, cadr(ast));
+            auto rhs_v = tx_pattern(tu, caddr(ast));
+            return bf_not(a, bf_is(tu, lhs_v, rhs_v));
+        }
+
+        // -- EqualPattern.
+        if (tag == u8"%EqualPattern")
+        {
+            auto expr = translate(tu, cadr(ast));
+            return bf_equal(a, expr);
+        }
+
+        // -- ColonAppend.
+        if (tag == u8"%ColonAppend")
+        {
+            auto head_list = cadr(ast);
+            auto rest = translate(tu, caddr(ast));
+            std::vector<Value> thead;
+            for (Value e = head_list; consp(e); e = cdr(e))
+                thead.push_back(translate(tu, car(e)));
+            // -- Build the &REST form.
+            Value result = a.list({ sym(a, u8"&REST"), rest });
+            for (auto it = thead.rbegin(); it != thead.rend(); ++it)
+                result = a.cons(*it, result);
+            return result;
+        }
+
+        // -- Signature.
+        if (tag == u8"%Signature")
+        {
+            auto name = translate(tu, cadr(ast));
+            auto type = translate(tu, caddr(ast));
+            return bf_signature(a, name, type);
+        }
+
+        // -- SuffixDot.
+        if (tag == u8"%SuffixDot")
+        {
+            auto operand = translate(tu, cadr(ast));
+            return bf_suffix_dot(a, operand);
+        }
+
+        // -- Restrict.
+        if (tag == u8"%Restrict")
+        {
+            auto expr = translate(tu, cadr(ast));
+            auto type = translate(tu, caddr(ast));
+            return bf_restrict(a, expr, type);
+        }
+
+        // -- Return.
+        if (tag == u8"%Return")
+        {
+            auto value = translate(tu, cadr(ast));
+            return bf_return(a, value);
+        }
+
+        // -- Leave.
+        if (tag == u8"%Leave")
+        {
+            auto value = translate(tu, cadr(ast));
+            return bf_leave(a, value);
+        }
+
+        // -- Lambda.
+        if (tag == u8"%Lambda")
+        {
+            auto body_v = translate(tu, caddr(ast));
+            return a.list({
+                sym(a, u8"LAMBDA"),
+                tx_list(tu, cadr(ast)),
+                body_v });
+        }
+
+        // -- Mapping (type: sources -> target).
+        if (tag == u8"%Mapping")
+        {
+            auto target = translate(tu, cadr(ast));
+            return a.list({
+                sym(a, u8"%Mapping"),
+                target,
+                tx_list(tu, caddr(ast)) });
+        }
+
+        // -- Forall (quantified type).
+        if (tag == u8"%Forall")
+        {
+            auto vars = cadr(ast);
+            auto body_v = translate(tu, caddr(ast));
+            return a.list({ sym(a, u8"%Forall"), vars, body_v });
+        }
+
+        // -- Dynamic.
+        if (tag == u8"%Dynamic")
+        {
+            auto expr = translate(tu, cadr(ast));
+            return a.list({ sym(a, u8"%Dynamic"), expr });
+        }
+
+        // -- Segments.
+        if (tag == u8"%BoundedSegment")
+        {
+            auto lo = translate(tu, cadr(ast));
+            auto hi = translate(tu, caddr(ast));
+            return bf_segment2(a, lo, hi);
+        }
+        if (tag == u8"%UnboundedSegment")
+        {
+            auto lo = translate(tu, cadr(ast));
+            return bf_segment1(a, lo);
+        }
+
+        // -- Iterators.
+        if (tag == u8"%While")
+        {
+            auto cond_v = translate(tu, cadr(ast));
+            return bf_while(tu, cond_v);
+        }
+        if (tag == u8"%Until")
+        {
+            auto cond_v = translate(tu, cadr(ast));
+            return bf_until(tu, cond_v);
+        }
+        if (tag == u8"%SuchThat")
+        {
+            auto pred = translate(tu, cadr(ast));
+            return bf_suchthat(tu, pred);
+        }
+        if (tag == u8"%For")
+        {
+            auto var = translate(tu, cadr(ast));
+            auto seq = translate(tu, caddr(ast));
+            auto step_v = translate(tu, car(cddr(cdr(ast))));
+            return bf_for(tu, var, seq, step_v);
+        }
+        if (tag == u8"%Iterators")
+        {
+            return bf_iterators(a, tx_list(tu, cadr(ast)));
+        }
+        if (tag == u8"%Cross")
+        {
+            return bf_cross(a, tx_list(tu, cadr(ast)));
+        }
+
+        // -- Repeat (loop).
+        if (tag == u8"%Repeat")
+        {
+            auto iters = translate(tu, cadr(ast));
+            auto body_v = translate(tu, caddr(ast));
+            return bf_lp(tu, iters, body_v);
+        }
+
+        // -- Reduce.
+        if (tag == u8"%Reduce")
+        {
+            auto op = translate(tu, cadr(ast));
+            auto body_v = translate(tu, caddr(ast));
+            // -- Check if body is a COLLECT form.
+            return bf_reduce(tu, op, body_v);
+        }
+
+        // -- Where.
+        if (tag == u8"%Where")
+        {
+            auto body_v = translate(tu, cadr(ast));
+            auto defs_raw = caddr(ast);
+            // -- defSheepAndGoats: separate definitions from
+            // non-definitions in the where-clause.
+            // - Definitions with args > rename to
+            //   enclosingFunction,localName, add as side
+            //   condition
+            // - Definitions without args > substitute
+            // - Non-definitions > include inline
+            struct DefInfo
+            {
+                Value original_name;
+                Value renamed;      // nil if no-arg (substitution)
+                Value body;         // translated body
+                Value args;
+            };
+            std::vector<std::pair<Value, Value>> opassoc;
+            std::vector<DefInfo> def_stack;
+            std::vector<Value> nondefs;
+
+            // -- Unwrap Pile if present.
+            // defs_raw may be (%Pile items) or ((%Pile items)).
+            Value defs_list = defs_raw;
+            if (consp(defs_raw) and consp(car(defs_raw))
+                and is_symbol(caar(defs_raw), u8"%Pile"))
+                defs_list = cadr(car(defs_raw));
+            else if (consp(defs_raw) and symbolp(car(defs_raw))
+                and symbol_name(car(defs_raw)) == u8"%Pile")
+                defs_list = cadr(defs_raw);
+
+            for (Value d = defs_list; consp(d); d = cdr(d))
+            {
+                auto def = car(d);
+                if (not consp(def)) { nondefs.push_back(def); continue; }
+                auto dtag_v = car(def);
+                if (not symbolp(dtag_v)) { nondefs.push_back(def); continue; }
+                auto dtag = symbol_name(dtag_v);
+
+                if (dtag == u8"%ConstantDefinition")
+                {
+                    auto lhs = cadr(def);
+                    auto rhs = caddr(def);
+                    // -- Check if LHS is a %Call (function def).
+                    if (consp(lhs) and symbolp(car(lhs))
+                        and symbol_name(car(lhs)) == u8"%Call")
+                    {
+                        auto op_name = cadr(lhs);
+                        auto args_ast = caddr(lhs);
+                        if (symbolp(op_name))
+                        {
+                            // -- Check if it has args.
+                            // Empty tuple ((%Tuple NIL)) means
+                            // zero-arg function > substitute.
+                            bool has_args = not null(args_ast);
+                            if (has_args
+                                and consp(args_ast)
+                                and null(cdr(args_ast))
+                                and consp(car(args_ast))
+                                and is_symbol(
+                                    caar(args_ast), u8"%Tuple")
+                                and null(
+                                    cadr(car(args_ast))))
+                                has_args = false;
+
+                            if (has_args)
+                            {
+                                // -- Rename: enclosingFunction,localName
+                                auto renamed_name =
+                                    tu.enclosing_function + u8","
+                                    + std::u8string(
+                                        symbol_name(op_name));
+                                auto renamed = sym(a, renamed_name);
+                                opassoc.push_back(
+                                    { op_name, renamed });
+                                // -- Translate args same as in
+                                // %ConstantDefinition handler.
+                                Value args_v;
+                                if (consp(args_ast)
+                                    and null(cdr(args_ast)))
+                                {
+                                    auto single = car(args_ast);
+                                    args_v = translate(tu, single);
+                                }
+                                else
+                                {
+                                    std::vector<Value> targs;
+                                    for (Value e = args_ast;
+                                         consp(e); e = cdr(e))
+                                        targs.push_back(
+                                            translate(tu, car(e)));
+                                    args_v = a.cons(
+                                        sym(a, u8"TUPLE"),
+                                        a.list(targs));
+                                }
+                                auto body_v2 = translate(tu, rhs);
+                                body_v2 = translate_form(a, body_v2);
+                                def_stack.push_back(
+                                    { op_name, renamed,
+                                      body_v2, args_v });
+                            }
+                            else
+                            {
+                                // -- No args: substitute body.
+                                auto body_v2 = translate(tu, rhs);
+                                body_v2 = translate_form(a, body_v2);
+                                opassoc.push_back(
+                                    { op_name, body_v2 });
+                            }
+                        }
+                        else
+                            nondefs.push_back(def);
+                    }
+                    else if (symbolp(lhs))
+                    {
+                        // -- Simple constant def in where.
+                        auto body_v2 = translate(tu, rhs);
+                        body_v2 = translate_form(a, body_v2);
+                        opassoc.push_back({ lhs, body_v2 });
+                    }
+                    else
+                        nondefs.push_back(def);
+                }
+                else
+                    nondefs.push_back(def);
+            }
+
+            // -- Add def_stack entries to side_conditions.
+            for (auto& di : def_stack)
+            {
+                // -- (renamed args body) triple for bf_def to emit.
+                tu.side_conditions.push_back(
+                    a.list({ di.renamed, di.args, di.body }));
+            }
+
+            // -- Apply substitutions (opassoc) to body and nondefs.
+            // bfSUBLIS: replace each op_name with its renamed
+            // value in the expression tree.
+            using SubPair = std::pair<Value, Value>;
+            struct SubHelper
+            {
+                Lisp::Arena& arena;
+                const std::vector<SubPair>& pairs;
+                Value apply(Value x) const
+                {
+                    if (null(x)) return x;
+                    if (symbolp(x))
+                    {
+                        for (auto& [from, to] : pairs)
+                        {
+                            if (symbolp(from)
+                                and symbol_name(from)
+                                   == symbol_name(x))
+                                return to;
+                        }
+                        return x;
+                    }
+                    if (not consp(x)) return x;
+                    if (is_symbol(car(x), u8"QUOTE"))
+                        return x;
+                    auto h = apply(car(x));
+                    auto t = apply(cdr(x));
+                    if (h == car(x) and t == cdr(x))
+                        return x;
+                    return arena.cons(h, t);
+                }
+            };
+            SubHelper sublis_helper{ a, opassoc };
+
+            // -- Apply substitutions to nondefs and body.
+            std::vector<Value> tnondefs;
+            for (auto& nd : nondefs)
+                tnondefs.push_back(
+                    sublis_helper.apply(translate(tu, nd)));
+            auto sub_body = sublis_helper.apply(body_v);
+
+            // -- Build result: nondefs + body.
+            tnondefs.push_back(sub_body);
+            return bf_mkprogn(a, a.list(tnondefs));
+        }
+
+        // -- DefaultValue.
+        if (tag == u8"%DefaultValue")
+        {
+            auto name = translate(tu, cadr(ast));
+            auto value = translate(tu, caddr(ast));
+            return a.list({ sym(a, u8"DEFAULT"), name, value });
+        }
+
+        // -- Key.
+        if (tag == u8"%Key")
+        {
+            auto key = translate(tu, cadr(ast));
+            auto value = translate(tu, caddr(ast));
+            return a.list({ sym(a, u8"%Key"), key, value });
+        }
+
+        // -- QualifiedName.
+        if (tag == u8"%QualifiedName")
+        {
+            auto qualifier = translate(tu, cadr(ast));
+            auto name = translate(tu, caddr(ast));
+            // -- In old Boot, this becomes bfColonColon(qualifier, name).
+            // Which calls makeSymbol or symbolBinding.
+            // For now, just return as-is.
+            return a.list({ sym(a, u8"bfColonColon"),
+                            qualifier, name });
+        }
+
+        // -- Throw.
+        if (tag == u8"%Throw")
+        {
+            auto expr = translate(tu, cadr(ast));
+            return a.list({ sym(a, u8"THROW"), expr });
+        }
+
+        // -- Try/Catch/Finally.
+        if (tag == u8"%Try")
+        {
+            auto body_v = translate(tu, cadr(ast));
+            return a.list({
+                sym(a, u8"HANDLER-CASE"), body_v,
+                tx_list(tu, caddr(ast)) });
+        }
+        if (tag == u8"%Catch")
+        {
+            auto sig = translate(tu, cadr(ast));
+            auto body_v = translate(tu, caddr(ast));
+            return a.list({ sig, body_v });
+        }
+        if (tag == u8"%Finally")
+        {
+            auto body_v = translate(tu, cadr(ast));
+            return a.list({ sym(a, u8"UNWIND-PROTECT"), body_v });
+        }
+
+        // -- Case.
+        if (tag == u8"%Case")
+        {
+            auto expr = translate(tu, cadr(ast));
+            return a.cons(sym(a, u8"CASE"),
+                a.cons(expr, tx_list(tu, caddr(ast))));
+        }
+
+        // -- Lisp (embedded Lisp expression).
+        if (tag == u8"%Lisp")
+        {
+            // -- Return the string as a raw Lisp form marker.
+            return a.list({ sym(a, u8"+LINE"), cadr(ast) });
+        }
+
+        // -- Fallback: return as-is.
+        return ast;
+    }
+
+    // -- bfSequence: sequence/pile to PROGN.
+    // Check if form is a single-clause COND exit:
+    // (COND (test (IDENTITY val))) > returns true and extracts
+    // test and val.
+    static bool exit_cond_p(Value form, Value& test, Value& val)
+    {
+        if (not consp(form)) return false;
+        if (not is_symbol(car(form), u8"COND")) return false;
+        auto clauses = cdr(form);
+        if (not consp(clauses)) return false;
+        if (not null(cdr(clauses))) return false; // must be single clause
+        auto clause = car(clauses); // (test (IDENTITY val))
+        if (not consp(clause)) return false;
+        test = car(clause);
+        auto body = cdr(clause);
+        if (not consp(body)) return false;
+        if (not null(cdr(body))) return false;
+        auto identity_form = car(body);
+        if (not consp(identity_form)) return false;
+        if (not is_symbol(car(identity_form), u8"IDENTITY"))
+            return false;
+        auto id_args = cdr(identity_form);
+        if (not consp(id_args)) return false;
+        if (not null(cdr(id_args))) return false;
+        val = car(id_args);
+        return true;
+    }
+
+    // -- bfAlternative: builds a COND clause (test body...).
+    // Handles the special case where test is
+    //   (AND c1 c2 ... (PROGN stmt T))
+    // turning it into ((AND c1 c2 ...) stmt body...).
+    static Value bf_alternative(Lisp::Arena& a, Value test, Value body)
+    {
+        // -- Check if test is (AND ... (PROGN stmt T))
+        if (consp(test) and is_symbol(car(test), u8"AND"))
+        {
+            auto and_args = cdr(test);
+            if (consp(and_args))
+            {
+                // -- Get the last element of the AND args.
+                Value rev = nil;
+                for (Value e = and_args; consp(e); e = cdr(e))
+                    rev = a.cons(car(e), rev);
+                // -- rev = reversed list, car(rev) = last element
+                auto last = car(rev);
+                if (consp(last) and is_symbol(car(last), u8"PROGN"))
+                {
+                    auto progn_body = cdr(last);
+                    // -- Check it ends with T.
+                    Value last_pb = nil;
+                    Value rest_pb = nil;
+                    Value prev = nil;
+                    for (Value e = progn_body; consp(e); e = cdr(e))
+                    {
+                        if (not null(cdr(e)))
+                        {
+                            if (null(rest_pb))
+                                rest_pb = e;
+                        }
+                        else
+                            last_pb = car(e);
+                    }
+                    if (symbolp(last_pb)
+                        and is_symbol(last_pb, u8"T"))
+                    {
+                        // -- Extract stmt (everything before the T).
+                        Value stmt = nil;
+                        if (consp(progn_body)
+                            and null(cdr(progn_body)))
+                        {
+                            // -- Only T, no stmt.
+                        }
+                        else
+                        {
+                            // -- Collect all but last.
+                            std::vector<Value> stmts;
+                            for (Value e = progn_body; consp(e);
+                                 e = cdr(e))
+                            {
+                                if (not null(cdr(e)))
+                                    stmts.push_back(car(e));
+                            }
+                            if (stmts.size() == 1)
+                                stmt = stmts[0];
+                            else
+                                stmt = a.cons(sym(a, u8"PROGN"),
+                                              a.list(stmts));
+                        }
+
+                        // -- Rebuild AND without the last element.
+                        std::vector<Value> conds;
+                        // -- rev has the reversed list; skip car(rev)
+                        // = last, reverse the rest.
+                        Value crev = cdr(rev);
+                        for (Value e = crev; consp(e); e = cdr(e))
+                            conds.insert(conds.begin(), car(e));
+                        Value new_test;
+                        if (conds.size() == 1)
+                            new_test = conds[0];
+                        else
+                            new_test = a.cons(
+                                sym(a, u8"AND"),
+                                a.list(conds));
+
+                        Value merged_body;
+                        if (not null(stmt))
+                            merged_body = bf_mkprogn(a,
+                                a.cons(stmt, a.cons(body, nil)));
+                        else
+                            merged_body = body;
+                        return a.cons(new_test,
+                            unwrap_progn(a, merged_body));
+                    }
+                }
+            }
+        }
+        return a.cons(test,
+            unwrap_progn(a, body));
+    }
+
+    static Value bf_sequence(TranslationUnit& tu, Value lst)
+    {
+        auto& a = tu.arena;
+        if (null(lst)) return nil;
+
+        // -- Collect consecutive exit-COND forms from the front.
+        std::vector<Value> clauses;
+        Value rest = lst;
+        while (consp(rest))
+        {
+            Value test, val;
+            if (not exit_cond_p(car(rest), test, val))
+                break;
+            clauses.push_back(bf_alternative(a, test, val));
+            rest = cdr(rest);
+        }
+
+        if (clauses.empty())
+        {
+            // -- No exits at the front.
+            if (null(cdr(lst)))
+            {
+                auto f = car(lst);
+                if (consp(f) and is_symbol(car(f), u8"PROGN"))
+                    return bf_sequence(tu, cdr(f));
+                return f;
+            }
+            return bf_mkprogn(a,
+                a.cons(car(lst),
+                       a.cons(bf_sequence(tu, cdr(lst)), nil)));
+        }
+
+        // -- We have some exit clauses.
+        if (null(rest))
+        {
+            // -- All exits, no fallthrough > (COND cl1 cl2 ...)
+            return a.cons(sym(a, u8"COND"),
+                          a.list(clauses));
+        }
+
+        // -- Exits + fallthrough > (COND cl1 cl2 ... (T fallthrough))
+        auto fallthrough = bf_sequence(tu, rest);
+        clauses.push_back(bf_alternative(a, sym(a, u8"T"), fallthrough));
+        return a.cons(sym(a, u8"COND"),
+                      a.list(clauses));
+    }
+
+    // -- translateForm: final cleanup pass
+
+    // -- Rename table for Boot > CL function names.
+    static const char8_t* rename_op(std::u8string_view name)
+    {
+        static const std::pair<const char8_t*, const char8_t*> table[] = {
+            {u8"abs", u8"ABS"},
+            {u8"abstractChar", u8"CODE-CHAR"},
+            {u8"alphabetic?", u8"ALPHA-CHAR-P"},
+            {u8"alphanumeric?", u8"ALPHANUMERICP"},
+            {u8"array?", u8"ARRAYP"},
+            {u8"arrayRef", u8"AREF"},
+            {u8"atom", u8"ATOM"},
+            {u8"bitref", u8"SBIT"},
+            {u8"canonicalFilename", u8"PROBE-FILE"},
+            {u8"charByName", u8"NAME-CHAR"},
+            {u8"charDowncase", u8"CHAR-DOWNCASE"},
+            {u8"charEq?", u8"CHAR="},
+            {u8"charUpcase", u8"CHAR-UPCASE"},
+            {u8"charString", u8"STRING"},
+            {u8"char?", u8"CHARACTERP"},
+            {u8"codePoint", u8"CHAR-CODE"},
+            {u8"cons?", u8"CONSP"},
+            {u8"copy", u8"COPY"},
+            {u8"copyString", u8"COPY-SEQ"},
+            {u8"copyVector", u8"COPY-SEQ"},
+            {u8"croak", u8"CROAK"},
+            {u8"digit?", u8"DIGIT-CHAR-P"},
+            {u8"exit", u8"EXIT"},
+            {u8"fifth", u8"FIFTH"},
+            {u8"first", u8"CAR"},
+            {u8"fileNameString", u8"FILE-NAMESTRING"},
+            {u8"filePath", u8"PATHNAME"},
+            {u8"filePath?", u8"PATHNAMEP"},
+            {u8"filePathDirectory", u8"PATHNAME-DIRECTORY"},
+            {u8"filePathName", u8"PATHNAME-NAME"},
+            {u8"filePathString", u8"NAMESTRING"},
+            {u8"filePathType", u8"PATHNAME-TYPE"},
+            {u8"float?", u8"FLOATP"},
+            {u8"flushOutput", u8"FORCE-OUTPUT"},
+            {u8"fourth", u8"CADDDR"},
+            {u8"freshLine", u8"FRESH-LINE"},
+            {u8"function?", u8"FUNCTIONP"},
+            {u8"functionSymbol?", u8"FBOUNDP"},
+            {u8"gensym", u8"GENSYM"},
+            {u8"genvar", u8"GENVAR"},
+            {u8"importSymbol", u8"IMPORT"},
+            {u8"inert?", u8"KEYWORDP"},
+            {u8"integer?", u8"INTEGERP"},
+            {u8"LAST", u8"last"},
+            {u8"list", u8"LIST"},
+            {u8"listEq?", u8"EQUAL"},
+            {u8"lowerCase?", u8"LOWER-CASE-P"},
+            {u8"makeFilePath", u8"MAKE-PATHNAME"},
+            {u8"makeSymbol", u8"INTERN"},
+            {u8"mergeFilePaths", u8"MERGE-PATHNAMES"},
+            {u8"newVector", u8"MAKE-ARRAY"},
+            {u8"not", u8"NOT"},
+            {u8"null", u8"NULL"},
+            {u8"odd?", u8"ODDP"},
+            {u8"property", u8"GET"},
+            {u8"readInteger", u8"PARSE-INTEGER"},
+            {u8"readLispFromString", u8"READ-FROM-STRING"},
+            {u8"readOnly?", u8"CONSTANTP"},
+            {u8"removeDuplicates", u8"REMDUP"},
+            {u8"rest", u8"CDR"},
+            {u8"sameObject?", u8"EQ"},
+            {u8"scalarEq?", u8"EQL"},
+            {u8"scalarEqual?", u8"EQL"},
+            {u8"second", u8"CADR"},
+            {u8"setPart", u8"SETELT"},
+            {u8"strconc", u8"CONCAT"},
+            {u8"stringChar", u8"SCHAR"},
+            {u8"stringDowncase", u8"STRING-DOWNCASE"},
+            {u8"string?", u8"STRINGP"},
+            {u8"stringEq?", u8"STRING="},
+            {u8"stringUpcase", u8"STRING-UPCASE"},
+            {u8"subSequence", u8"SUBSEQ"},
+            {u8"symbolBinding", u8"FIND-SYMBOL"},
+            {u8"symbolScope", u8"SYMBOL-PACKAGE"},
+            {u8"symbolEq?", u8"EQ"},
+            {u8"symbolFunction", u8"SYMBOL-FUNCTION"},
+            {u8"symbolGlobal?", u8"BOUNDP"},
+            {u8"symbolName", u8"SYMBOL-NAME"},
+            {u8"symbolValue", u8"SYMBOL-VALUE"},
+            {u8"symbol?", u8"SYMBOLP"},
+            {u8"third", u8"CADDR"},
+            {u8"toString", u8"WRITE-TO-STRING"},
+            {u8"upperCase?", u8"UPPER-CASE-P"},
+            {u8"valueEq?", u8"EQUAL"},
+            {u8"vector?", u8"SIMPLE-VECTOR-P"},
+            {u8"vectorRef", u8"SVREF"},
+            {u8"writeByte", u8"WRITE-BYTE"},
+            {u8"writeChar", u8"WRITE-CHAR"},
+            {u8"writeInteger", u8"PRINC"},
+            {u8"writeLine", u8"WRITE-LINE"},
+            {u8"writeNewline", u8"TERPRI"},
+            {u8"writeString", u8"WRITE-STRING"},
+            {u8"PLUS", u8"+"},
+            {u8"MINUS", u8"-"},
+            {u8"TIMES", u8"*"},
+            {u8"POWER", u8"EXPT"},
+            {u8"SLASH", u8"/"},
+            {u8"LT", u8"<"},
+            {u8"GT", u8">"},
+            {u8"LE", u8"<="},
+            {u8"GE", u8">="},
+            {u8"SHOEEQ", u8"EQUAL"},
+            {u8"SHOENE", u8"/="},
+            {u8"T", u8"T$"},
+        };
+        for (auto& [from, to] : table)
+        {
+            if (name == from)
+                return to;
+        }
+        return nullptr;
+    }
+
+    Value translate_form(Lisp::Arena& a, Value x)
+    {
+        if (not consp(x)) return x;
+        if (is_symbol(car(x), u8"QUOTE")) return x;
+
+        // -- apply > FUNCALL/APPLY.
+        if (is_symbol(car(x), u8"apply"))
+        {
+            auto fun = cadr(x);
+            auto args = cddr(x);
+            auto last_arg = last_elem(args);
+            if (null(last_arg))
+            {
+                // -- (apply f arg1 ... NIL) > (FUNCALL f targ1 ...)
+                Value result = nil;
+                auto translated = but_last(a, cdr(x));
+                std::vector<Value> telems;
+                for (Value e = translated; consp(e); e = cdr(e))
+                    telems.push_back(translate_form(a, car(e)));
+                return a.cons(sym(a, u8"FUNCALL"),
+                              a.list(telems));
+            }
+            // -- General case: (APPLY f args...).
+            std::vector<Value> telems;
+            for (Value e = cdr(x); consp(e); e = cdr(e))
+                telems.push_back(translate_form(a, car(e)));
+            return a.cons(sym(a, u8"APPLY"), a.list(telems));
+        }
+
+        // -- LET > translate bindings.
+        if (is_symbol(car(x), u8"LET"))
+        {
+            auto bindings = cadr(x);
+            auto body = caddr(x);
+            std::vector<Value> tbindings;
+            for (Value b = bindings; consp(b); b = cdr(b))
+            {
+                auto binding = car(b);
+                if (consp(binding) and consp(cdr(binding)))
+                {
+                    auto var = car(binding);
+                    auto init = cadr(binding);
+                    tbindings.push_back(
+                        a.list({ var, translate_form(a, init) }));
+                }
+                else
+                    tbindings.push_back(binding);
+            }
+            return a.list({
+                car(x),
+                a.list(tbindings),
+                translate_form(a, body) });
+        }
+
+        // -- L%T > translate init.
+        if (is_symbol(car(x), u8"L%T") and consp(cdr(x)) and consp(cddr(x)))
+        {
+            auto var = cadr(x);
+            auto init = caddr(x);
+            return a.list({ car(x), var, translate_form(a, init) });
+        }
+
+        // -- COND > translate each branch.
+        if (is_symbol(car(x), u8"COND"))
+        {
+            std::vector<Value> tbranches;
+            for (Value e = cdr(x); consp(e); e = cdr(e))
+            {
+                auto branch = car(e);
+                std::vector<Value> telems;
+                for (Value b = branch; consp(b); b = cdr(b))
+                    telems.push_back(translate_form(a, car(b)));
+                tbranches.push_back(a.list(telems));
+            }
+            return a.cons(sym(a, u8"COND"),
+                          a.list(tbranches));
+        }
+
+        // -- PROGN > re-sequence after translating children.
+        if (is_symbol(car(x), u8"PROGN"))
+        {
+            std::vector<Value> telems;
+            for (Value e = cdr(x); consp(e); e = cdr(e))
+                telems.push_back(translate_form(a, car(e)));
+            // -- bf_sequence only uses tu.arena - safe to use a
+            // temporary TranslationUnit here.
+            TranslationUnit dummy_tu(a);
+            return bf_sequence(dummy_tu, a.list(telems));
+        }
+
+        // -- LOOP, RETURN > translate args.
+        if (is_symbol(car(x), u8"LOOP")
+            or is_symbol(car(x), u8"RETURN"))
+        {
+            std::vector<Value> telems;
+            for (Value e = cdr(x); consp(e); e = cdr(e))
+                telems.push_back(translate_form(a, car(e)));
+            return a.cons(car(x), a.list(telems));
+        }
+
+        // -- Default: check for rename, translate all elements.
+        auto op = car(x);
+        if (symbolp(op))
+        {
+            auto renamed = rename_op(symbol_name(op));
+            if (renamed)
+                op = sym(a, renamed);
+        }
+        std::vector<Value> targs;
+        for (Value e = cdr(x); consp(e); e = cdr(e))
+            targs.push_back(translate_form(a, car(e)));
+        return a.cons(op, a.list(targs));
+    }
+
+    // -- shoeCompTran: variable analysis
+
+    // -- Collect atoms from a parameter list.
+    static void collect_atoms(Value x, std::vector<Value>& result)
+    {
+        if (null(x)) return;
+        if (symbolp(x))
+        {
+            result.push_back(x);
+            return;
+        }
+        if (consp(x))
+        {
+            collect_atoms(car(x), result);
+            collect_atoms(cdr(x), result);
+        }
+    }
+
+    // -- Check if a symbol is a dynamic ($-prefixed) variable.
+    static bool dynamic_var_p(Value x)
+    {
+        return symbolp(x) and dollar_prefixed(x);
+    }
+
+    // -- shoeCompTran1: scan body for L%T, %Dynamic, %Leave, %Namespace.
+    // (Replaced by scan_for_vars below.)
+
+    // -- scan_for_vars: recursive scanner for variable declarations.
+    static void scan_for_vars(Value x,
+                               std::vector<Value>& fluid_vars,
+                               std::vector<Value>& local_vars,
+                               std::vector<Value>& dollar_vars)
+    {
+        if (null(x) or not consp(x)) return;
+
+        // -- L%T var init > local variable.
+        if (is_symbol(car(x), u8"L%T") and consp(cdr(x)))
+        {
+            auto var = cadr(x);
+            if (symbolp(var))
+            {
+                if (dynamic_var_p(var))
+                    dollar_vars.push_back(var);
+                else
+                    local_vars.push_back(var);
+            }
+            if (consp(cddr(x)))
+                scan_for_vars(caddr(x), fluid_vars, local_vars, dollar_vars);
+            return;
+        }
+
+        // -- %Dynamic x > fluid variable.
+        if (is_symbol(car(x), u8"%Dynamic") and consp(cdr(x)))
+        {
+            auto var = cadr(x);
+            if (symbolp(var))
+                fluid_vars.push_back(var);
+            return;
+        }
+
+        // -- QUOTE > don't recurse.
+        if (is_symbol(car(x), u8"QUOTE")) return;
+
+        // -- Recurse into all sub-forms.
+        for (Value e = x; consp(e); e = cdr(e))
+            scan_for_vars(car(e), fluid_vars, local_vars, dollar_vars);
+    }
+
+    // -- Convert L%T to SETQ, %Dynamic to fluid, %Leave to RETURN.
+    static Value shoe_comp_tran1_transform(Arena& a, Value x)
+    {
+        if (null(x) or not consp(x)) return x;
+        if (is_symbol(car(x), u8"QUOTE")) return x;
+
+        if (is_symbol(car(x), u8"L%T") and consp(cdr(x)))
+        {
+            auto var = cadr(x);
+            auto init = consp(cddr(x)) ? caddr(x) : nil;
+            return a.list({ sym(a, u8"SETQ"), var,
+                            shoe_comp_tran1_transform(a, init) });
+        }
+
+        if (is_symbol(car(x), u8"%Leave") and consp(cdr(x)))
+        {
+            return a.list({ sym(a, u8"RETURN"),
+                            shoe_comp_tran1_transform(a, cadr(x)) });
+        }
+
+        if (is_symbol(car(x), u8"%Dynamic") and consp(cdr(x)))
+        {
+            // -- Dynamic vars are handled by declarations; strip the wrapper.
+            return cadr(x);
+        }
+
+        // -- Recurse.
+        std::vector<Value> result;
+        for (Value e = x; consp(e); e = cdr(e))
+            result.push_back(shoe_comp_tran1_transform(a, car(e)));
+        return a.list(result);
+    }
+
+    // -- Remove duplicates from a symbol list.
+    static std::vector<Value> unique_syms(const std::vector<Value>& v)
+    {
+        std::vector<Value> result;
+        for (auto s : v)
+        {
+            bool found = false;
+            for (auto r : result)
+            {
+                if (symbolp(s) and symbolp(r)
+                    and symbol_name(s) == symbol_name(r))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (not found) result.push_back(s);
+        }
+        return result;
+    }
+
+    // -- Set difference: elements in a but not in b.
+    static std::vector<Value> set_diff(const std::vector<Value>& a,
+                                    const std::vector<Value>& b)
+    {
+        std::vector<Value> result;
+        for (auto x : a)
+        {
+            bool in_b = false;
+            for (auto y : b)
+            {
+                if (symbolp(x) and symbolp(y)
+                    and symbol_name(x) == symbol_name(y))
+                {
+                    in_b = true;
+                    break;
+                }
+            }
+            if (not in_b) result.push_back(x);
+        }
+        return result;
+    }
+
+    // -- shoeCompTran: full variable analysis.
+    //    Takes (LAMBDA args body...) and produces
+    //    (LAMBDA args (LET* ((locals..)) (DECLARE ...) body'...)).
+    static Value shoe_comp_tran(Arena& arena, Value x)
+    {
+        if (not consp(x)) return x;
+        auto lamtype = car(x);
+        auto args = cadr(x);
+        auto body = cddr(x);
+
+        // -- Scan for variables.
+        std::vector<Value> fluid_vars, local_vars, dollar_vars;
+        for (Value s = body; consp(s); s = cdr(s))
+            scan_for_vars(car(s), fluid_vars, local_vars, dollar_vars);
+
+        fluid_vars = unique_syms(fluid_vars);
+        local_vars = unique_syms(local_vars);
+        dollar_vars = unique_syms(dollar_vars);
+
+        // -- Remove fluid vars and parameter atoms from local vars.
+        std::vector<Value> param_atoms;
+        collect_atoms(args, param_atoms);
+        local_vars = set_diff(local_vars, fluid_vars);
+        local_vars = set_diff(local_vars, param_atoms);
+
+        // -- Transform the body: L%T > SETQ, %Leave > RETURN.
+        std::vector<Value> tbody;
+        for (Value s = body; consp(s); s = cdr(s))
+            tbody.push_back(shoe_comp_tran1_transform(arena, car(s)));
+
+        // -- Build the new body with declarations.
+        std::vector<Value> new_body;
+
+        // -- Dollar vars that aren't fluid > DECLARE SPECIAL.
+        auto fvars = set_diff(dollar_vars, fluid_vars);
+        if (not fvars.empty())
+        {
+            auto decl = arena.cons(sym(arena, u8"SPECIAL"),
+                                    arena.list(fvars));
+            new_body.push_back(arena.list({ sym(arena, u8"DECLARE"), decl }));
+        }
+
+        // -- Fluid parameters > DECLARE SPECIAL.
+        std::vector<Value> fluid_params;
+        for (auto p : param_atoms)
+        {
+            for (auto f : fluid_vars)
+            {
+                if (symbolp(p) and symbolp(f)
+                    and symbol_name(p) == symbol_name(f))
+                {
+                    fluid_params.push_back(p);
+                    break;
+                }
+            }
+        }
+        if (not fluid_params.empty())
+        {
+            auto decl = arena.cons(sym(arena, u8"SPECIAL"),
+                                    arena.list(fluid_params));
+            new_body.push_back(
+                arena.list({ sym(arena, u8"DECLARE"), decl }));
+        }
+
+        // -- Local vars > LET* wrapping.
+        if (not local_vars.empty())
+        {
+            // -- Wrap in LET*.
+            std::vector<Value> letbindings;
+            for (auto v : local_vars)
+                letbindings.push_back(v);
+
+            for (auto& b : tbody) new_body.push_back(b);
+            auto let_body = arena.list(new_body);
+            auto result_body = arena.list({
+                sym(arena, u8"LET*"),
+                arena.list(letbindings) });
+            // -- Append the body elements.
+            Value result = arena.cons(sym(arena, u8"LET*"),
+                arena.cons(arena.list(letbindings),
+                           let_body));
+            return arena.list({ lamtype, args, result });
+        }
+        else
+        {
+            for (auto& b : tbody) new_body.push_back(b);
+            auto result = arena.cons(lamtype,
+                arena.cons(args, arena.list(new_body)));
+            return result;
+        }
+    }
+
+    // -- bfDef: function definition translation
+
+    // -- Simplified bfDef: extract function name, params, translate body.
+    static std::vector<Value> bf_def(TranslationUnit& tu,
+                                  Value op, Value args, Value body)
+    {
+        auto& a = tu.arena;
+
+        // -- Extract parameter list.
+        Value param_list;
+        if (bf_tuple_p(args))
+            param_list = cdr(args);
+        else
+            param_list = a.cons(args, nil);
+
+        // -- Build (LAMBDA params body) and run shoeCompTran.
+        auto lambda = a.cons(sym(a, u8"LAMBDA"),
+                              a.cons(param_list, a.cons(body, nil)));
+        auto translated = shoe_comp_tran(a, lambda);
+
+        // -- Extract the translated args and body.
+        auto targs = cadr(translated);
+        auto tbody = cddr(translated);
+
+        // -- Build DEFUN.
+        auto defun = a.cons(sym(a, u8"DEFUN"),
+                             a.cons(op, a.cons(targs, tbody)));
+
+        // -- Collect: main def + all side conditions.
+        std::vector<Value> results;
+
+        // -- First emit side conditions (where-clause local defs).
+        auto saved_sides = std::move(tu.side_conditions);
+        tu.side_conditions.clear();
+        for (auto sc : saved_sides)
+        {
+            // -- Each sc is (renamed args body).
+            auto sc_op = car(sc);
+            auto sc_args = cadr(sc);
+            auto sc_body = caddr(sc);
+            auto sc_defs = bf_def(tu, sc_op, sc_args, sc_body);
+            for (auto& d : sc_defs)
+                results.push_back(d);
+        }
+
+        // -- When clamming, generate the implementation (with ;
+        // suffix), a hash-table cache, a wrapper DEFUN, and
+        // cache-info metadata.
+        if (tu.clamming and symbolp(op))
+        {
+            auto name = std::u8string(symbol_name(op));
+            auto auxfn = sym(a, name + u8";");
+            auto cache_name = sym(a, name + u8";AL");
+
+            // -- 1. (DEFUN op; (params) body)
+            auto impl_defun = a.cons(sym(a, u8"DEFUN"),
+                a.cons(auxfn, a.cons(targs, tbody)));
+            results.push_back(impl_defun);
+
+            // -- 2. (DEFPARAMETER cache (MAKE-HASHTABLE 'UEQUAL))
+            auto make_ht = a.list({
+                sym(a, u8"MAKE-HASHTABLE"),
+                a.list({ sym(a, u8"QUOTE"), sym(a, u8"UEQUAL") }) });
+            results.push_back(a.list({
+                sym(a, u8"DEFPARAMETER"), cache_name, make_ht }));
+
+            // -- 3. (DEFUN op (&REST g1)
+            //      (PROG (g2) (RETURN (COND
+            //        ((SETQ g2 (GETHASH g1 cache)) g2)
+            //        (T (SETF (GETHASH g1 cache)
+            //                 (APPLY #'auxfn g1)))))))
+            auto g1 = tu.gensym();
+            auto g2 = tu.gensym();
+            auto rest_arg = a.list({
+                sym(a, u8"&REST"), g1 });
+            auto gethash = a.list({
+                sym(a, u8"GETHASH"), g1, cache_name });
+            auto setq_clause = a.list({
+                a.list({ sym(a, u8"SETQ"), g2, gethash }),
+                g2 });
+            auto apply_call = a.list({
+                sym(a, u8"APPLY"),
+                a.list({ sym(a, u8"FUNCTION"), auxfn }),
+                g1 });
+            auto setf_clause = a.list({
+                sym(a, u8"T"),
+                a.list({ sym(a, u8"SETF"), gethash, apply_call }) });
+            auto cond = a.list({
+                sym(a, u8"COND"), setq_clause, setf_clause });
+            auto prog_body = a.list({
+                sym(a, u8"PROG"),
+                a.list({ g2 }),
+                a.list({ sym(a, u8"RETURN"), cond }) });
+            auto wrapper_defun = a.list({
+                sym(a, u8"DEFUN"), op, rest_arg, prog_body });
+            results.push_back(wrapper_defun);
+
+            // -- 4. (SETF (GET 'op 'cacheInfo)
+            //      '(op cache hash-table
+            //        (SETQ cache (MAKE-HASHTABLE 'UEQUAL))
+            //        (hashCount cache)))
+            auto reset_code = a.list({
+                sym(a, u8"SETQ"), cache_name, make_ht });
+            auto count_code = a.list({
+                sym(a, u8"hashCount"), cache_name });
+            auto cache_vec = a.list({
+                op, cache_name, sym(a, u8"hash-table"),
+                reset_code, count_code });
+            results.push_back(a.list({
+                sym(a, u8"SETF"),
+                a.list({ sym(a, u8"GET"),
+                         a.list({ sym(a, u8"QUOTE"), op }),
+                         a.list({ sym(a, u8"QUOTE"),
+                                  sym(a, u8"cacheInfo") }) }),
+                a.list({ sym(a, u8"QUOTE"), cache_vec }) }));
+        }
+        else
+        {
+            // -- Then the main DEFUN.
+            results.push_back(defun);
+        }
+        return results;
+    }
+
+    // -- bfMDef: macro definition translation
+
+    static std::vector<Value> bf_mdef(TranslationUnit& tu,
+                                   Value op, Value args, Value body)
+    {
+        auto& a = tu.arena;
+        Value param_list;
+        if (bf_tuple_p(args))
+            param_list = cdr(args);
+        else
+            param_list = a.cons(args, nil);
+
+        // -- Build DEFMACRO with a MLAMBDA-style body.
+        // Simplified: just use the body directly.
+        auto defmacro = a.cons(sym(a, u8"DEFMACRO"),
+            a.cons(op, a.cons(param_list, a.cons(body, nil))));
+        return { defmacro };
+    }
+
+    // -- def_from_call: shared tail for %ConstantDefinition
+    //    when the LHS is a %Call (direct or via %Signature).
+    //    Sets enclosing_function, translates the body, and
+    //    calls bf_def.
+    static std::vector<Value> def_from_call(
+        TranslationUnit& tu, Value op, Value args, Value rhs)
+    {
+        auto saved_ef = tu.enclosing_function;
+        if (symbolp(op))
+            tu.enclosing_function =
+                std::u8string(symbol_name(op));
+        tu.side_conditions.clear();
+        auto body = translate(tu, rhs);
+        body = translate_form(tu.arena, body);
+        auto result = bf_def(tu, op, args, body);
+        tu.enclosing_function = saved_ef;
+        return result;
+    }
+
+    // -- genDeclaration: type declaration
+
+    // -- bfType: convert a Boot type to a Lisp type specifier.
+    static Value bf_type(Arena& a, Value t)
+    {
+        if (consp(t) and is_symbol(car(t), u8"%Mapping"))
+        {
+            auto target = cadr(t);
+            auto sources = caddr(t);
+            // -- (FUNCTION (src1 src2 ...) target)
+            return a.list({
+                sym(a, u8"FUNCTION"),
+                sources,
+                bf_type(a, target) });
+        }
+        return t;
+    }
+
+    static Value gen_declaration(Arena& a, Value name, Value t)
+    {
+        if (consp(t) and is_symbol(car(t), u8"%Mapping"))
+        {
+            return a.list({
+                sym(a, u8"DECLAIM"),
+                a.list({ sym(a, u8"FTYPE"), bf_type(a, t), name }) });
+        }
+        if (consp(t) and is_symbol(car(t), u8"%Forall"))
+        {
+            // -- Substitute type vars with *.
+            auto body_t = caddr(t);
+            return gen_declaration(a, name, body_t);
+        }
+        return a.list({
+            sym(a, u8"DECLAIM"),
+            a.list({ sym(a, u8"TYPE"), bf_type(a, t), name }) });
+    }
+
+    // -- translateToplevel: top-level dispatch
+
+    std::vector<Value> translate_toplevel(TranslationUnit& tu, Value ast)
+    {
+        auto& a = tu.arena;
+
+        if (not consp(ast))
+            return { ast };
+
+        auto tag_v = car(ast);
+        if (not symbolp(tag_v))
+            return { ast };
+        auto tag = symbol_name(tag_v);
+
+        // -- %Where at top level: lift where-clause into the
+        //    body of the wrapped definition.
+        if (tag == u8"%Where")
+        {
+            auto body = cadr(ast);
+            auto defs = caddr(ast);
+
+            // -- If the body is a definition node, lift the
+            // where-clause into the definition's body (RHS).
+            if (consp(body))
+            {
+                auto btag = car(body);
+                if (symbolp(btag))
+                {
+                    auto bn = symbol_name(btag);
+                    if (bn == u8"%ConstantDefinition"
+                        or bn == u8"%Definition")
+                    {
+                        auto def_lhs = cadr(body);
+                        auto def_rhs = caddr(body);
+                        auto new_rhs = a.list(
+                            { sym(a, u8"%Where"),
+                              def_rhs, defs });
+                        auto new_def = a.list(
+                            { btag, def_lhs, new_rhs });
+                        return translate_toplevel(tu, new_def);
+                    }
+                    if (bn == u8"%Macro")
+                    {
+                        auto op = cadr(body);
+                        auto args = caddr(body);
+                        auto mbody = car(cddr(cdr(body)));
+                        auto new_body = a.list(
+                            { sym(a, u8"%Where"),
+                              mbody, defs });
+                        auto new_macro = a.list(
+                            { btag, op, args, new_body });
+                        return translate_toplevel(tu, new_macro);
+                    }
+                }
+            }
+
+            // -- Fall through: translate as expression.
+            auto expr = translate(tu, ast);
+            expr = translate_form(a, expr);
+            return { expr };
+        }
+
+        // -- %Signature(name, type) > (DECLAIM ...)
+        if (tag == u8"%Signature")
+        {
+            auto name = cadr(ast);
+            auto type = caddr(ast);
+            auto name_t = translate(tu, name);
+            auto type_t = translate(tu, type);
+            return { gen_declaration(a, name_t, type_t) };
+        }
+
+        // -- %Definition(op, args, body) > DEFUN
+        if (tag == u8"%Definition")
+        {
+            auto op = translate(tu, cadr(ast));
+            auto args = translate(tu, caddr(ast));
+            auto body = translate(tu, car(cddr(cdr(ast))));
+            body = translate_form(a, body);
+            return bf_def(tu, op, args, body);
+        }
+
+        // -- %ConstantDefinition(lhs, rhs)
+        //    If lhs is a %Call, treat as function definition.
+        //    Otherwise, treat as DEFCONSTANT.
+        if (tag == u8"%ConstantDefinition")
+        {
+            auto lhs_raw = cadr(ast);
+            auto rhs = caddr(ast);
+
+            // -- Unwrap %Restrict (qualified names like
+            // AxiomCore::%sysInit()).
+            // (%Restrict qualifier (%Call name args)) > (%Call name args)
+            Value lhs_inner = lhs_raw;
+            if (consp(lhs_raw)
+                and is_symbol(car(lhs_raw), u8"%Restrict"))
+            {
+                auto inner = caddr(lhs_raw);
+                if (consp(inner)
+                    and is_symbol(car(inner), u8"%Call"))
+                    lhs_inner = inner;
+            }
+
+            // -- Check if LHS is a function call shape.
+            if (consp(lhs_inner) and is_symbol(car(lhs_inner), u8"%Call"))
+            {
+                auto op_ast = cadr(lhs_inner);
+                // -- For qualified names (%QualifiedName pkg name),
+                // extract just the name for the DEFUN.
+                Value op;
+                if (consp(op_ast) and is_symbol(
+                    car(op_ast), u8"%QualifiedName"))
+                {
+                    op = translate(tu, caddr(op_ast));
+                }
+                else
+                {
+                    op = translate(tu, op_ast);
+                }
+                auto raw_args = caddr(lhs_inner);
+
+                // -- Functions with double-quoted (lazy) parameters
+                // get a ,LAM suffix on their DEFUN name.
+                if (lazy_params_p(raw_args) and symbolp(op))
+                {
+                    auto name = symbol_name(op);
+                    auto lam_name = std::u8string(name) + u8",LAM";
+                    op = sym(a, lam_name);
+                }
+
+                // -- Build a tuple from the args.
+                Value args;
+                if (consp(raw_args) and length(raw_args) == 1)
+                {
+                    // -- Single arg: check if it's a tuple.
+                    auto single = car(raw_args);
+                    if (consp(single) and is_symbol(car(single), u8"%Tuple"))
+                        args = translate(tu, single);
+                    else
+                        args = translate(tu, single);
+                }
+                else
+                {
+                    // -- Multiple args in a list > make a TUPLE.
+                    args = a.cons(sym(a, u8"TUPLE"),
+                                   tx_list(tu, raw_args));
+                }
+                return def_from_call(tu, op, args, rhs);
+            }
+
+            // -- Check if LHS is a %Signature wrapping a function call.
+            if (consp(lhs_raw) and is_symbol(car(lhs_raw), u8"%Signature"))
+            {
+                auto inner = cadr(lhs_raw);
+                auto sig_type = caddr(lhs_raw);
+                if (consp(inner) and is_symbol(car(inner), u8"%Call"))
+                {
+                    auto op = translate(tu, cadr(inner));
+                    Value args = a.cons(sym(a, u8"TUPLE"),
+                                     tx_list(tu, caddr(inner)));
+                    auto defs = def_from_call(tu, op, args, rhs);
+                    // -- Add the signature declaration.
+                    auto sig = gen_declaration(a, op, translate(tu, sig_type));
+                    defs.insert(defs.begin(), sig);
+                    return defs;
+                }
+            }
+
+            // -- Simple constant.
+            auto lhs = translate(tu, lhs_raw);
+            auto rhs_t = translate(tu, rhs);
+            rhs_t = translate_form(a, rhs_t);
+            return { a.list({ sym(a, u8"DEFCONSTANT"), lhs, rhs_t }) };
+        }
+
+        // -- %Assignment(target, value) > DEFPARAMETER
+        if (tag == u8"%Assignment")
+        {
+            auto lhs_raw = cadr(ast);
+            auto rhs = caddr(ast);
+
+            // -- Check for %Signature wrapper.
+            Value sig = nil;
+            Value lhs;
+            if (consp(lhs_raw) and is_symbol(car(lhs_raw), u8"%Signature"))
+            {
+                auto name = cadr(lhs_raw);
+                auto type = caddr(lhs_raw);
+                sig = gen_declaration(a, translate(tu, name), translate(tu, type));
+                lhs = translate(tu, name);
+            }
+            else
+            {
+                lhs = translate(tu, lhs_raw);
+            }
+
+            auto rhs_t = translate(tu, rhs);
+            rhs_t = translate_form(a, rhs_t);
+            std::vector<Value> result;
+            if (not null(sig)) result.push_back(sig);
+            result.push_back(
+                a.list({ sym(a, u8"DEFPARAMETER"), lhs, rhs_t }));
+            return result;
+        }
+
+        // -- %Module(name, exports, interface)
+        if (tag == u8"%Module")
+        {
+            auto name = cadr(ast);
+            auto exports = caddr(ast);
+            auto iface = car(cddr(cdr(ast)));
+
+            std::vector<Value> result;
+            // -- (PROVIDE "name")
+            auto name_str = symbolp(name) ? symbol_name(name) : std::u8string_view(u8"???");
+            result.push_back(
+                a.list({ sym(a, u8"PROVIDE"), str(a, name_str) }));
+
+            // -- (EVAL-WHEN (:COMPILE-TOPLEVEL :LOAD-TOPLEVEL :EXECUTE)
+            //   (EXPORT '(names...)))
+            if (not null(exports))
+            {
+                std::vector<Value> export_names;
+                for (Value e = exports; consp(e); e = cdr(e))
+                {
+                    auto n = car(e);
+                    if (consp(n) and is_symbol(car(n), u8"%Quote"))
+                        export_names.push_back(cadr(n));
+                    else
+                        export_names.push_back(translate(tu, n));
+                }
+                auto export_list = a.list(export_names);
+                result.push_back(a.list({
+                    sym(a, u8"EVAL-WHEN"),
+                    a.list({
+                        sym(a, u8":COMPILE-TOPLEVEL"),
+                        sym(a, u8":LOAD-TOPLEVEL"),
+                        sym(a, u8":EXECUTE") }),
+                    a.list({
+                        sym(a, u8"EXPORT"),
+                        a.list({ sym(a, u8"QUOTE"), export_list }) }) }));
+            }
+
+            // -- Translate interface definitions.
+            for (Value d = iface; consp(d); d = cdr(d))
+            {
+                auto forms = translate_toplevel(tu, car(d));
+                for (auto f : forms) result.push_back(f);
+            }
+
+            return result;
+        }
+
+        // -- %Import(what)
+        if (tag == u8"%Import")
+        {
+            auto what = cadr(ast);
+            auto what_t = translate(tu, what);
+            auto name_str = symbolp(what_t)
+                ? symbol_name(what_t) : std::u8string_view(u8"???");
+            return { a.list({
+                sym(a, u8"IMPORT-MODULE"), str(a, name_str) }) };
+        }
+
+        // -- %Namespace(name)
+        if (tag == u8"%Namespace")
+        {
+            auto name = cadr(ast);
+            auto name_str = symbolp(name)
+                ? symbol_name(name) : std::u8string_view(u8"???");
+            return { a.list({
+                sym(a, u8"IN-PACKAGE"), str(a, name_str) }) };
+        }
+
+        // -- %Macro(op, args, body)
+        if (tag == u8"%Macro")
+        {
+            auto op = translate(tu, cadr(ast));
+            auto args = translate(tu, caddr(ast));
+            auto body = translate(tu, car(cddr(cdr(ast))));
+            body = translate_form(a, body);
+            return bf_mdef(tu, op, args, body);
+        }
+
+        // -- %TypeAlias(name, type)
+        if (tag == u8"%TypeAlias")
+        {
+            auto name = translate(tu, cadr(ast));
+            auto type = translate(tu, caddr(ast));
+            return { a.list({
+                sym(a, u8"DEFTYPE"), name,
+                nil,  // empty arg list
+                a.list({ sym(a, u8"QUOTE"), bf_type(a, type) }) }) };
+        }
+
+        // -- %Structure(name, variants)
+        if (tag == u8"%Structure")
+        {
+            auto name_ast = cadr(ast);
+            auto variants_raw = caddr(ast);
+            std::vector<Value> result;
+
+            // -- Unwrap single-element list (from span_list).
+            Value content = variants_raw;
+            if (consp(content) and null(cdr(content)))
+                content = car(content);
+
+            // -- Check for Record: (%Record fields accessors)
+            if (consp(content) and symbolp(car(content))
+                and symbol_name(car(content)) == u8"%Record")
+            {
+                auto struct_name = translate(tu, name_ast);
+                auto fields_raw = cadr(content);
+                auto accessors_raw = caddr(content);
+
+                // -- Extract field names from the Record(...)
+                // call inside fields_raw.
+                // fields_raw is a list of one %Call node:
+                // ((%Call Record (%Tuple (%Sig f1 t1) ...)))
+                Value fields = nil;
+                if (consp(fields_raw))
+                {
+                    auto record_call = car(fields_raw);
+                    if (consp(record_call)
+                        and symbolp(car(record_call))
+                        and symbol_name(car(record_call))
+                           == u8"%Call")
+                    {
+                        auto args = caddr(record_call);
+                        // -- Unwrap span_list wrapper.
+                        if (consp(args) and null(cdr(args)))
+                        {
+                            auto inner = car(args);
+                            if (consp(inner)
+                                and symbolp(car(inner))
+                                and symbol_name(car(inner))
+                                   == u8"%Tuple")
+                                fields = cadr(inner);
+                        }
+                    }
+                }
+
+                std::vector<std::u8string> field_names;
+                for (Value f = fields; consp(f); f = cdr(f))
+                {
+                    auto field = car(f);
+                    if (consp(field)
+                        and symbolp(car(field))
+                        and symbol_name(car(field))
+                           == u8"%Signature"
+                        and consp(cdr(field))
+                        and symbolp(cadr(field)))
+                    {
+                        auto fname = symbol_name(
+                            cadr(field));
+                        field_names.push_back(
+                            Boot::unescape_boot_id(fname));
+                    }
+                }
+
+                if (not field_names.empty())
+                {
+                    // -- (DEFSTRUCT (%LoadUnit (:COPIER copy%LoadUnit))
+                    //   fdefs sigs xports ...)
+                    auto copier_name = std::u8string(u8"copy")
+                        + std::u8string(symbol_name(struct_name));
+                    auto struct_opts = a.list({
+                        struct_name,
+                        a.list({ sym(a, u8":COPIER"),
+                                 sym(a, copier_name) }) });
+                    std::vector<Value> slot_names;
+                    for (auto& fn : field_names)
+                        slot_names.push_back(sym(a, fn));
+                    auto defstruct = a.cons(sym(a, u8"DEFSTRUCT"),
+                        a.cons(struct_opts,
+                               a.list(slot_names)));
+                    result.push_back(defstruct);
+
+                    // -- (DEFMACRO mk%LoadUnit (f1 f2 ...)
+                    //   (LIST 'MAKE-%LoadUnit :f1 f1 :f2 f2 ...))
+                    auto mk_name = std::u8string(u8"mk")
+                        + std::u8string(symbol_name(struct_name));
+                    auto make_name = std::u8string(u8"MAKE-")
+                        + std::u8string(symbol_name(struct_name));
+                    std::vector<Value> mk_params;
+                    std::vector<Value> mk_body_elems;
+                    mk_body_elems.push_back(
+                        a.list({ sym(a, u8"QUOTE"),
+                                 sym(a, make_name) }));
+                    for (auto& fn : field_names)
+                    {
+                        auto p = sym(a, fn);
+                        mk_params.push_back(p);
+                        // -- keyword :fieldname
+                        mk_body_elems.push_back(
+                            sym(a, std::u8string(u8":") + fn));
+                        mk_body_elems.push_back(p);
+                    }
+                    auto mk_macro = a.list({
+                        sym(a, u8"DEFMACRO"),
+                        sym(a, mk_name),
+                        a.list(mk_params),
+                        a.cons(sym(a, u8"LIST"),
+                               a.list(mk_body_elems)) });
+                    result.push_back(mk_macro);
+
+                    // -- Generate accessor DEFMACROs from
+                    // AccessorDef nodes.
+                    // Each accessor: (%AccessorDef name
+                    //   (%Call . fieldname))
+                    // Generates: (DEFMACRO name (bfVar#1)
+                    //   (LIST 'StructName-field bfVar#1))
+                    for (Value ac = accessors_raw; consp(ac);
+                         ac = cdr(ac))
+                    {
+                        auto adef = car(ac);
+                        if (not consp(adef)) continue;
+                        if (not symbolp(car(adef))) continue;
+                        if (symbol_name(car(adef))
+                            != u8"%AccessorDef")
+                            continue;
+                        auto acc_name = cadr(adef);
+                        auto selector = caddr(adef);
+                        if (not symbolp(acc_name)) continue;
+                        // -- Extract field name from selector.
+                        // selector is (%Call . fieldname)
+                        // where . is the dot operator.
+                        std::u8string field_name;
+                        if (consp(selector)
+                            and symbolp(car(selector))
+                            and symbol_name(car(selector))
+                               == u8"%Call")
+                        {
+                            // -- (%Call . fieldname)
+                            // caddr = fieldname or
+                            // (fieldname) list
+                            auto fn = caddr(selector);
+                            if (consp(fn))
+                                fn = car(fn);
+                            if (symbolp(fn))
+                            {
+                                field_name =
+                                    Boot::unescape_boot_id(
+                                        symbol_name(fn));
+                            }
+                        }
+                        if (field_name.empty()) continue;
+                        // -- Build: StructName-field
+                        auto slot_accessor =
+                            std::u8string(
+                                symbol_name(struct_name))
+                            + u8"-" + field_name;
+                        auto param = tu.gensym();
+                        auto macro = a.list({
+                            sym(a, u8"DEFMACRO"),
+                            acc_name,
+                            a.list({ param }),
+                            a.list({
+                                sym(a, u8"LIST"),
+                                a.list({ sym(a, u8"QUOTE"),
+                                    sym(a, slot_accessor) }),
+                                param }) });
+                        result.push_back(macro);
+                    }
+                }
+
+                return result;
+            }
+
+            // -- Check for Pile of variants.
+            Value variant_list = nil;
+            if (consp(content) and symbolp(car(content))
+                and symbol_name(car(content)) == u8"%Pile")
+            {
+                variant_list = cadr(content);
+            }
+            else
+            {
+                // -- Single variant or already a list.
+                variant_list = variants_raw;
+            }
+
+            // -- Check for Enumeration variant:
+            // ((%Call Enumeration ((%Tuple (c1 c2 ...)))))
+            // > (DEFTYPE name () '(MEMBER c1 c2 ...))
+            if (consp(variant_list) and null(cdr(variant_list)))
+            {
+                auto variant = car(variant_list);
+                if (consp(variant) and is_symbol(car(variant), u8"%Call")
+                    and symbolp(cadr(variant))
+                    and symbol_name(cadr(variant)) == u8"Enumeration")
+                {
+                    auto vargs = caddr(variant);
+                    // -- Extract constants from args.
+                    std::vector<Value> csts;
+                    if (consp(vargs) and null(cdr(vargs)))
+                    {
+                        auto inner = car(vargs);
+                        Value elems = nil;
+                        if (consp(inner)
+                            and is_symbol(car(inner), u8"%Tuple"))
+                            elems = cadr(inner);
+                        else
+                            elems = vargs;
+                        for (Value e = elems; consp(e); e = cdr(e))
+                        {
+                            if (symbolp(car(e)))
+                                csts.push_back(car(e));
+                        }
+                    }
+                    if (not csts.empty())
+                    {
+                        auto struct_name = translate(tu, name_ast);
+                        auto member_list = a.cons(sym(a, u8"MEMBER"),
+                            a.list(csts));
+                        auto quoted = a.list({
+                            sym(a, u8"QUOTE"), member_list });
+                        result.push_back(a.list({
+                            sym(a, u8"DEFTYPE"),
+                            struct_name, nil, quoted }));
+                        return result;
+                    }
+                }
+            }
+
+            // -- Walk variants: each is a %Call node like
+            // (%Call %Command %String) or
+            // (%Call %Module (%Tuple %Symbol %List %List))
+            for (Value v = variant_list; consp(v); v = cdr(v))
+            {
+                auto variant = car(v);
+                if (not consp(variant)) continue;
+                if (not symbolp(car(variant))) continue;
+
+                auto vtag = symbol_name(car(variant));
+                if (vtag != u8"%Call") continue;
+
+                auto vname = cadr(variant);
+                if (not symbolp(vname)) continue;
+
+                // -- Count arguments from the third element.
+                // vargs is a list (from span_list).
+                // Single arg: (%String) > arity 1
+                // Multi arg: ((%Tuple (%Symbol %List %List)))
+                //   > unwrap > count tuple elements
+                auto vargs = caddr(variant);
+                int arity = 0;
+                if (null(vargs))
+                {
+                    arity = 0;
+                }
+                else if (consp(vargs))
+                {
+                    auto first = car(vargs);
+                    // -- Check if it's a single-element list
+                    // wrapping a %Tuple node.
+                    if (null(cdr(vargs)) and consp(first)
+                        and symbolp(car(first))
+                        and symbol_name(car(first)) == u8"%Tuple")
+                    {
+                        // -- Count elements in the tuple's
+                        // children list.
+                        for (Value e = cadr(first); consp(e);
+                             e = cdr(e))
+                            ++arity;
+                    }
+                    else
+                    {
+                        // -- Count list elements.
+                        for (Value e = vargs; consp(e);
+                             e = cdr(e))
+                            ++arity;
+                    }
+                }
+                else if (symbolp(vargs))
+                {
+                    arity = 1;
+                }
+
+                // -- Generate constructor DEFUN.
+                std::vector<Value> params;
+                for (int i = 0; i < arity; ++i)
+                    params.push_back(tu.gensym());
+                auto param_list = a.list(params);
+                auto cons_body = a.list({
+                    sym(a, u8"CONS"),
+                    a.list({ sym(a, u8"QUOTE"), vname }),
+                    a.cons(sym(a, u8"LIST"), param_list) });
+                auto defun = a.list({
+                    sym(a, u8"DEFUN"), vname, param_list,
+                    cons_body });
+                result.push_back(defun);
+            }
+
+            return result;
+        }
+
+        // -- %Lisp(string)
+        if (tag == u8"%Lisp")
+        {
+            auto text = cadr(ast);
+            return { a.list({ sym(a, u8"+LINE"), text }) };
+        }
+
+        // -- Default: translate as top-level expression.
+        {
+            auto expr = translate(tu, ast);
+            expr = translate_form(a, expr);
+            return { expr };
+        }
+    }
+
+    // -- translate_file: full file translation
+
+    std::vector<Value> translate_file(
+        TranslationUnit& tu,
+        const std::vector<Value>& top_levels)
+    {
+        auto& a = tu.arena;
+        std::vector<Value> result;
+
+        // -- Add preamble.
+        result.push_back(a.list({
+            sym(a, u8"PROCLAIM"),
+            a.list({ sym(a, u8"QUOTE"),
+                     a.list({ sym(a, u8"OPTIMIZE"),
+                              sym(a, u8"SPEED") }) }) }));
+
+        // -- Translate each top-level form.
+        for (auto& tl : top_levels)
+        {
+            auto forms = translate_toplevel(tu, tl);
+            for (auto f : forms)
+                result.push_back(f);
+        }
+
+        return result;
+    }
+
+    // -- Pretty printer
+
+    void pretty_print(std::ostream& os, Value form, int indent)
+    {
+        // -- For now, use the simple printer.
+        Lisp::print(os, form);
+    }
+}

--- a/src/syntax/lisp-value.cxx
+++ b/src/syntax/lisp-value.cxx
@@ -1,0 +1,323 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Implementation of the Lisp value arena and printer.
+
+#include <iostream>
+#include <open-axiom/LispValue>
+#include <open-axiom/Charset>
+
+namespace OpenAxiom::Lisp {
+
+    using OpenAxiom::operator<<;
+
+    // -- Arena implementation
+
+    std::u8string_view Arena::intern_string(std::u8string_view s)
+    {
+        owned_strings.emplace_front(s);
+        return std::u8string_view(owned_strings.front());
+    }
+
+    Arena::Arena()
+    {
+        T = make_symbol(u8"T");
+        quote_sym = make_symbol(u8"QUOTE");
+        nil_sym = make_symbol(u8"NIL");
+    }
+
+    Value Arena::make_symbol(std::u8string_view name)
+    {
+        auto it = symbols.find(name);
+        if (it != symbols.end())
+            return it->second;
+        auto interned = intern_string(name);
+        auto& v = sym_pool.emplace_front();
+        v.name = interned;
+        auto result = tag(&v, ValueKind::Symbol);
+        symbols[interned] = result;
+        return result;
+    }
+
+    Value Arena::make_integer(std::int64_t value)
+    {
+        auto& v = int_pool.emplace_front();
+        v.value = value;
+        return tag(&v, ValueKind::Integer);
+    }
+
+    Value Arena::make_float(double value)
+    {
+        auto& v = float_pool.emplace_front();
+        v.value = value;
+        return tag(&v, ValueKind::Float);
+    }
+
+    Value Arena::make_string(std::u8string_view text)
+    {
+        auto interned = intern_string(text);
+        auto& v = str_pool.emplace_front();
+        v.text = interned;
+        return tag(&v, ValueKind::String);
+    }
+
+    Value Arena::cons(Value a, Value d)
+    {
+        auto& v = cons_pool.emplace_front();
+        v.car = a;
+        v.cdr = d;
+        return tag(&v, ValueKind::Cons);
+    }
+
+    Value Arena::list(std::initializer_list<Value> elems)
+    {
+        Value result = nil;
+        auto it = elems.end();
+        while (it != elems.begin())
+        {
+            --it;
+            result = cons(*it, result);
+        }
+        return result;
+    }
+
+    Value Arena::list(const std::vector<Value>& elems)
+    {
+        Value result = nil;
+        for (auto it = elems.rbegin(); it != elems.rend(); ++it)
+            result = cons(*it, result);
+        return result;
+    }
+
+    std::uint32_t length(Value v)
+    {
+        std::uint32_t n = 0;
+        while (consp(v))
+        {
+            ++n;
+            v = cdr(v);
+        }
+        return n;
+    }
+
+    // -- Printer implementation
+
+    void print(std::ostream& os, Value v)
+    {
+        if (null(v))
+        {
+            os << "NIL";
+            return;
+        }
+
+        switch (kind(v))
+        {
+
+        case ValueKind::Symbol: {
+            auto name = symbol_name(v);
+            // -- Handle keyword symbols (prefixed with ':'). 
+            if (name.size() > 1 and name[0] == u8':')
+            {
+                auto rest = name.substr(1);
+                os << ':';
+                if (needs_bar_quoting(rest))
+                    print_bar_quoted(os, rest);
+                else
+                    os << rest;
+            }
+            else if (needs_bar_quoting(name))
+                print_bar_quoted(os, name);
+            else
+                os << name;
+            break;
+        }
+
+        case ValueKind::Integer:
+            os << integer_value(v);
+            break;
+
+        case ValueKind::Float:
+            os << as<FloatData>(v)->value;
+            break;
+
+        case ValueKind::String:
+            os << '"' << string_text(v) << '"';
+            break;
+
+        case ValueKind::Cons: {
+            os << '(';
+            auto cur = v;
+            bool first = true;
+            while (consp(cur))
+            {
+                if (not first)
+                    os << ' ';
+                first = false;
+                print(os, car(cur));
+                cur = cdr(cur);
+            }
+            if (not null(cur))
+            {
+                os << " . ";
+                print(os, cur);
+            }
+            os << ')';
+            break;
+        }
+
+        }
+    }
+
+    // -- Condition evaluator for reader directives
+    //
+    // The lowered Boot condition AST uses tagged lists:
+    //   (%Call fun args)         -- function application
+    //   (%InfixExpr op lhs rhs)  -- infix operator
+    //   (%PrefixExpr op operand) -- prefix operator
+    //   (%QualifiedName pkg sym) -- e.g. KEYWORD::GCL -> :GCL
+    //
+    // The features list is a Lisp-style list of keyword symbols
+    // (e.g. (:SBCL :COMMON-LISP ...)).  %hasFeature checks
+    // membership via symbol name comparison.
+
+    // -- Resolve a keyword expression to its keyword name.
+    //    Handles both (%QualifiedName KEYWORD X) -> ":X"
+    //    and names prefixed with "&" (Boot macro for KEYWORD::).
+    static std::u8string resolve_keyword(Value v)
+    {
+        // -- (%QualifiedName KEYWORD X) -> ":X"
+        if (is_tagged(v, u8"%QualifiedName"))
+        {
+            auto pkg = cadr(v);
+            auto sym = caddr(v);
+            if (symbolp(pkg) and symbol_name(pkg) == u8"KEYWORD"
+                and symbolp(sym))
+            {
+                std::u8string kw = u8":";
+                kw += symbol_name(sym);
+                return kw;
+            }
+        }
+        // -- A bare symbol like ":GCL" (already keyword-prefixed).
+        if (symbolp(v))
+        {
+            auto name = symbol_name(v);
+            if (not name.empty() and name[0] == u8':')
+                return std::u8string(name);
+        }
+        return {};
+    }
+
+    // -- Check if a keyword is in the features list.
+    static bool has_feature(std::u8string_view kw, Value features)
+    {
+        auto cur = features;
+        while (consp(cur))
+        {
+            auto item = car(cur);
+            if (symbolp(item) and symbol_name(item) == kw)
+                return true;
+            cur = cdr(cur);
+        }
+        return false;
+    }
+
+    bool eval_condition(Value v, Value features)
+    {
+        if (null(v))
+            return false;
+
+        // -- Non-cons atom: true (non-nil).
+        if (not consp(v))
+            return true;
+
+        auto tag_v = car(v);
+        if (not symbolp(tag_v))
+            return true;
+        auto name = symbol_name(tag_v);
+
+        // -- (%Call |%hasFeature| (kw-expr))
+        if (name == u8"%Call")
+        {
+            auto fun = cadr(v);
+            if (symbolp(fun) and symbol_name(fun) == u8"%hasFeature")
+            {
+                // -- Third element is the args list.
+                auto args = caddr(v);
+                // -- args is the result of span_list: a proper list
+                // of arguments.  For %hasFeature, the first arg
+                // is the keyword expression.
+                Value kw_expr = null(args) ? nil
+                    : consp(args) ? car(args) : args;
+                auto kw = resolve_keyword(kw_expr);
+                if (kw.empty())
+                    return false;
+                return has_feature(kw, features);
+            }
+            // -- Unknown function: treat as false.
+            return false;
+        }
+
+        // -- (%InfixExpr |and| lhs rhs)
+        if (name == u8"%InfixExpr")
+        {
+            auto op = cadr(v);
+            if (not symbolp(op))
+                return true;
+            auto opname = symbol_name(op);
+            auto lhs = caddr(v);
+            auto rhs = car(cddr(cdr(v)));  // fourth element
+            if (opname == u8"and")
+                return eval_condition(lhs, features)
+                    and eval_condition(rhs, features);
+            if (opname == u8"or")
+                return eval_condition(lhs, features)
+                    or eval_condition(rhs, features);
+            return true;
+        }
+
+        // -- (%PrefixExpr |not| operand)
+        if (name == u8"%PrefixExpr")
+        {
+            auto op = cadr(v);
+            if (symbolp(op) and symbol_name(op) == u8"not")
+                return not eval_condition(caddr(v), features);
+            return true;
+        }
+
+        // -- Anything else: non-nil means true.
+        return true;
+    }
+}

--- a/src/syntax/sexpr.cxx
+++ b/src/syntax/sexpr.cxx
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2013, Gabriel Dos Reis.
+// -- Copyright (C) 2010-2026, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -32,12 +32,11 @@
 
 // --% Author: Gabriel Dos Reis.
 
-#include <ctype.h>
-#include <string.h>
 #include <iostream>
 #include <iterator>
 #include <open-axiom/sexpr>
 #include <open-axiom/FileMapping>
+#include <open-axiom/Charset>
 #include <open-axiom/diagnostics>
 
 namespace OpenAxiom {
@@ -48,9 +47,10 @@ namespace OpenAxiom {
          auto column = std::to_string(s.cur - s.line);
          auto msg = "invalid character on line " + line +
             " and column " + column;
-         if (isprint(*s.cur))
-            throw Diagnostics::BasicError(msg + ": " + std::string(1, *s.cur));
-         throw Diagnostics::BasicError(msg + " with code " + std::to_string(*s.cur));
+         auto c = *s.cur;
+         if (ascii_printable(c))
+            throw Diagnostics::BasicError(msg + ": " + std::string(1, static_cast<char>(c)));
+         throw Diagnostics::BasicError(msg + " with code " + std::to_string(static_cast<int>(c)));
       }
       
       static void
@@ -58,32 +58,25 @@ namespace OpenAxiom {
          throw Diagnostics::BasicError(s);
       }
 
-      // Return true if character `c' introduces a blank.
+      // -- Return true if the character `c' introduces a delimiter.
       static bool
-      is_blank(char c) {
-         return c == ' ' or c == '\t' or c == '\v'
-            or c == '\n' or c == '\f' or c == '\r';
-      }
-      
-      // Return true if the character `c' introduces a delimiter.
-      static bool
-      is_delimiter(char c) {
-         return is_blank(c)
-            or c == '(' or c == ')' or c == '\''
-            or c == '`' or c == '#';
+      sexpr_delimiter(char8_t c) {
+         return ascii_space(c)
+            or c == u8'(' or c == u8')' or c == u8'\''
+            or c == u8'`' or c == u8'#';
       }
 
-      // Move the cursor past all consecutive blank characters, and
+      // -- Move the cursor past all consecutive blank characters, and
       // return true if there are more input characters to consider.
       static bool
       skip_blank(Reader::State& s) {
          for (bool done = false; s.cur < s.bytes.end and not done; )
             switch (*s.cur) {
-            case '\n':
+            case u8'\n':
                ++s.bytes.lineno;
                s.line = ++s.cur;
                break;
-            case ' ': case '\t': case '\v': case '\r': case '\f':
+            case u8' ': case u8'\t': case u8'\v': case u8'\r': case u8'\f':
                ++s.cur;
                break;
             default: done = true; break;
@@ -91,22 +84,22 @@ namespace OpenAxiom {
          return s.cur < s.bytes.end;
       }
 
-      // Move `cur' to end-of-line marker.
+      // -- Move `cur' to end-of-line marker.
       static void
       skip_to_eol(Reader::State& s) {
-         // FIXME: properly handle CR+LF.
-         while (s.cur < s.bytes.end and *s.cur != '\n')
+         // -- FIXME: properly handle CR+LF.
+         while (s.cur < s.bytes.end and *s.cur != u8'\n')
             ++s.cur;
       }
 
-      // Move `cur' one-past a non-esacaped character `c'.
+      // -- Move `cur' one-past a non-esacaped character `c'.
       // Return true if the character was seen.
       static bool
-      skip_to_nonescaped_char(Reader::State& s, char c) {
+      skip_to_nonescaped_char(Reader::State& s, char8_t c) {
          for (bool saw_escape = false; s.cur < s.bytes.end; ++s.cur)
             if (saw_escape)
                saw_escape = false;
-            else if (*s.cur == '\\')
+            else if (*s.cur == u8'\\')
                saw_escape = true;
             else if (*s.cur == c) {
                ++s.cur;
@@ -115,11 +108,11 @@ namespace OpenAxiom {
          return false;
       }
 
-      // Move the cursor past the closing quote of string literal.
+      // -- Move the cursor past the closing quote of string literal.
       // Return true if the closing quote was effectively seen.
       static inline bool
       skip_to_quote(Reader::State& s) {
-         return skip_to_nonescaped_char(s, '"');
+         return skip_to_nonescaped_char(s, u8'"');
       }
 
       template<typename Pred>
@@ -130,18 +123,18 @@ namespace OpenAxiom {
          return s.cur < s.bytes.end;
       }
 
-      // Return true if the character `c' be part of a non-absolute
+      // -- Return true if the character `c' be part of a non-absolute
       // identifier.
       static bool
-      identifier_part(Byte c) {
+      identifier_part(char8_t c) {
          switch (c) {
-         case '+': case '-': case '*': case '/': case '%': case '^':
-         case '~': case '@': case '$': case '&': case '=':
-         case '<': case '>': case '?': case '!': case '_':
-         case '[': case ']': case '{': case '}':
+         case u8'+': case u8'-': case u8'*': case u8'/': case u8'%': case u8'^':
+         case u8'~': case u8'@': case u8'$': case u8'&': case u8'=':
+         case u8'<': case u8'>': case u8'?': case u8'!': case u8'_':
+         case u8'[': case u8']': case u8'{': case u8'}':
             return true;
          default:
-            return isalnum(c);
+            return ascii_alnum(c);
          }
       }
 
@@ -258,12 +251,10 @@ namespace OpenAxiom {
          v.visit(*this);
       }
 
-      // ---------------
       // -- Allocator --
-      // ---------------
       Allocator::Allocator() { }
 
-      // This destructor is defined here so that it provides
+      // -- This destructor is defined here so that it provides
       // a single instantiation point for destructors of all
       // used templates floating around.
       Allocator::~Allocator() { }
@@ -352,19 +343,19 @@ namespace OpenAxiom {
          return vectors.make(elts);
       }
 
-      // The sequence of characters in [cur, last) consists
+      // -- The sequence of characters in [cur, last) consists
       // entirely of digits.  Return the corresponding natural value.
       static size_t
-      natural_value(const Byte* cur, const Byte* last) {
+      natural_value(const char8_t* cur, const char8_t* last) {
          size_t n = 0;
          for (; cur < last; ++cur)
-            // FIXME: check for overflow.
-            n = 10 * n + (*cur - '0');
+            // -- FIXME: check for overflow.
+            n = 10 * n + (*cur - u8'0');
          return n;
       }
 
       // -- Reader --
-      Reader::Reader(const Byte* f, const Byte* l)
+      Reader::Reader(const char8_t* f, const char8_t* l)
             : st{ { f, l, 1 }, f, f }
       { }
 
@@ -374,7 +365,7 @@ namespace OpenAxiom {
 
       static const Syntax* read_sexpr(Reader::State&);
 
-      // Parse a string literal
+      // -- Parse a string literal
       static const Syntax*
       read_string(Reader::State& s) {
          auto start = s.cur++;
@@ -384,22 +375,22 @@ namespace OpenAxiom {
          return s.alloc.make_string(t);
       }
 
-      // Parse an absolute identifier.
+      // -- Parse an absolute identifier.
       static const Syntax*
       read_absolute_symbol(Reader::State& s) {
          auto start = ++s.cur;
-         if (not skip_to_nonescaped_char(s, '|'))
+         if (not skip_to_nonescaped_char(s, u8'|'))
             syntax_error("missing closing bar sign for an absolute symbol");
          Lexeme t = { { start, s.cur - 1 }, s.bytes.lineno };
          return s.alloc.make_symbol(SymbolSyntax::absolute, t);
       }
 
-      // Read an atom starting with digits.
+      // -- Read an atom starting with digits.
       static const Syntax*
       read_maybe_natural(Reader::State& s) {
          auto start = s.cur;
-         advance_while (s, isdigit);
-         if (s.cur >= s.bytes.end or is_delimiter(*s.cur)) {
+         advance_while (s, ascii_digit);
+         if (s.cur >= s.bytes.end or sexpr_delimiter(*s.cur)) {
             Lexeme t = { { start, s.cur }, s.bytes.lineno };
             return s.alloc.make_integer(t);
          }
@@ -408,7 +399,7 @@ namespace OpenAxiom {
          return s.alloc.make_symbol(SymbolSyntax::ordinary, t);
       }
 
-      // Read an identifier.
+      // -- Read an identifier.
       static const Syntax*
       read_identifier(Reader::State& s) {
          auto start = s.cur;
@@ -417,14 +408,14 @@ namespace OpenAxiom {
          return s.alloc.make_symbol(SymbolSyntax::ordinary, t);
       }
 
-      // Read an atom starting with a '+' or '-' sign; this
+      // -- Read an atom starting with a '+' or '-' sign; this
       // should be identifier, or a signed integer.
       static const Syntax*
       read_maybe_signed_number(Reader::State& s) {
          auto start = s.cur++;
-         if (s.cur < s.bytes.end and isdigit(*s.cur)) {
-            advance_while(s, isdigit);
-            if (s.cur >= s.bytes.end or is_delimiter(*s.cur)) {
+         if (s.cur < s.bytes.end and ascii_digit(*s.cur)) {
+            advance_while(s, ascii_digit);
+            if (s.cur >= s.bytes.end or sexpr_delimiter(*s.cur)) {
                Lexeme t = { { start, s.cur }, s.bytes.lineno };
                return s.alloc.make_integer(t);
             }
@@ -442,16 +433,16 @@ namespace OpenAxiom {
          return s.alloc.make_symbol(SymbolSyntax::keyword, t);
       }
 
-      // Read an atom.
+      // -- Read an atom.
       static const Syntax*
       read_atom(Reader::State& s) {
          switch (*s.cur) {
-         case '"': return read_string(s);
-         case ':': return read_keyword(s);
-         case '-': case '+': return read_maybe_signed_number(s);
+         case u8'"': return read_string(s);
+         case u8':': return read_keyword(s);
+         case u8'-': case u8'+': return read_maybe_signed_number(s);
 
-         case '0': case '1': case '2': case '3': case '4':
-         case '5': case '6': case '7': case '8': case '9':
+         case u8'0': case u8'1': case u8'2': case u8'3': case u8'4':
+         case u8'5': case u8'6': case u8'7': case u8'8': case u8'9':
             return read_maybe_natural(s);
 
          default:
@@ -463,7 +454,7 @@ namespace OpenAxiom {
          }
       }
 
-      // Parse a quote expression.
+      // -- Parse a quote expression.
       static const Syntax*
       read_quote(Reader::State& s) {
          ++s.cur;               // skip the quote character
@@ -473,7 +464,7 @@ namespace OpenAxiom {
          return s.alloc.make_quote(x);
       }
 
-      // Parse a backquote expression.
+      // -- Parse a backquote expression.
       static const Syntax*
       read_backquote(Reader::State& s) {
          ++s.cur;               // skip the backquote character
@@ -483,13 +474,13 @@ namespace OpenAxiom {
          return s.alloc.make_antiquote(x);
       }
 
-      // We've just seen "#(" indicating the start of a literal
+      // -- We've just seen "#(" indicating the start of a literal
       // vector.  Read the elements and return the corresponding form.
       static const Syntax*
       finish_literal_vector(Reader::State& s) {
          ++s.cur;               // Skip the open paren.
          std::vector<const Syntax*> elts { };
-         while (skip_blank(s) and *s.cur != ')') {
+         while (skip_blank(s) and *s.cur != u8')') {
             if (auto x = read_sexpr(s))
                elts.push_back(x);
             else
@@ -502,21 +493,21 @@ namespace OpenAxiom {
          return s.alloc.make_vector(elts);
       }
 
-      // We've just seen the sharp sign followed by a digit.  We assume
+      // -- We've just seen the sharp sign followed by a digit.  We assume
       // we are about to read an anchor or a back reference.
       static const Syntax*
       finish_anchor_or_reference(Reader::State& s) {
          auto start = s.cur;
-         advance_while(s, isdigit);
+         advance_while(s, ascii_digit);
          if (s.cur >= s.bytes.end)
             syntax_error("end-of-input after sharp-number sign");
-         const Byte c = *s.cur;
-         if (c != '#' and c != '=')
+         const char8_t c = *s.cur;
+         if (c != u8'#' and c != u8'=')
             syntax_error("syntax error after sharp-number-equal sign");
          Lexeme t = { { start, s.cur }, s.bytes.lineno };
          auto n = natural_value(start, s.cur);
          ++s.cur;
-         if (c == '#')
+         if (c == u8'#')
             return s.alloc.make_reference(n, t);
          auto x = read_sexpr(s);
          if (x == nullptr)
@@ -581,30 +572,30 @@ namespace OpenAxiom {
          if (++s.cur >= s.bytes.end)
             syntax_error("end-of-input reached after sharp sign");
          switch (*s.cur) {
-         case '(':  return finish_literal_vector(s);
-         case '\'': return finish_function(s);
-         case ':': return finish_uninterned_symbol(s);
-         case '.': return finish_readtime_eval(s);
-         case '\\': return finish_character(s);
-         case '+': return finish_include(s);
-         case '-': return finish_exclude(s);
+         case u8'(':  return finish_literal_vector(s);
+         case u8'\'': return finish_function(s);
+         case u8':': return finish_uninterned_symbol(s);
+         case u8'.': return finish_readtime_eval(s);
+         case u8'\\': return finish_character(s);
+         case u8'+': return finish_include(s);
+         case u8'-': return finish_exclude(s);
 
          default:
-            if (isdigit(*s.cur))
+            if (ascii_digit(*s.cur))
                return finish_anchor_or_reference(s);
             syntax_error("syntax error after sharp-sign");
          }
          return nullptr;
       }
 
-      // We have just seen a dot; read the tail and the closing parenthesis.
+      // -- We have just seen a dot; read the tail and the closing parenthesis.
       static const Syntax*
       finish_dotted_list(Reader::State& s, std::vector<const Syntax*>& elts) {
          ++s.cur;               // Skip dot sign.
          auto x = read_sexpr(s);
          if (x == nullptr)
             syntax_error("missing expression after dot sign");
-         if (not skip_blank(s) or *s.cur != ')')
+         if (not skip_blank(s) or *s.cur != u8')')
             syntax_error("missing closing parenthesis");
          ++s.cur;
          elts.push_back(x);
@@ -617,12 +608,12 @@ namespace OpenAxiom {
          std::vector<const Syntax*> elts { };
          while (skip_blank(s))
             switch (*s.cur) {
-            case '.':
+            case u8'.':
                if (elts.empty())
                   syntax_error("missing expression before dot sign.");
                return finish_dotted_list(s, elts);
 
-            case ')':
+            case u8')':
                ++s.cur;
                return s.alloc.make_list(elts);
 
@@ -641,12 +632,12 @@ namespace OpenAxiom {
       read_sexpr(Reader::State& s) {
          while (skip_blank(s))
             switch (*s.cur) {
-            case ';': skip_to_eol(s); break;
-            case '\'': return read_quote(s);
-            case '`': return read_backquote(s);
-            case '|': return read_absolute_symbol(s);
-            case '#': return read_sharp_et_al(s);
-            case '(': return read_pair(s);
+            case u8';': skip_to_eol(s); break;
+            case u8'\'': return read_quote(s);
+            case u8'`': return read_backquote(s);
+            case u8'|': return read_absolute_symbol(s);
+            case u8'#': return read_sharp_et_al(s);
+            case u8'(': return read_pair(s);
             default: return read_atom(s);
             }
          return nullptr;
@@ -657,11 +648,11 @@ namespace OpenAxiom {
          return read_sexpr(st);
       }
 
-      const Byte*
+      const char8_t*
       Reader::position(Ordinal p) {
          st.cur = st.bytes.start + p;
          st.line = st.cur;
-         // while (st.line > st.start and st.line[-1] != '\n')
+         // -- while (st.line > st.start and st.line[-1] != '\n')
          //    --st.line;
          return st.cur;
       }

--- a/src/syntax/syntax-print.cxx
+++ b/src/syntax/syntax-print.cxx
@@ -1,0 +1,173 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   S-expression printer for syntax trees.  Uses the node
+// --%   descriptor infrastructure from SyntaxTree to drive a
+// --%   generic, data-driven formatting pass.
+
+#include <iostream>
+#include <open-axiom/SyntaxPrint>
+#include <open-axiom/Charset>
+
+namespace OpenAxiom::Syntax {
+
+    // -- Extract the source text of a token.
+    std::u8string token_text(TokenIndex ti,
+                             const std::vector<Token>& toks,
+                             const Fragment& frag)
+    {
+        auto idx = std::uint32_t(ti);
+        if (idx >= toks.size())
+            return u8"???";
+        auto& tok = toks[idx];
+        // -- Single-line token: extract substring.
+        if (tok.start.line == tok.end.line)
+        {
+            auto& line = frag[tok.start.line];
+            auto col0 = tok.start.column;
+            auto col1 = tok.end.column;
+            if (col1 <= col0)
+                return u8"";
+            return std::u8string(line.data() + col0, col1 - col0);
+        }
+        // -- Multi-line token (e.g. string with continuation):
+        // concatenate lines.
+        std::u8string result;
+        for (auto ln = tok.start.line; ln <= tok.end.line; ++ln)
+        {
+            auto& line = frag[ln];
+            auto col0 = (ln == tok.start.line) ? tok.start.column : 0;
+            auto col1 = (ln == tok.end.line) ? tok.end.column
+                                             : static_cast<uint16_t>(line.size());
+            result.append(line.data() + col0, col1 - col0);
+        }
+        return result;
+    }
+
+    // -- Emit a token's text, quoting it with |bars| if needed.
+    void print_token(std::ostream& os, TokenIndex ti,
+                     const std::vector<Token>& toks,
+                     const Fragment& frag)
+    {
+        auto text = token_text(ti, toks, frag);
+        if (needs_bar_quoting(text))
+            print_bar_quoted(os, text);
+        else
+            os << std::u8string_view(text);
+    }
+
+    // -- Print a NodeField value to a stream.
+    static void print_field(std::ostream& os,
+                            const NodeField& f,
+                            const SyntaxForest& forest,
+                            const std::vector<Token>& toks,
+                            const Fragment& frag)
+    {
+        switch (f.role)
+        {
+        case FieldRole::Child:
+            print_sexpr(os, f.child, forest, toks, frag);
+            break;
+        case FieldRole::Span:
+            for (std::uint32_t i = 0; i < f.span.count; ++i)
+            {
+                if (i > 0) os << ' ';
+                print_sexpr(os, forest.child(f.span, i),
+                            forest, toks, frag);
+            }
+            break;
+        case FieldRole::WrappedSpan:
+            os << '(';
+            for (std::uint32_t i = 0; i < f.span.count; ++i)
+            {
+                if (i > 0) os << ' ';
+                print_sexpr(os, forest.child(f.span, i),
+                            forest, toks, frag);
+            }
+            os << ')';
+            break;
+        case FieldRole::Token:
+            print_token(os, f.token, toks, frag);
+            break;
+        case FieldRole::Literal:
+            os << token_text(f.token, toks, frag);
+            break;
+        }
+    }
+
+    // -- Print a syntax node as an S-expression.
+    void print_sexpr(std::ostream& os,
+                     NodeIndex node,
+                     const SyntaxForest& forest,
+                     const std::vector<Token>& toks,
+                     const Fragment& frag)
+    {
+        if (not valid(node))
+        {
+            os << "NIL";
+            return;
+        }
+
+        // -- Special case: Unparsed uses " .. " separator.
+        if (kind(node) == Kind::Unparsed)
+        {
+            auto& n = forest.unparsed_node(index(node));
+            os << "(%Unparsed ";
+            print_token(os, n.first, toks, frag);
+            os << " .. ";
+            print_token(os, n.last, toks, frag);
+            os << ')';
+            return;
+        }
+
+        auto desc = describe_node(node, forest);
+
+        // -- Leaf nodes: print single field directly.
+        if (desc.tag == nullptr)
+        {
+            print_field(os, desc.fields[0], forest, toks, frag);
+            return;
+        }
+
+        // -- Tagged compound node: (%Tag field1 field2 ...).
+        os << "(%" << desc.tag;
+        for (std::uint8_t i = 0; i < desc.count; ++i)
+        {
+            os << ' ';
+            print_field(os, desc.fields[i], forest, toks, frag);
+        }
+        os << ')';
+    }
+}

--- a/src/syntax/syntax-tree.cxx
+++ b/src/syntax/syntax-tree.cxx
@@ -1,0 +1,629 @@
+// -- -*- C++ -*-
+// Copyright (C) 2026, Gabriel Dos Reis.
+// All rights reserved.
+// Written by Gabriel Dos Reis.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     - Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     - Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in
+//       the documentation and/or other materials provided with the
+//       distribution.
+//
+//     - Neither the name of OpenAxiom, nor the names of its contributors may
+//       be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// --% Author: Gabriel Dos Reis
+// --% Description:
+// --%   Implementation of SyntaxForest: the arena that owns all syntax
+// --%   tree nodes for a Boot translation unit.
+
+#include <open-axiom/SyntaxTree>
+
+namespace OpenAxiom::Syntax {
+
+    // -- Allocate a contiguous span of `count` child slots in the
+    // -- shared children array, initialized to NodeIndex::none.
+    NodeSpan SyntaxForest::allocate_span(std::uint32_t count)
+    {
+        auto offset = static_cast<std::uint32_t>(children.size());
+        children.resize(children.size() + count, NodeIndex::none);
+        return { offset, count };
+    }
+
+    // -- Access the i-th child within a span (mutable).
+    NodeIndex& SyntaxForest::child(NodeSpan span, std::uint32_t i)
+    {
+        return children[span.offset + i];
+    }
+
+    // -- Access the i-th child within a span (const).
+    const NodeIndex& SyntaxForest::child(NodeSpan span, std::uint32_t i) const
+    {
+        return children[span.offset + i];
+    }
+
+    // -- Helper macro: push a node into a per-kind vector and return
+    // the corresponding NodeIndex handle.  The `func` argument
+    // is the snake_case function suffix, `kind_tag` is the
+    // PascalCase Kind enumerator.
+#define DEFINE_MAKE_AS(func, kind_tag, vec, SynType)            \
+    NodeIndex SyntaxForest::make_##func(const SynType& node) \
+    {                                                       \
+        auto idx = static_cast<std::uint32_t>(vec.size()); \
+        vec.push_back(node);                                \
+        return make_node(Kind::kind_tag, idx);        \
+    }
+
+    // -- Atoms --
+    DEFINE_MAKE_AS(literal, Literal, literals, LiteralSyntax)
+    DEFINE_MAKE_AS(name, Name, names, NameSyntax)
+    DEFINE_MAKE_AS(qualified_name, QualifiedName, qualified_names, QualifiedNameSyntax)
+
+    // -- Module system --
+    DEFINE_MAKE_AS(module, Module, modules, ModuleSyntax)
+    DEFINE_MAKE_AS(namespace, Namespace, namespaces, NamespaceSyntax)
+    DEFINE_MAKE_AS(import, Import, imports, ImportSyntax)
+    DEFINE_MAKE_AS(import_signature, ImportSignature, import_signatures, ImportSignatureSyntax)
+
+    // -- Definitions --
+    DEFINE_MAKE_AS(constant_def, ConstantDef, constant_defs, ConstantDefSyntax)
+    DEFINE_MAKE_AS(function_def, FunctionDef, function_defs, FunctionDefSyntax)
+    DEFINE_MAKE_AS(macro_def, MacroDef, macro_defs, MacroDefSyntax)
+    DEFINE_MAKE_AS(type_alias, TypeAlias, type_aliases, TypeAliasSyntax)
+    DEFINE_MAKE_AS(signature, Signature, signatures, SignatureSyntax)
+
+    // -- Expressions --
+    DEFINE_MAKE_AS(apply, Apply, applications, ApplySyntax)
+    DEFINE_MAKE_AS(infix, InfixExpr, infix_exprs, InfixExprSyntax)
+    DEFINE_MAKE_AS(prefix, PrefixExpr, prefix_exprs, PrefixExprSyntax)
+    DEFINE_MAKE_AS(suffix_dot, SuffixDot, suffix_dots, SuffixDotSyntax)
+    DEFINE_MAKE_AS(restrict, Restrict, restricts, RestrictSyntax)
+    DEFINE_MAKE_AS(coerce, Coerce, coercions, CoerceSyntax)
+    DEFINE_MAKE_AS(quote, Quote, quotes, QuoteSyntax)
+    DEFINE_MAKE_AS(bracket, Bracket, brackets, BracketSyntax)
+    DEFINE_MAKE_AS(tuple, Tuple, tuples, TupleSyntax)
+    DEFINE_MAKE_AS(sequence, Sequence, sequences, SequenceSyntax)
+    DEFINE_MAKE_AS(pile, Pile, piles, PileSyntax)
+
+    // -- Types --
+    DEFINE_MAKE_AS(mapping, Mapping, mappings, MappingSyntax)
+    DEFINE_MAKE_AS(forall, Forall, foralls, ForallSyntax)
+
+    // -- Control flow --
+    DEFINE_MAKE_AS(if, IfExpr, if_exprs, IfExprSyntax)
+    DEFINE_MAKE_AS(return, Return, returns, ReturnSyntax)
+    DEFINE_MAKE_AS(leave, Leave, leaves, LeaveSyntax)
+    DEFINE_MAKE_AS(implies, Implies, implications, ImpliesSyntax)
+
+    // -- Loops --
+    DEFINE_MAKE_AS(while, While, whiles, WhileSyntax)
+    DEFINE_MAKE_AS(until, Until, untils, UntilSyntax)
+    DEFINE_MAKE_AS(for_in, ForIn, for_ins, ForInSyntax)
+    DEFINE_MAKE_AS(such_that, SuchThat, such_thats, SuchThatSyntax)
+    DEFINE_MAKE_AS(iterators, Iterators, iterators_list, IteratorsSyntax)
+    DEFINE_MAKE_AS(cross, Cross, crosses, CrossSyntax)
+    DEFINE_MAKE_AS(repeat, Repeat, repeats, RepeatSyntax)
+
+    // -- Pattern matching --
+    DEFINE_MAKE_AS(is, Is, is_tests, IsSyntax)
+    DEFINE_MAKE_AS(isnt, Isnt, isnt_tests, IsntSyntax)
+    DEFINE_MAKE_AS(equal_pattern, EqualPattern, equal_patterns, EqualPatternSyntax)
+    DEFINE_MAKE_AS(colon_append, ColonAppend, colon_appends, ColonAppendSyntax)
+
+    // -- Assignment & binding --
+    DEFINE_MAKE_AS(assignment, Assignment, assignments, AssignmentSyntax)
+    DEFINE_MAKE_AS(lambda, Lambda, lambdas, LambdaSyntax)
+    DEFINE_MAKE_AS(default_value, DefaultValue, default_values, DefaultValueSyntax)
+    DEFINE_MAKE_AS(key_arg, KeyArg, key_args, KeyArgSyntax)
+
+    // -- Segments --
+    DEFINE_MAKE_AS(bounded_segment, BoundedSegment, bounded_segments, BoundedSegmentSyntax)
+    DEFINE_MAKE_AS(unbounded_segment, UnboundedSegment, unbounded_segments, UnboundedSegmentSyntax)
+
+    // -- Reduce --
+    DEFINE_MAKE_AS(reduce, Reduce, reduces, ReduceSyntax)
+
+    // -- Structural --
+    DEFINE_MAKE_AS(structure, Structure, structures, StructureSyntax)
+    DEFINE_MAKE_AS(record, Record, records, RecordSyntax)
+    DEFINE_MAKE_AS(accessor_def, AccessorDef, accessor_defs, AccessorDefSyntax)
+    DEFINE_MAKE_AS(case, Case, cases, CaseSyntax)
+
+    // -- Exception handling --
+    DEFINE_MAKE_AS(throw, Throw, throws, ThrowSyntax)
+    DEFINE_MAKE_AS(catch, Catch, catches, CatchSyntax)
+    DEFINE_MAKE_AS(finally, Finally, finallys, FinallySyntax)
+    DEFINE_MAKE_AS(try, Try, trys, TrySyntax)
+
+    // -- Scoping --
+    DEFINE_MAKE_AS(where, Where, wheres, WhereSyntax)
+    DEFINE_MAKE_AS(dynamic, Dynamic, dynamics, DynamicSyntax)
+
+    // -- Spad type system --
+    DEFINE_MAKE_AS(with, With, withs, WithSyntax)
+    DEFINE_MAKE_AS(add, Add, adds, AddSyntax)
+    DEFINE_MAKE_AS(capsule, Capsule, capsules, CapsuleSyntax)
+    DEFINE_MAKE_AS(pretend, Pretend, pretends, PretendSyntax)
+    DEFINE_MAKE_AS(has, Has, has_tests, HasSyntax)
+    DEFINE_MAKE_AS(collect, Collect, collects, CollectSyntax)
+    DEFINE_MAKE_AS(join, Join, joins, JoinSyntax)
+
+    // -- Spad declarations --
+    DEFINE_MAKE_AS(free_decl, FreeDecl, free_decls, FreeDeclSyntax)
+    DEFINE_MAKE_AS(export_decl, ExportDecl, export_decls, ExportDeclSyntax)
+
+    // -- Embedded Lisp --
+    DEFINE_MAKE_AS(lisp_expr, LispExpr, lisp_exprs, LispExprSyntax)
+
+    // -- Fallback --
+    DEFINE_MAKE_AS(unparsed, Unparsed, unparsed, UnparsedSyntax)
+
+#undef DEFINE_MAKE_AS
+
+    // -- Node descriptor infrastructure
+
+    // -- Return the S-expression tag name for a given Kind.
+    //    Returns nullptr for leaf nodes (Literal, Name).
+    const char* tag_name(Kind k)
+    {
+        switch (k) {
+        case Kind::Literal:           return nullptr;
+        case Kind::Name:              return nullptr;
+        case Kind::QualifiedName:     return "QualifiedName";
+        case Kind::Module:            return "Module";
+        case Kind::Namespace:         return "Namespace";
+        case Kind::Import:            return "Import";
+        case Kind::ImportSignature:   return "ImportSignature";
+        case Kind::ConstantDef:       return "ConstantDefinition";
+        case Kind::FunctionDef:       return "Definition";
+        case Kind::MacroDef:          return "Macro";
+        case Kind::TypeAlias:         return "TypeAlias";
+        case Kind::Signature:         return "Signature";
+        case Kind::Apply:             return "Call";
+        case Kind::InfixExpr:         return "InfixExpr";
+        case Kind::PrefixExpr:        return "PrefixExpr";
+        case Kind::SuffixDot:         return "SuffixDot";
+        case Kind::Restrict:          return "Restrict";
+        case Kind::Coerce:            return "Coerce";
+        case Kind::Quote:             return "Quote";
+        case Kind::Bracket:           return "Bracket";
+        case Kind::Tuple:             return "Tuple";
+        case Kind::Sequence:          return "Sequence";
+        case Kind::Pile:              return "Pile";
+        case Kind::Mapping:           return "Mapping";
+        case Kind::Forall:            return "Forall";
+        case Kind::IfExpr:            return "If";
+        case Kind::Return:            return "Return";
+        case Kind::Leave:             return "Leave";
+        case Kind::Implies:           return "Implies";
+        case Kind::While:             return "While";
+        case Kind::Until:             return "Until";
+        case Kind::ForIn:             return "For";
+        case Kind::SuchThat:          return "SuchThat";
+        case Kind::Iterators:         return "Iterators";
+        case Kind::Cross:             return "Cross";
+        case Kind::Repeat:            return "Repeat";
+        case Kind::Is:                return "Is";
+        case Kind::Isnt:              return "Isnt";
+        case Kind::EqualPattern:      return "EqualPattern";
+        case Kind::ColonAppend:       return "ColonAppend";
+        case Kind::Assignment:        return "Assignment";
+        case Kind::Lambda:            return "Lambda";
+        case Kind::DefaultValue:      return "DefaultValue";
+        case Kind::KeyArg:            return "Key";
+        case Kind::BoundedSegment:    return "BoundedSegment";
+        case Kind::UnboundedSegment:  return "UnboundedSegment";
+        case Kind::Reduce:            return "Reduce";
+        case Kind::Structure:         return "Structure";
+        case Kind::Record:            return "Record";
+        case Kind::AccessorDef:       return "AccessorDef";
+        case Kind::Case:              return "Case";
+        case Kind::Throw:             return "Throw";
+        case Kind::Catch:             return "Catch";
+        case Kind::Finally:           return "Finally";
+        case Kind::Try:               return "Try";
+        case Kind::Where:             return "Where";
+        case Kind::Dynamic:           return "Dynamic";
+        case Kind::With:              return "With";
+        case Kind::Add:               return "Add";
+        case Kind::Capsule:           return "Capsule";
+        case Kind::Pretend:           return "Pretend";
+        case Kind::Has:               return "Has";
+        case Kind::Collect:           return "Collect";
+        case Kind::Join:              return "Join";
+        case Kind::FreeDecl:          return "Free";
+        case Kind::ExportDecl:        return "Export";
+        case Kind::LispExpr:          return "Lisp";
+        case Kind::Unparsed:          return "Unparsed";
+        default:                            return "???";
+        }
+    }
+
+    // -- Describe a node's shape and extract its field values.
+    NodeDescriptor describe_node(NodeIndex node,
+                                 const SyntaxForest& forest)
+    {
+        auto k = kind(node);
+        auto idx = index(node);
+        auto tag = tag_name(k);
+
+        switch (k) {
+
+        // -- Atoms --
+        case Kind::Literal: {
+            auto& n = forest.literal(idx);
+            return { tag, 1, { literal_field(n.token) } };
+        }
+        case Kind::Name: {
+            auto& n = forest.name(idx);
+            return { tag, 1, { token_field(n.token) } };
+        }
+        case Kind::QualifiedName: {
+            auto& n = forest.qualified_name(idx);
+            return { tag, 2, { child_field(n.qualifier),
+                               child_field(n.name) } };
+        }
+
+        // -- Module system --
+        case Kind::Module: {
+            auto& n = forest.module(idx);
+            return { tag, 3, { child_field(n.name),
+                               wrapped_span_field(n.exports),
+                               wrapped_span_field(n.interface) } };
+        }
+        case Kind::Namespace: {
+            auto& n = forest.namespace_node(idx);
+            return { tag, 1, { child_field(n.name) } };
+        }
+        case Kind::Import: {
+            auto& n = forest.import_node(idx);
+            return { tag, 1, { child_field(n.what) } };
+        }
+        case Kind::ImportSignature: {
+            auto& n = forest.import_signature(idx);
+            return { tag, 3, { child_field(n.signature),
+                               child_field(n.name),
+                               child_field(n.provenance) } };
+        }
+
+        // -- Definitions --
+        case Kind::ConstantDef: {
+            auto& n = forest.constant_def(idx);
+            return { tag, 2, { child_field(n.name),
+                               child_field(n.body) } };
+        }
+        case Kind::FunctionDef: {
+            auto& n = forest.function_def(idx);
+            return { tag, 3, { child_field(n.name),
+                               wrapped_span_field(n.parameters),
+                               child_field(n.body) } };
+        }
+        case Kind::MacroDef: {
+            auto& n = forest.macro_def(idx);
+            return { tag, 3, { child_field(n.name),
+                               wrapped_span_field(n.parameters),
+                               child_field(n.body) } };
+        }
+        case Kind::TypeAlias: {
+            auto& n = forest.type_alias(idx);
+            return { tag, 2, { child_field(n.name),
+                               child_field(n.type) } };
+        }
+        case Kind::Signature: {
+            auto& n = forest.signature(idx);
+            return { tag, 2, { child_field(n.name),
+                               child_field(n.type) } };
+        }
+
+        // -- Expressions --
+        case Kind::Apply: {
+            auto& n = forest.apply(idx);
+            return { tag, 2, { child_field(n.function),
+                               span_field(n.arguments) } };
+        }
+        case Kind::InfixExpr: {
+            auto& n = forest.infix_expr(idx);
+            return { tag, 3, { token_field(n.op),
+                               child_field(n.lhs),
+                               child_field(n.rhs) } };
+        }
+        case Kind::PrefixExpr: {
+            auto& n = forest.prefix_expr(idx);
+            return { tag, 2, { token_field(n.op),
+                               child_field(n.operand) } };
+        }
+        case Kind::SuffixDot: {
+            auto& n = forest.suffix_dot(idx);
+            return { tag, 1, { child_field(n.operand) } };
+        }
+        case Kind::Restrict: {
+            auto& n = forest.restrict_node(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.type) } };
+        }
+        case Kind::Coerce: {
+            auto& n = forest.coerce(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.type) } };
+        }
+        case Kind::Quote: {
+            auto& n = forest.quote(idx);
+            return { tag, 1, { child_field(n.expr) } };
+        }
+        case Kind::Bracket: {
+            auto& n = forest.bracket(idx);
+            return { tag, 1, { span_field(n.elements) } };
+        }
+        case Kind::Tuple: {
+            auto& n = forest.tuple(idx);
+            return { tag, 1, { span_field(n.elements) } };
+        }
+        case Kind::Sequence: {
+            auto& n = forest.sequence(idx);
+            return { tag, 1, { span_field(n.statements) } };
+        }
+        case Kind::Pile: {
+            auto& n = forest.pile(idx);
+            return { tag, 1, { span_field(n.items) } };
+        }
+
+        // -- Types --
+        case Kind::Mapping: {
+            auto& n = forest.mapping(idx);
+            return { tag, 2, { wrapped_span_field(n.sources),
+                               child_field(n.target) } };
+        }
+        case Kind::Forall: {
+            auto& n = forest.forall(idx);
+            return { tag, 2, { wrapped_span_field(n.variables),
+                               child_field(n.body) } };
+        }
+
+        // -- Control flow --
+        case Kind::IfExpr: {
+            auto& n = forest.if_expr(idx);
+            return { tag, 3, { child_field(n.condition),
+                               child_field(n.consequent),
+                               child_field(n.alternate) } };
+        }
+        case Kind::Return: {
+            auto& n = forest.return_node(idx);
+            return { tag, 1, { child_field(n.value) } };
+        }
+        case Kind::Leave: {
+            auto& n = forest.leave(idx);
+            return { tag, 1, { child_field(n.value) } };
+        }
+        case Kind::Implies: {
+            auto& n = forest.implies(idx);
+            return { tag, 2, { child_field(n.condition),
+                               child_field(n.body) } };
+        }
+
+        // -- Loops --
+        case Kind::While: {
+            auto& n = forest.while_node(idx);
+            return { tag, 1, { child_field(n.condition) } };
+        }
+        case Kind::Until: {
+            auto& n = forest.until_node(idx);
+            return { tag, 1, { child_field(n.condition) } };
+        }
+        case Kind::ForIn: {
+            auto& n = forest.for_in(idx);
+            return { tag, 3, { child_field(n.variable),
+                               child_field(n.sequence),
+                               child_field(n.step) } };
+        }
+        case Kind::SuchThat: {
+            auto& n = forest.such_that(idx);
+            return { tag, 1, { child_field(n.predicate) } };
+        }
+        case Kind::Iterators: {
+            auto& n = forest.iterators(idx);
+            return { tag, 1, { span_field(n.clauses) } };
+        }
+        case Kind::Cross: {
+            auto& n = forest.cross(idx);
+            return { tag, 1, { span_field(n.factors) } };
+        }
+        case Kind::Repeat: {
+            auto& n = forest.repeat(idx);
+            return { tag, 2, { child_field(n.iterators),
+                               child_field(n.body) } };
+        }
+
+        // -- Pattern matching --
+        case Kind::Is: {
+            auto& n = forest.is_test(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.pattern) } };
+        }
+        case Kind::Isnt: {
+            auto& n = forest.isnt_test(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.pattern) } };
+        }
+        case Kind::EqualPattern: {
+            auto& n = forest.equal_pattern(idx);
+            return { tag, 1, { child_field(n.expr) } };
+        }
+        case Kind::ColonAppend: {
+            auto& n = forest.colon_append(idx);
+            return { tag, 2, { wrapped_span_field(n.head),
+                               child_field(n.rest) } };
+        }
+
+        // -- Assignment & binding --
+        case Kind::Assignment: {
+            auto& n = forest.assignment(idx);
+            return { tag, 2, { child_field(n.target),
+                               child_field(n.value) } };
+        }
+        case Kind::Lambda: {
+            auto& n = forest.lambda(idx);
+            return { tag, 2, { wrapped_span_field(n.parameters),
+                               child_field(n.body) } };
+        }
+        case Kind::DefaultValue: {
+            auto& n = forest.default_value(idx);
+            return { tag, 2, { child_field(n.name),
+                               child_field(n.value) } };
+        }
+        case Kind::KeyArg: {
+            auto& n = forest.key_arg(idx);
+            return { tag, 2, { child_field(n.key),
+                               child_field(n.value) } };
+        }
+
+        // -- Segments --
+        case Kind::BoundedSegment: {
+            auto& n = forest.bounded_segment(idx);
+            return { tag, 2, { child_field(n.lo),
+                               child_field(n.hi) } };
+        }
+        case Kind::UnboundedSegment: {
+            auto& n = forest.unbounded_segment(idx);
+            return { tag, 1, { child_field(n.lo) } };
+        }
+
+        // -- Reduce --
+        case Kind::Reduce: {
+            auto& n = forest.reduce(idx);
+            return { tag, 2, { child_field(n.op),
+                               child_field(n.body) } };
+        }
+
+        // -- Structural --
+        case Kind::Structure: {
+            auto& n = forest.structure(idx);
+            return { tag, 2, { child_field(n.name),
+                               wrapped_span_field(n.variants) } };
+        }
+        case Kind::Record: {
+            auto& n = forest.record(idx);
+            return { tag, 2, { wrapped_span_field(n.fields),
+                               wrapped_span_field(n.accessors) } };
+        }
+        case Kind::AccessorDef: {
+            auto& n = forest.accessor_def(idx);
+            return { tag, 2, { child_field(n.name),
+                               child_field(n.selector) } };
+        }
+        case Kind::Case: {
+            auto& n = forest.case_node(idx);
+            return { tag, 2, { child_field(n.expr),
+                               wrapped_span_field(n.branches) } };
+        }
+
+        // -- Exception handling --
+        case Kind::Throw: {
+            auto& n = forest.throw_node(idx);
+            return { tag, 1, { child_field(n.expr) } };
+        }
+        case Kind::Catch: {
+            auto& n = forest.catch_node(idx);
+            return { tag, 2, { child_field(n.signature),
+                               child_field(n.body) } };
+        }
+        case Kind::Finally: {
+            auto& n = forest.finally_node(idx);
+            return { tag, 1, { child_field(n.body) } };
+        }
+        case Kind::Try: {
+            auto& n = forest.try_node(idx);
+            return { tag, 2, { child_field(n.body),
+                               wrapped_span_field(n.handlers) } };
+        }
+
+        // -- Scoping --
+        case Kind::Where: {
+            auto& n = forest.where(idx);
+            return { tag, 2, { child_field(n.body),
+                               wrapped_span_field(n.definitions) } };
+        }
+        case Kind::Dynamic: {
+            auto& n = forest.dynamic(idx);
+            return { tag, 1, { child_field(n.expr) } };
+        }
+
+        // -- Spad type system --
+        case Kind::With: {
+            auto& n = forest.with_node(idx);
+            return { tag, 1, { child_field(n.body) } };
+        }
+        case Kind::Add: {
+            auto& n = forest.add_node(idx);
+            return { tag, 1, { child_field(n.body) } };
+        }
+        case Kind::Capsule: {
+            auto& n = forest.capsule(idx);
+            return { tag, 1, { span_field(n.items) } };
+        }
+        case Kind::Pretend: {
+            auto& n = forest.pretend_node(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.type) } };
+        }
+        case Kind::Has: {
+            auto& n = forest.has_node(idx);
+            return { tag, 2, { child_field(n.expr),
+                               child_field(n.type) } };
+        }
+        case Kind::Collect: {
+            auto& n = forest.collect(idx);
+            return { tag, 2, { child_field(n.body),
+                               child_field(n.iterators) } };
+        }
+        case Kind::Join: {
+            auto& n = forest.join_node(idx);
+            return { tag, 1, { wrapped_span_field(n.arguments) } };
+        }
+
+        // -- Spad declarations --
+        case Kind::FreeDecl: {
+            auto& n = forest.free_decl(idx);
+            return { tag, 1, { child_field(n.expr) } };
+        }
+        case Kind::ExportDecl: {
+            auto& n = forest.export_decl(idx);
+            return { tag, 1, { child_field(n.signature) } };
+        }
+
+        // -- Embedded Lisp --
+        case Kind::LispExpr: {
+            auto& n = forest.lisp_expr(idx);
+            return { tag, 1, { token_field(n.token) } };
+        }
+
+        // -- Fallback --
+        case Kind::Unparsed: {
+            auto& n = forest.unparsed_node(idx);
+            return { tag, 2, { token_field(n.first),
+                               token_field(n.last) } };
+        }
+
+        default:
+            return { "???", 0, { } };
+        }
+    }
+}

--- a/src/syntax/token.cxx
+++ b/src/syntax/token.cxx
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2024, Gabriel Dos Reis.
+// -- Copyright (C) 2013-2024, Gabriel Dos Reis.
 // All rights reserved.
 // Written by Gabriel Dos Reis.
 //
@@ -35,7 +35,8 @@
 #include <iostream>
 
 namespace OpenAxiom {
-   std::ostream& operator<<(std::ostream& os, TokenCategory tc) {
+   std::ostream& operator<<(std::ostream& os, TokenCategory tc)
+   {
       switch (tc) {
       case TokenCategory::Unclassified: os << "UNCLASSIFIED"; break;
       case TokenCategory::Whitespace: os << "WHITESPACE"; break;
@@ -55,13 +56,15 @@ namespace OpenAxiom {
    }
 
 
-   bool separator_or_punctuator(uint8_t c) {
-      switch (c) {
-      case '.': case '`': case '^': case '&': case '~': case '*':
-      case '-': case '+': case ';': case ',': case '@': case '|':
-      case '\'': case ':': case '=': case '\\': case '"': case '/':
-      case '(': case ')': case '{': case '}': case '[': case ']':
-      case '<': case '>': case '#': case ' ':
+   bool separator_or_punctuator(char8_t c)
+   {
+      switch (c)
+      {
+      case u8'.': case u8'`': case u8'^': case u8'&': case u8'~': case u8'*':
+      case u8'-': case u8'+': case u8';': case u8',': case u8'@': case u8'|':
+      case u8'\'': case u8':': case u8'=': case u8'\\': case u8'"': case u8'/':
+      case u8'(': case u8')': case u8'{': case u8'}': case u8'[': case u8']':
+      case u8'<': case u8'>': case u8'#': case u8' ':
          return true;
       default:
          return false;
@@ -85,10 +88,11 @@ namespace OpenAxiom {
 #undef OPENAXIOM_DEFINE_TOKEN      
    };
 
-   TokenClassification classify(std::string_view s)
+   TokenClassification classify(std::string_view s, Language dialect)
    {
       for (auto& t : token_map) {
-         if (t.text == s)
+         if (t.text == s
+             and (uint8_t(t.dialect) & uint8_t(dialect)) != 0)
             return { t.category, t.value };
       }
       return { TokenCategory::Identifier, TokenValue::Unknown };
@@ -110,5 +114,434 @@ namespace OpenAxiom {
       while (auto t = lex.get(lang))
          v.push_back(t);
       return v;
+   }
+
+   // -- Pile phase - mirrors the algorithm of pile.boot.
+   //
+   //  Given a flat token vector (with formatting tokens from the
+   //  tokenizer), this phase:
+   //    1. Strips existing formatting/whitespace/comment tokens.
+   //    2. Groups remaining tokens into logical "lines" by their
+   //       source line number.
+   //    3. Coagulates adjacent lines when:
+   //       - the next line starts with `then` or `else`, or
+   //       - the current line ends with an infix operator,
+   //         comma, or semicolon.
+   //    4. Recursively builds a pile tree based on indentation
+   //       columns.
+   //    5. Inserts Indent/Justify/Unindent tokens to delimit
+   //       pile structures.
+   namespace {
+      // -- A "line" in the pile sense: a contiguous run of content
+      // tokens from the same source line (or coagulated from
+      // adjacent source lines).
+      struct PileLine {
+         std::vector<Token> tokens;
+
+         bool empty() const { return tokens.empty(); }
+
+         ColumnIndex column() const {
+            return tokens.front().start.column;
+         }
+
+         // -- The value of the last non-comment token on this line.
+         TokenValue last_value() const {
+            for (auto it = tokens.rbegin(); it != tokens.rend(); ++it)
+               if (it->category != TokenCategory::Comment)
+                  return it->value;
+            return TokenValue::EndOfStream;
+         }
+
+         // -- The value of the first non-comment token on this line.
+         TokenValue first_value() const {
+            for (auto& t : tokens)
+               if (t.category != TokenCategory::Comment)
+                  return t.value;
+            return TokenValue::EndOfStream;
+         }
+
+         // -- Position of the first token (for synthesizing formatting tokens).
+         FragmentCursor first_pos() const {
+            return tokens.front().start;
+         }
+
+         // -- Position of the last token (for synthesizing formatting tokens).
+         FragmentCursor last_pos() const {
+            return tokens.back().end;
+         }
+
+         // -- True if this line consists entirely of descriptions (++).
+         // Description-only lines form their own piles and must not
+         // be coagulated with adjacent code lines.  Wisecracks (--)
+         // do not have this restriction.
+         bool description_only_p() const {
+            for (auto& t : tokens)
+               if (t.value != TokenValue::Commentary)
+                  return false;
+            return true;
+         }
+      };
+
+      // -- True if `v` is an infix operator (the SHOEINF set from pile.boot).
+      bool is_infix(TokenValue v) {
+         switch (v) {
+         case TokenValue::Eq:
+         case TokenValue::Star:
+         case TokenValue::StarStar:
+         case TokenValue::Plus:
+         case TokenValue::Minus:
+         case TokenValue::Slash:
+         case TokenValue::Less:
+         case TokenValue::LessEq:
+         case TokenValue::Greater:
+         case TokenValue::GreaterEq:
+         case TokenValue::TildeEq:
+         case TokenValue::And:
+         case TokenValue::Or:
+         case TokenValue::Is:
+         case TokenValue::Isnt:
+         case TokenValue::Rem:
+         case TokenValue::Quo:
+            return true;
+         default:
+            return false;
+         }
+      }
+
+      // -- True if `v` is a token that triggers coagulation when it
+      // ends the current line.
+      bool coagulate_trailing(TokenValue v) {
+         return is_infix(v)
+            or v == TokenValue::Comma
+            or v == TokenValue::Semicolon;
+      }
+
+      // -- True if `v` is a token that triggers coagulation when it
+      // starts the next line.
+      bool coagulate_leading(TokenValue v) {
+         return v == TokenValue::Then
+            or v == TokenValue::Else;
+      }
+
+      // -- Make a synthetic formatting token at a given position.
+      Token make_formatting(TokenValue v, FragmentCursor pos) {
+         Token t { };
+         t.start = pos;
+         t.end = pos;
+         t.category = TokenCategory::Formatting;
+         t.value = v;
+         return t;
+      }
+
+      // -- True if `v` opens a grouping delimiter.
+      bool is_open_delimiter(TokenValue v) {
+         switch (v) {
+         case TokenValue::OpenParen:
+         case TokenValue::OpenBracket:
+         case TokenValue::OpenBrace:
+         case TokenValue::OpenMetaParen:
+         case TokenValue::OpenMetaBracket:
+         case TokenValue::OpenMetaBrace:
+            return true;
+         default:
+            return false;
+         }
+      }
+
+      // -- True if `v` closes a grouping delimiter.
+      bool is_close_delimiter(TokenValue v) {
+         switch (v) {
+         case TokenValue::CloseParen:
+         case TokenValue::CloseBracket:
+         case TokenValue::CloseBrace:
+         case TokenValue::CloseMetaParen:
+         case TokenValue::CloseMetaBracket:
+         case TokenValue::CloseMetaBrace:
+            return true;
+         default:
+            return false;
+         }
+      }
+
+      // -- Step 1 & 2: strip whitespace and formatting tokens, keep
+      //    comments (wisecracks and descriptions attach to definitions),
+      //    and group remaining tokens by source line.
+      //    Inside balanced grouping delimiters (parens, brackets,
+      //    braces), all tokens belong to the same logical line
+      //    regardless of source line breaks - mirroring the
+      //    tokenizer's group_depth suppression of formatting tokens.
+      std::vector<PileLine> group_into_lines(const std::vector<Token>& raw) {
+         std::vector<PileLine> lines;
+         PileLine current;
+         int group_depth = 0;
+         for (auto& t : raw) {
+            if (t.category == TokenCategory::Whitespace
+                or t.category == TokenCategory::Formatting)
+               continue;
+            // -- Only split on line boundaries when outside delimiters.
+            if (group_depth == 0
+                and not current.empty()
+                and t.start.line != current.tokens.back().start.line) {
+               lines.push_back(std::move(current));
+               current = PileLine{};
+            }
+            current.tokens.push_back(t);
+            if (is_open_delimiter(t.value))
+               ++group_depth;
+            else if (is_close_delimiter(t.value) and group_depth > 0)
+               --group_depth;
+         }
+         if (not current.empty())
+            lines.push_back(std::move(current));
+         return lines;
+      }
+
+      // -- Steps 3-5: pile tree building with coagulation.
+      //
+      //  This faithfully mirrors pile.boot's algorithm:
+      //    - pile_tree / eq_pile_tree: find sub-trees by column
+      //    - pile_forest: collect a forest of sibling sub-piles
+      //    - pile_forests: process head + merge children
+      //    - pile_cforest: format a forest (coagulate, then wrap)
+      //    - pile_coagulate: merge adjacent sub-piles per SHOEINF
+      //
+      //  Coagulation happens during forest emission (not before
+      //  pile tree building), matching pile.boot's shoePileCforest.
+      //  Single children are NOT wrapped with Indent/Unindent,
+      //  matching pile.boot's "rest x = nil => first x" check.
+
+      // -- Result of pile_tree / eq_pile_tree / pile_forests.
+      struct PileTreeResult {
+         bool found;
+         std::vector<Token> tree;
+         std::size_t next;
+      };
+
+      // -- Result of pile_forest.
+      struct ForestResult {
+         std::vector<std::vector<Token>> children;
+         std::size_t next;
+      };
+
+      // -- Forward declaration for mutual recursion.
+      PileTreeResult pile_forests(const std::vector<PileLine>& lines,
+                                  std::size_t pos, int n);
+
+      // -- pile_tree: consume one sub-tree at column > n.
+      // Mirrors shoePileTree(n, s) from pile.boot.
+      PileTreeResult pile_tree(const std::vector<PileLine>& lines,
+                               std::size_t pos, int n) {
+         if (pos >= lines.size())
+            return { false, {}, pos };
+         if (static_cast<int>(lines[pos].column()) <= n)
+            return { false, {}, pos };
+         return pile_forests(lines, pos,
+                             static_cast<int>(lines[pos].column()));
+      }
+
+      // -- eq_pile_tree: consume one sub-tree at column == n.
+      // Mirrors eqshoePileTree(n, s) from pile.boot.
+      PileTreeResult eq_pile_tree(const std::vector<PileLine>& lines,
+                                  std::size_t pos, int n) {
+         if (pos >= lines.size())
+            return { false, {}, pos };
+         if (static_cast<int>(lines[pos].column()) != n)
+            return { false, {}, pos };
+         return pile_forests(lines, pos,
+                             static_cast<int>(lines[pos].column()));
+      }
+
+      // -- pile_forest: collect a forest of sibling sub-piles.
+      // Mirrors shoePileForest + shoePileForest1 from pile.boot.
+      ForestResult pile_forest(const std::vector<PileLine>& lines,
+                               std::size_t pos, int n) {
+         auto first = pile_tree(lines, pos, n);
+         if (not first.found)
+            return { {}, pos };
+
+         // -- Column of the first child - siblings must match this.
+         int child_col = static_cast<int>(lines[pos].column());
+
+         std::vector<std::vector<Token>> forest;
+         forest.push_back(std::move(first.tree));
+         auto next = first.next;
+
+         // -- Collect remaining siblings at column == child_col.
+         while (next < lines.size()) {
+            auto sib = eq_pile_tree(lines, next, child_col);
+            if (not sib.found)
+               break;
+            forest.push_back(std::move(sib.tree));
+            next = sib.next;
+         }
+
+         return { std::move(forest), next };
+      }
+
+      // -- Helpers for sub-pile token inspection --
+
+      // -- First non-comment, non-formatting token value.
+      TokenValue first_content_value(const std::vector<Token>& tokens) {
+         for (auto& t : tokens)
+            if (t.category != TokenCategory::Comment
+                and t.category != TokenCategory::Formatting)
+               return t.value;
+         return TokenValue::EndOfStream;
+      }
+
+      // -- Last non-comment, non-formatting token value.
+      TokenValue last_content_value(const std::vector<Token>& tokens) {
+         for (auto it = tokens.rbegin(); it != tokens.rend(); ++it)
+            if (it->category != TokenCategory::Comment
+                and it->category != TokenCategory::Formatting)
+               return it->value;
+         return TokenValue::EndOfStream;
+      }
+
+      // -- True if a sub-pile consists entirely of descriptions (++).
+      bool description_only_pile_p(const std::vector<Token>& pile) {
+         for (auto& t : pile)
+            if (t.category != TokenCategory::Formatting
+                and t.value != TokenValue::Commentary)
+               return false;
+         return not pile.empty();
+      }
+
+      // -- pile_coagulate: merge adjacent sub-piles.
+      // Mirrors shoePileCoagulate from pile.boot.
+      // Merges when:
+      //   - next sub-pile starts with THEN or ELSE, or
+      //   - current sub-pile ends with infix / comma / semicolon.
+      // Description-only sub-piles are never merged.
+      std::vector<std::vector<Token>> pile_coagulate(
+            std::vector<std::vector<Token>> forest) {
+         if (forest.size() <= 1)
+            return forest;
+         std::vector<std::vector<Token>> result;
+         result.push_back(std::move(forest[0]));
+         for (std::size_t i = 1; i < forest.size(); ++i) {
+            auto& prev = result.back();
+            if (not description_only_pile_p(prev)
+                and not description_only_pile_p(forest[i])
+                and (coagulate_leading(first_content_value(forest[i]))
+                     or coagulate_trailing(last_content_value(prev)))) {
+               for (auto& t : forest[i])
+                  prev.push_back(std::move(t));
+            } else {
+               result.push_back(std::move(forest[i]));
+            }
+         }
+         return result;
+      }
+
+      // -- separate_piles: insert Justify (BACKSET) between sub-piles.
+      // Mirrors shoeSeparatePiles from pile.boot.
+      std::vector<Token> separate_piles(
+            const std::vector<std::vector<Token>>& piles) {
+         std::vector<Token> result;
+         for (std::size_t i = 0; i < piles.size(); ++i) {
+            if (i > 0) {
+               // -- Justify position at last token of preceding pile,
+               // matching shoeLastTokPosn in shoeSeparatePiles.
+               auto pos = piles[i - 1].back().start;
+               result.push_back(make_formatting(TokenValue::Justify, pos));
+            }
+            for (auto& t : piles[i])
+               result.push_back(t);
+         }
+         return result;
+      }
+
+      // -- en_pile: wrap with Indent/Unindent.
+      // Mirrors shoeEnPile from pile.boot.
+      std::vector<Token> en_pile(std::vector<Token> tokens) {
+         if (tokens.empty())
+            return {};
+         auto indent_pos = tokens.front().start;
+         auto unindent_pos = tokens.back().start;
+         std::vector<Token> result;
+         result.reserve(tokens.size() + 2);
+         result.push_back(make_formatting(TokenValue::Indent, indent_pos));
+         for (auto& t : tokens)
+            result.push_back(std::move(t));
+         result.push_back(make_formatting(TokenValue::Unindent, unindent_pos));
+         return result;
+      }
+
+      // -- pile_cforest: process a forest of sub-piles.
+      // Mirrors shoePileCforest from pile.boot:
+      //   0 children > empty
+      //   1 child > just the child (no wrapping)
+      //   2+ children > coagulate, then:
+      //     1 after coag > just the result (no wrapping)
+      //     2+ after coag > wrap with Indent + Justify + Unindent
+      std::vector<Token> pile_cforest(
+            std::vector<std::vector<Token>> forest) {
+         if (forest.empty())
+            return {};
+         if (forest.size() == 1)
+            return std::move(forest[0]);
+
+         auto coagulated = pile_coagulate(std::move(forest));
+         if (coagulated.size() == 1)
+            return std::move(coagulated[0]);
+
+         return en_pile(separate_piles(coagulated));
+      }
+
+      // -- pile_forests: process head line + merge children.
+      // Mirrors shoePileForests from pile.boot:
+      //   1. Collect children via pile_forest
+      //   2. If no children, return head as-is
+      //   3. Process children with pile_cforest (coagulate + wrap)
+      //   4. Append processed children to head
+      //   5. Loop (in pile.boot this is tail-recursive; here it's
+      //      a loop - the second iteration always finds no more
+      //      children since pile_forest already consumed them all).
+      PileTreeResult pile_forests(const std::vector<PileLine>& lines,
+                                  std::size_t pos, int n) {
+         // -- Start with head line's tokens.
+         std::vector<Token> head(lines[pos].tokens.begin(),
+                                 lines[pos].tokens.end());
+         auto next = pos + 1;
+
+         for (;;) {
+            auto [children, child_next] = pile_forest(lines, next, n);
+            if (children.empty())
+               return { true, std::move(head), next };
+
+            // -- shoePileCtree: append processed forest to head.
+            auto processed = pile_cforest(std::move(children));
+            head.insert(head.end(), processed.begin(), processed.end());
+            next = child_next;
+         }
+      }
+   } // anonymous namespace
+
+   std::vector<Token> pile(const std::vector<Token>& raw) {
+      // -- Step 1-2: strip formatting and group into lines.
+      auto lines = group_into_lines(raw);
+      if (lines.empty())
+         return {};
+
+      // -- Steps 3-5: build pile tree and emit.
+      // Coagulation happens inside pile_cforest, not here.
+      std::vector<Token> out;
+      std::size_t pos = 0;
+      while (pos < lines.size()) {
+         auto result = pile_tree(lines, pos, -1);
+         if (result.found) {
+            for (auto& t : result.tree)
+               out.push_back(std::move(t));
+            pos = result.next;
+         } else {
+            // -- Safety fallback (column > -1 is always true for
+            // real columns, so this shouldn't happen).
+            for (auto& t : lines[pos].tokens)
+               out.push_back(t);
+            ++pos;
+         }
+      }
+      return out;
    }
 }

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -249,7 +249,7 @@ build_rts_options(Command* command, Driver driver)
    }
 }
 
-// Return a description of the driver to invokve by default.
+// -- Return a description of the driver to invokve by default.
 static Driver default_driver(bool explicit_no_gui) {
    if (OPENAXIOM_USE_SMAN)
       return Driver::sman;
@@ -310,7 +310,7 @@ static void print_usage(void) {
    print_line("Submit bug report to " PACKAGE_BUGREPORT);
 }
 
-   // Map a option to the driver that implement that action.
+   // -- Map a option to the driver that implement that action.
    struct DriverMap {
       const char* action;
       const Driver driver;
@@ -325,7 +325,7 @@ static void print_usage(void) {
       { "--make", Driver::linker },
    };
 
-   // Obtain the driver that implement a specific action requested
+   // -- Obtain the driver that implement a specific action requested
    // on command line.
    static Driver
    option_driver(const char* opt) {
@@ -381,7 +381,7 @@ preprocess_arguments(Command* command, int argc, char** argv)
          else {
             /* Maybe option for the driver.  */
 	    if (argv[i][0] == '-') {
-               // this is awkward to handle here since it supposed
+               // -- this is awkward to handle here since it supposed
                // to go to Superman.  FIXME when sman is gone.
                if (strcmp(argv[i], "--no-gui") == 0)
                   explicit_no_gui = true;
@@ -437,7 +437,7 @@ preprocess_arguments(Command* command, int argc, char** argv)
    return driver;
 }
 
-   // Return a pointer to the path to the program to execute, as
+   // -- Return a pointer to the path to the program to execute, as
    // specified by `command' and `driver'.
    static const char*
    executable_path(const Command* command, Driver driver) {
@@ -446,7 +446,7 @@ preprocess_arguments(Command* command, int argc, char** argv)
          : make_path_for(command->root_dir, driver);
    }
 
-   // Return the total number of command-line arguments.
+   // -- Return the total number of command-line arguments.
    static int
    args_count(const Command* cmd) {
       return cmd->core.argc > 1

--- a/src/utils/hammer.cc
+++ b/src/utils/hammer.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2013, Gabriel Dos Reis.
+// -- Copyright (C) 2013, Gabriel Dos Reis.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -49,9 +49,10 @@
 #include <vector>
 #include <map>
 #include <open-axiom/storage>
+#include <open-axiom/Charset>
 #include <open-axiom/FileMapping>
 
-// Workaround lack of standard streaming operation for std::u8string.
+// -- Workaround lack of standard streaming operation for std::u8string.
 static std::ostream& print(std::ostream& os, const std::u8string& s)
 {
    constexpr auto cast = [](auto p) { return reinterpret_cast<const char*>(&*p); };
@@ -60,43 +61,35 @@ static std::ostream& print(std::ostream& os, const std::u8string& s)
 }
 
 namespace OpenAxiom::Hammer {
-   // -------------
    // -- Element --
-   // -------------
    // Base class of document elements.
    struct Element {
       virtual ~Element() = default;
    };
 
-   // ---------------
    // -- BasicText --
-   // ---------------
    // Plain text, with no reference to any chunk.  
    struct BasicText : Element {
       BasicText(const char8_t* f, const char8_t* l) : span(f, l) { }
-      // Pointer to the start of this basic text element
+      // -- Pointer to the start of this basic text element
       const char8_t* begin() const { return span.first; }
-      // One-past-the-end of the this basic text element.
+      // -- One-past-the-end of the this basic text element.
       const char8_t* end() const { return span.second; }
    private:
       std::pair<const char8_t*, const char8_t*> span;
    };
 
-   // ---------------
    // -- Reference --
-   // ---------------
    // Reference to a a chunk by name.
    struct Reference : Element {
       explicit Reference(const std::u8string& s) : label(s) { }
-      // Naame of the chunk referenced.
+      // -- Naame of the chunk referenced.
       const std::u8string& name() const { return label; }
    private:
       const std::u8string label;
    };
 
-   // -------------------
    // -- CompositeText --
-   // -------------------
    // Sequence of basic elements and reference to chunks.
    struct CompositeText: private std::vector<const Element*> {
       typedef std::vector<const Element*> base;
@@ -106,7 +99,7 @@ namespace OpenAxiom::Hammer {
       using base::size;
       using base::operator[];
 
-      // Augment this chunk with a basic text in the open interval
+      // -- Augment this chunk with a basic text in the open interval
       // [f,l).
       CompositeText& add_text(const char8_t* f, const char8_t* l) {
          texts.push_back(BasicText(f, l));
@@ -114,7 +107,7 @@ namespace OpenAxiom::Hammer {
          return *this;
       }
 
-      // Augment this chunk with a reference to another chunk
+      // -- Augment this chunk with a reference to another chunk
       // named `n'.  Note that we don't attempt to check for
       // possible circularities.
       CompositeText reference_chunk(const char8_t* f, const char8_t* l) {
@@ -128,9 +121,7 @@ namespace OpenAxiom::Hammer {
       std::list<Reference> refs;
    };
 
-   // --------------
    // -- Document --
-   // --------------
    // A whole document; a sequence of chunks.
    struct Document : std::list<CompositeText> {
       Document(const Memory::FileMapping& file)
@@ -140,7 +131,7 @@ namespace OpenAxiom::Hammer {
          parse(file);
       }
 
-      // Return a pointer to a document chunk name `n'.
+      // -- Return a pointer to a document chunk name `n'.
       // Otherwise, return null.
       CompositeText* lookup_chunk(const std::u8string& n) const {
          ChunkTable::const_iterator i = defs.find(n);
@@ -154,7 +145,7 @@ namespace OpenAxiom::Hammer {
       CompositeText* active_chunk; // chunk under construction.
       const char8_t* text_start;      // begining of current basic text.
 
-      // Append basic text in the range `[text_start,last)'
+      // -- Append basic text in the range `[text_start,last)'
       // to the current chunk.
       void finish_chunk(const char8_t* last) {
          if (text_start != last)
@@ -163,7 +154,7 @@ namespace OpenAxiom::Hammer {
          text_start = last;
       }
 
-      // Start a new chunk or extend an existing chunk.
+      // -- Start a new chunk or extend an existing chunk.
       void begin_chunk(const std::u8string& name, const char8_t* start) {
          if (CompositeText* chunk = lookup_chunk(name))
             active_chunk = chunk;
@@ -174,17 +165,17 @@ namespace OpenAxiom::Hammer {
          text_start = start;
       }
 
-      // Parse a file mapping into this document.
+      // -- Parse a file mapping into this document.
       void parse(const Memory::FileMapping&);
    };
 
-   // Return true if the character `c' introduces a newline.
+   // -- Return true if the character `c' introduces a newline.
    static inline bool
    looking_at_newline(char8_t c) {
       return c == u8'\n' or c == u8'\r';
    }
 
-   // Attempt to advance the cursor past newline marker.
+   // -- Attempt to advance the cursor past newline marker.
    // Return true on sucess.
    static bool
    saw_newline(const char8_t*& cur, const char8_t* end) {
@@ -200,17 +191,17 @@ namespace OpenAxiom::Hammer {
       return false;
    }
 
-   // Move `cur' to end of line or `end', whichever comes first.
+   // -- Move `cur' to end of line or `end', whichever comes first.
    // Return true if the area swept consisted only of blank characters.
    static inline bool
    trailing_blank(const char8_t*& cur, const char8_t* end) {
       bool result = true;
       for (; cur < end and not saw_newline(cur, end); ++cur)
-         result = isspace(*cur);
+         result = ascii_space(*cur);
       return result;
    }
 
-   // Attempt to advance `cur' past the double left angle brackets
+   // -- Attempt to advance `cur' past the double left angle brackets
    // starting a chunk name.  Returm true on success.
    static bool
    chunk_name_began(const char8_t*& cur, const char8_t* end) {
@@ -221,7 +212,7 @@ namespace OpenAxiom::Hammer {
       return false;
    }
 
-   // Attempt to move `cur' past the double right angle brackets
+   // -- Attempt to move `cur' past the double right angle brackets
    // terminating a chunk name.  Returm true on success.
    static bool
    chunk_name_ended(const char8_t*& cur, const char8_t* end) {
@@ -232,7 +223,7 @@ namespace OpenAxiom::Hammer {
       return false;
    }
 
-   // We've just seen the start of a chunk reference; skip
+   // -- We've just seen the start of a chunk reference; skip
    // characters till we seen of the chunk's name.
    static void
    skip_to_end_of_chunk_name(const char8_t*& cur, const char8_t* end) {
@@ -244,7 +235,7 @@ namespace OpenAxiom::Hammer {
       }
    }
 
-   // Move the cursor until end of line.
+   // -- Move the cursor until end of line.
    static void
    skip_to_end_of_line(const char8_t*& cur, const char8_t* end) {
       while (cur < end) {
@@ -258,15 +249,15 @@ namespace OpenAxiom::Hammer {
    Document::parse(const Memory::FileMapping& file) {
       auto cur = text_start;
       auto last = reinterpret_cast<const char8_t*>(file.end());
-      // Process one line at a time.
+      // -- Process one line at a time.
       while (cur < last) {
-         // 1. `@' ends previous chunk
+         // -- 1. `@' ends previous chunk
          if (*cur == u8'@') {
             auto p = cur;
             if (trailing_blank(++cur, last))
                finish_chunk(p);
          }
-         // 2. `<<' introduces a chunk reference or a chunk definition.
+         // -- 2. `<<' introduces a chunk reference or a chunk definition.
          else if (chunk_name_began(cur, last)) {
             auto label_start = cur;
             skip_to_end_of_chunk_name(cur, last);
@@ -274,13 +265,13 @@ namespace OpenAxiom::Hammer {
                auto label_end = cur - 2;
                if (cur < last and *cur == u8'=') {
                   if (trailing_blank(++cur, last)) {
-                     // chunk definition or extension
+                     // -- chunk definition or extension
                      finish_chunk(label_start - 2);
                      begin_chunk(std::u8string(label_start, label_end), cur);
                   }
                }
                else if (trailing_blank(cur, last)) {
-                  // This is just a reference to a chunk.
+                  // -- This is just a reference to a chunk.
                   active_chunk->add_text(text_start, label_start - 2);
                   active_chunk->reference_chunk(label_start, label_end);
                   text_start = cur;
@@ -295,7 +286,7 @@ namespace OpenAxiom::Hammer {
       finish_chunk(cur);
    }
 
-   // Capture  chunk resolution in a document.
+   // -- Capture  chunk resolution in a document.
    struct resolve_chunk {
       resolve_chunk(const std::u8string& s, const Document& f)
             : name(s), doc(f) { }
@@ -303,10 +294,10 @@ namespace OpenAxiom::Hammer {
       const Document& doc;    // document containing the chunk.
    };
 
-   // Print the resolution of a chunk name onto an output stream.
+   // -- Print the resolution of a chunk name onto an output stream.
    std::ostream&
    operator<<(std::ostream& os, const resolve_chunk& rc) {
-      // FIXME: no attempt at detecting circularities.
+      // -- FIXME: no attempt at detecting circularities.
       const CompositeText* doc = rc.doc.lookup_chunk(rc.name);
       if (doc == 0) {
          print(std::cerr << "chunk ", rc.name) << " is undefined" << std::endl;
@@ -328,13 +319,13 @@ namespace OpenAxiom::Hammer {
       return os;
    }
 
-   // Return true if the `arg' is the option named`opt'.
+   // -- Return true if the `arg' is the option named`opt'.
    static inline bool
    is_option(const char* arg, const char* opt) {
       return strcmp(arg, opt) == 0;
    }
 
-   // `arg' is a argument on the command line.  If `arg'
+   // -- `arg' is a argument on the command line.  If `arg'
    // does not match option name `opt', return null.  Otherwise,
    // return a pointer to the terminating NUL character if there
    // is no specified value for that option, or a pointer to the
@@ -343,7 +334,7 @@ namespace OpenAxiom::Hammer {
    is_named_arg(const char* arg, const char* opt) {
       const int n = strlen(opt);
       int i = 0;
-      // Get out if argion name does not match.
+      // -- Get out if argion name does not match.
       // Note:  Ideally, we could use strncmp().  However, that
       // function is not available in C++98, so we cannot depend on it.
       for (; i < n ; ++i)
@@ -364,7 +355,7 @@ main(int argc, char* argv[]) {
    const char* chunk = nullptr;      // chunck to tangle
    const char* output_path = nullptr; // path to the output file
    const char* input_path = nullptr;  // path to the input file.
-   // 1. Process command line arguments.
+   // -- 1. Process command line arguments.
    for (int pos = 1; error_count == 0 and pos < argc; ++pos) {
       if (const char* val = is_named_arg(argv[pos], "--tangle")) {
          if (chunk != 0) {
@@ -394,7 +385,7 @@ main(int argc, char* argv[]) {
          input_path = argv[pos];
    }
 
-   // 2. Basic sanity check.
+   // -- 2. Basic sanity check.
    if (input_path == 0) {
       std::cerr << "missing input file" << std::endl;
       return 1;
@@ -411,7 +402,7 @@ main(int argc, char* argv[]) {
    if (error_count != 0)
       return 1;
 
-   // 3. Attempt to extract the chunk.
+   // -- 3. Attempt to extract the chunk.
    try {
       OpenAxiom::Memory::FileMapping file(input_path);
       std::ofstream os(output_path);

--- a/src/utils/storage.cxx
+++ b/src/utils/storage.cxx
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2022, Gabriel Dos Reis.
+// -- Copyright (C) 2010-2022, Gabriel Dos Reis.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -57,9 +57,7 @@
 #include <string.h>
 
 namespace OpenAxiom {
-   // ----------------
    // -- SystemError --
-   // ----------------
    SystemError::SystemError(const std::string& s) : text(s) { }
 
    SystemError::~SystemError() { }
@@ -75,7 +73,7 @@ namespace OpenAxiom {
    }
 
    namespace Memory {
-      // Return storage page allocation unit in byte count.
+      // -- Return storage page allocation unit in byte count.
       size_t page_size() {
 #if defined(_WIN32)
          SYSTEM_INFO si = { };
@@ -84,12 +82,12 @@ namespace OpenAxiom {
 #elif defined(HAVE_UNISTD_H)
          return sysconf(_SC_PAGESIZE);
 #else
-         // Well, we have to return a number.
+         // -- Well, we have to return a number.
          return 4096;
 #endif         
       }
 
-      // Subroutine of os_acquire_raw_memory.  Attempt to acquire
+      // -- Subroutine of os_acquire_raw_memory.  Attempt to acquire
       // storage from the host OS.  Return null on failure.
       static inline Pointer
       os_allocate_read_write_raw_memory(size_t nbytes) {
@@ -125,9 +123,7 @@ namespace OpenAxiom {
 #endif            
       }
 
-      // -------------
       // -- Storage --
-      // -------------
       struct Storage::Handle {
          size_t extent;         // count of allocated bytes
          void* start;           // beginning of usable address.
@@ -138,7 +134,7 @@ namespace OpenAxiom {
          return Storage::byte_address(h) + h->extent;
       }
 
-      // Acquire storage chunk of at least `n' bytes.
+      // -- Acquire storage chunk of at least `n' bytes.
       // The result is a pointer to a storage object.  That object
       // `result' is constructed such that `begin(result)' points
       // to the next allocatable address.
@@ -162,9 +158,7 @@ namespace OpenAxiom {
          return h->start;
       }
 
-      // -------------------------
       // -- SinglyLinkedStorage --
-      // -------------------------
       struct OneWayLinkHeader : Storage::Handle {
          Handle* previous;
       };
@@ -174,9 +168,7 @@ namespace OpenAxiom {
          return static_cast<OneWayLinkHeader*>(h)->previous;
       }
 
-      // -------------------------
       // -- DoublyLinkedStorage --
-      // -------------------------
       struct TwoWayLinkHeader : Storage::Handle {
          Handle* previous;
          Handle* next;
@@ -199,7 +191,7 @@ namespace OpenAxiom {
 
       DoublyLinkedStorage::Handle*
       DoublyLinkedStorage::acquire(size_t n, size_t a) {
-         // Add enough padding space for specified alignment.
+         // -- Add enough padding space for specified alignment.
          const size_t overhead = round_up(sizeof (TwoWayLinkHeader), a);
          TwoWayLinkHeader* h =
             acquire_storage_with_header<TwoWayLinkHeader>(overhead + n);
@@ -209,9 +201,7 @@ namespace OpenAxiom {
          return h;
       }
 
-      // ------------------
       // -- BlockStorage --
-      // ------------------
       struct BlockHeader : OneWayLinkHeader {
          Byte* available;
       };
@@ -226,9 +216,9 @@ namespace OpenAxiom {
          const size_t overhead = round_up(sizeof (BlockHeader), a);
          BlockHeader* h =
             acquire_storage_with_header<BlockHeader>(overhead + n);
-         // Remember the next available address to allocate from.
+         // -- Remember the next available address to allocate from.
          h->available = byte_address(h) + overhead;
-         // That is also where the actual object storage starts.
+         // -- That is also where the actual object storage starts.
          h->start = h->available;
          h->previous = nullptr;
          return h;
@@ -252,10 +242,8 @@ namespace OpenAxiom {
          return p;
       }
 
-      // -----------------
       // -- FileMapping --
-      // -----------------
-      FileMapping::FileMapping(std::string path)
+      FileMapping::FileMapping(const std::string& path)
       {
 #if defined(_WIN32)
          HANDLE file = CreateFile(path.c_str(), GENERIC_READ, 
@@ -273,7 +261,7 @@ namespace OpenAxiom {
          HANDLE mapping = CreateFileMapping(file, 0, PAGE_READONLY, 0, 0, 0);
          if (mapping == 0)
             filesystem_error("could not map file " + path);
-         start = static_cast<Byte*>(MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0));
+         start = static_cast<std::byte*>(MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0));
          CloseHandle(mapping);
          CloseHandle(file);
 #elif defined(HAVE_SYS_STAT_H) && defined(HAVE_SYS_MMAN_H) && defined(HAVE_FCNTL_H)
@@ -292,9 +280,9 @@ namespace OpenAxiom {
             close(fd);
             return;
          }
-         start = static_cast<Byte*>(mmap(Pointer(), s.st_size, PROT_READ, MAP_SHARED, fd, 0));
+         start = static_cast<std::byte*>(mmap(Pointer(), s.st_size, PROT_READ, MAP_SHARED, fd, 0));
          close(fd);
-         if (start == MAP_FAILED)
+         if (start == static_cast<std::byte*>(MAP_FAILED))
             filesystem_error("could not map file " + path);
 #else
 #  error "Don't know how to map a file on this platform"         
@@ -302,12 +290,14 @@ namespace OpenAxiom {
       }
 
       FileMapping::FileMapping(FileMapping&& f)
-            : start(f.start), extent(f.extent) {
+            : start{ f.start }, extent{ f.extent }
+      {
          f.start = nullptr;
          f.extent = 0;
       }
 
-      FileMapping::~FileMapping() {
+      FileMapping::~FileMapping()
+      {
          if (start != nullptr) {
 #if defined(_WIN32)
             UnmapViewOfFile(start);

--- a/src/utils/string-pool.cc
+++ b/src/utils/string-pool.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2011, Gabriel Dos Reis.
+// -- Copyright (C) 2010-2011, Gabriel Dos Reis.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,15 +31,13 @@
 
 // --% Author: Gabriel Dos Reis
 
-#include <string.h>
+#include <cstring>
 #include <open-axiom/string-pool>
 
 namespace OpenAxiom {
-   // ----------------
    // -- StringItem --
-   // ----------------
    bool
-   StringItem::equal(const Byte* str, size_t sz) const {
+   StringItem::equal(const char8_t* str, size_t sz) const {
       if (length != sz)
          return false;
       for (size_t i = 0; i < sz; ++i)
@@ -49,34 +47,32 @@ namespace OpenAxiom {
    }
 
 
-   // ----------------
    // -- StringPool --
-   // ----------------
    StringPool::StringPool()
          : BasicHashTable<StringItem>(109),
            strings(2 * Memory::page_size())
    { }
 
-   // Return a hash for the string starting from `str'
+   // -- Return a hash for the string starting from `str'
    // of length `sz'.
    static size_t
-   hash(const Byte* str, size_t sz) {
+   hash(const char8_t* str, size_t sz) {
       size_t h = 0;
       for(size_t i = 0; i < sz; ++i)
          h = str[i] + (h << 6) + (h << 16) - h;
       return h;
    }
 
-   const Byte*
-   StringPool::make_copy(const Byte* f, size_t sz) {
-      Byte* s = strings.allocate(sz + 1);
-      memcpy(s, f, sz);
-      s[sz] = '\0';
+   const char8_t*
+   StringPool::make_copy(const char8_t* f, size_t sz) {
+      char8_t* s = strings.allocate(sz + 1);
+      std::memcpy(s, f, sz);
+      s[sz] = u8'\0';
       return s;
    }
    
    StringPool::EntryType*
-   StringPool::intern(const Byte* src, size_t sz) {
+   StringPool::intern(const char8_t* src, size_t sz) {
       const size_t h = hash(src, sz);
       EntryType* e = hash_chain(h);
       if (sz == 0)
@@ -84,7 +80,7 @@ namespace OpenAxiom {
       for (; e->text != 0; e = e->chain) {
          if (e->hash == h and e->equal(src, sz))
             return e;
-         // If this is the last entry in this hash chain, allocate
+         // -- If this is the last entry in this hash chain, allocate
          // a new bucket to hold the information we want to store.
          if (e->chain == 0)
             e->chain = new_bucket();
@@ -97,6 +93,6 @@ namespace OpenAxiom {
 
    StringPool::EntryType*
    StringPool::intern(const char* s) {
-      return intern(reinterpret_cast<const Byte*>(s), strlen(s));
+      return intern(reinterpret_cast<const char8_t*>(s), std::strlen(s));
    }
 }


### PR DESCRIPTION
Migrate the entire Boot/Spad pipeline to char8_t and C++20.

## Summary

- **char8_t migration** across all headers and source files
- **Tagged-pointer Lisp value infrastructure**: `LispValue` header with `enum class Value : uint64_t`, Arena allocator, printer, condition evaluator
- **Boot-to-Lisp translator** with CST-to-AST lowering (`BootAst`, `BootTranslator`, `boot-ast.cxx`, `boot-translator.cxx`)
- **S-expression printer** using shared bar-quoting from `Charset`
- **Locale-independent ASCII classification**: `ascii_printable`, `needs_bar_quoting`, `print_bar_quoted`
- **Lisp value utilities**: `for_each(Value, Fn)` list traversal, `operator<<(ostream&, Value)`
- **UTF-8 output**: `operator<<(ostream&, u8string_view)`

## Cleanup and hardening

- **Predicate naming**: Lisp-convention suffixes (`symbolp`, `keywordp`, `dollar_prefixed`, `exit_cond_p`, `dynamic_var_p`, `description_only_p`, etc.)
- **Comment style**: `// -- ` prefix for description comments, no box banners
- **Hardening**: specific `catch` clauses (no `catch(...)`), `const std::string&` for `FileMapping` constructor, removed unused `#include <optional>`
- **CI**: GCC+CCL workflow changed to nightly schedule

## Testing

- Boot: 0/114 parse failures
- Spad: 0/1074 parse failures (includes cherry-picked OCT.spad fix from upstream commit 788f42e9)
- Full clean build with MSVC 2026 / C++20