### PR TITLE
Windows CRLF fix, replace KEYWORD:: with bfInert, and build improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Database files are binary; do not perform CRLF conversion or text diffs.
+*.daase binary

--- a/cmake/OpenAxiomScanAlgebra.cmake
+++ b/cmake/OpenAxiomScanAlgebra.cmake
@@ -116,6 +116,7 @@ function(oa_scan_algebra_sources srcdir)
   set(_pamphlet_bases "")
   set(_plain_bases "")
 
+  message(STATUS "Algebra: reading source manifest...")
   foreach(_entry ${_entries})
     # Skip comments and blank lines.
     string(STRIP "${_entry}" _entry)
@@ -191,6 +192,8 @@ function(oa_scan_algebra_sources srcdir)
 
   set(_all_ctors "")
 
+  list(LENGTH _pamphlet_bases _npam_tmp)
+  message(STATUS "Algebra: scanning ${_npam_tmp} pamphlets for constructors...")
   foreach(_base ${_pamphlet_bases})
     set(_pam "${srcdir}/${_base}.spad.pamphlet")
     file(STRINGS "${_pam}" _lines

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1165,7 +1165,7 @@ oa_scan_algebra_sources("${oa_algebra_srcdir}")
 # -- Build the catch-all layer for unassigned constructors -----------------
 # Must be called after oa_scan_algebra_sources() so that OA_ALGEBRA_CONSTRUCTORS
 # is populated.  See OpenAxiomAlgebraLayers.cmake for the catch-all strategy.
-
+message(STATUS "Algebra: assigning constructors to compilation layers...")
 oa_algebra_build_catchall()
 
 # -- Paths for initdb (needed by oa_spad_compile_prefix) -------------------
@@ -1603,7 +1603,7 @@ add_custom_target(all-algebra-layers
 # Autotools equivalent: all-algebra
 # Umbrella target for the entire algebra substrate.  Depends on
 # all-algebra-layers and (eventually) all-share and all-hyper-pre.
-add_custom_target(all-algebra
+add_custom_target(all-algebra ALL
   DEPENDS all-algebra-layers
   COMMENT "Build the complete OpenAxiom algebra (bootstrap + all layers)"
 )

--- a/src/boot/ast.boot
+++ b/src/boot/ast.boot
@@ -174,7 +174,7 @@ bfColon x==
 
 bfColonColon: (%Symbol,%Symbol) -> %Symbol
 bfColonColon(package, name) == 
-  %hasFeature KEYWORD::CLISP and package in '(EXT FFI) =>
+  %hasFeature bfInert '"CLISP" and package in '(EXT FFI) =>
     symbolBinding(symbolName name,package)
   makeSymbol(symbolName name, package)
 
@@ -1137,7 +1137,7 @@ shoeCompTran1(x,fluidVars,locVars,dollarVars) ==
       elts isnt [.,:.] =>
         elts := shoeCompTran1(elts,fluidVars,locVars,dollarVars)
         x.op := 'MAKE_-ARRAY
-        x.args := [['LIST_-LENGTH,elts],KEYWORD::INITIAL_-CONTENTS,elts]
+        x.args := [['LIST_-LENGTH,elts],bfInert '"INITIAL-CONTENTS",elts]
       x.op := 'COERCE
       x.args := [shoeCompTran1(elts,fluidVars,locVars,dollarVars),quote 'VECTOR]
     x
@@ -1279,7 +1279,7 @@ bfCompHash(tu,op,argl,body) ==
   bfTuple [computeFunction,:bfMain(tu,auxfn,op)]
  
 shoeCompileTimeEvaluation x ==
-  ["EVAL-WHEN", [KEYWORD::COMPILE_-TOPLEVEL], x]
+  ["EVAL-WHEN", [bfInert '"COMPILE-TOPLEVEL"], x]
 
 bfMain(tu,auxfn,op)==
   g1 := bfGenSymbol tu
@@ -1395,7 +1395,7 @@ bfHandlers(n,e,hs) == main(n,e,hs,nil) where
     hs = nil =>
       ["COND",
         :reverse!
-          [[true,["THROW",KEYWORD::OPEN_-AXIOM_-CATCH_-POINT,n]],:xs]]
+          [[true,["THROW",bfInert '"OPEN-AXIOM-CATCH-POINT",n]],:xs]]
     hs is [['%Catch,['%Signature,v,t],s],:hs'] =>
       t := 
         symbol? t => quote [t] -- instantiate niladic type ctor
@@ -1405,8 +1405,8 @@ bfHandlers(n,e,hs) == main(n,e,hs,nil) where
 
 codeForCatchHandlers(g,e,cs) ==
   ehTest := ['AND,['CONSP,g],
-              bfQ(['CAR,g],KEYWORD::OPEN_-AXIOM_-CATCH_-POINT)]
-  ["LET",[[g,["CATCH",KEYWORD::OPEN_-AXIOM_-CATCH_-POINT,e]]],
+              bfQ(['CAR,g],bfInert '"OPEN-AXIOM-CATCH-POINT")]
+  ["LET",[[g,["CATCH",bfInert '"OPEN-AXIOM-CATCH-POINT",e]]],
     ["COND",[ehTest,bfHandlers(g,["CDR",g],cs)],[true,g]]]
 
 ++ Generate code for try-catch expressions.
@@ -1431,8 +1431,8 @@ bfThrow e ==
   t :=
     symbol? t => quote [t]
     quote t
-  ["THROW",KEYWORD::OPEN_-AXIOM_-CATCH_-POINT,
-    ["CONS",KEYWORD::OPEN_-AXIOM_-CATCH_-POINT,["CONS",t,x]]]
+  ["THROW",bfInert '"OPEN-AXIOM-CATCH-POINT",
+    ["CONS",bfInert '"OPEN-AXIOM-CATCH-POINT",["CONS",t,x]]]
 
 --%
 
@@ -1580,79 +1580,79 @@ nativeType t ==
   t isnt [.,:.] =>
     t' := rest objectAssoc(coreSymbol t,$NativeTypeTable) => 
       t' := 
-	%hasFeature KEYWORD::SBCL => bfColonColon("SB-ALIEN", t')
-	%hasFeature KEYWORD::CLISP => bfColonColon("FFI",t')
+	%hasFeature bfInert '"SBCL" => bfColonColon("SB-ALIEN", t')
+	%hasFeature bfInert '"CLISP" => bfColonColon("FFI",t')
 	t'
       -- ??? decree we have not discovered Unicode yet.
-      t is "string" and %hasFeature KEYWORD::SBCL =>
-	[t',KEYWORD::EXTERNAL_-FORMAT,KEYWORD::ASCII,
-	   KEYWORD::ELEMENT_-TYPE, "BASE-CHAR"]
+      t is "string" and %hasFeature bfInert '"SBCL" =>
+	[t',bfInert '"EXTERNAL-FORMAT",bfInert '"ASCII",
+	   bfInert '"ELEMENT-TYPE", "BASE-CHAR"]
       t'
     t in '(byte uint8) =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","UNSIGNED"),8]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","UINT8")
-      %hasFeature KEYWORD::ECL or %hasFeature KEYWORD::CLOZURE =>
-        KEYWORD::UNSIGNED_-BYTE
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","UNSIGNED"),8]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","UINT8")
+      %hasFeature bfInert '"ECL" or %hasFeature bfInert '"CLOZURE" =>
+        bfInert '"UNSIGNED-BYTE"
       nativeType "char"           -- approximate by 'char' for GCL
     t is "int16" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","SIGNED"),16]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","INT16")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT16_-T =>
-         KEYWORD::INT16_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::SIGNED_-HALFWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","SIGNED"),16]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","INT16")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT16-T" =>
+         bfInert '"INT16-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"SIGNED-HALFWORD"
       unknownNativeTypeError t
     t is "uint16" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","UNSIGNED"),16]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","UINT16")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT16_-T =>
-         KEYWORD::UINT16_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::UNSIGNED_-HALFWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","UNSIGNED"),16]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","UINT16")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT16-T" =>
+         bfInert '"UINT16-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"UNSIGNED-HALFWORD"
       unknownNativeTypeError t
     t is "int32" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","SIGNED"),32]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","INT32")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT32_-T =>
-         KEYWORD::INT32_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::SIGNED_-FULLWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","SIGNED"),32]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","INT32")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT32-T" =>
+         bfInert '"INT32-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"SIGNED-FULLWORD"
       unknownNativeTypeError t
     t is "uint32" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","UNSIGNED"),32]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","INT32")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT32_-T =>
-         KEYWORD::UINT32_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::UNSIGNED_-FULLWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","UNSIGNED"),32]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","INT32")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT32-T" =>
+         bfInert '"UINT32-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"UNSIGNED-FULLWORD"
       unknownNativeTypeError t
     t is "int64" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","SIGNED"),64]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","INT64")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT64_-T =>
-         KEYWORD::INT64_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::SIGNED_-DOUBLEWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","SIGNED"),64]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","INT64")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT64-T" =>
+         bfInert '"INT64-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"SIGNED-DOUBLEWORD"
       unknownNativeTypeError t
     t is "uint64" =>
-      %hasFeature KEYWORD::SBCL => [bfColonColon("SB-ALIEN","UNSIGNED"),64]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","UINT64")
-      %hasFeature KEYWORD::ECL and %hasFeature KEYWORD::UINT64_-T =>
-         KEYWORD::UINT64_-T
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::UNSIGNED_-DOUBLEWORD
+      %hasFeature bfInert '"SBCL" => [bfColonColon("SB-ALIEN","UNSIGNED"),64]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","UINT64")
+      %hasFeature bfInert '"ECL" and %hasFeature bfInert '"UINT64-T" =>
+         bfInert '"UINT64-T"
+      %hasFeature bfInert '"CLOZURE" => bfInert '"UNSIGNED-DOUBLEWORD"
       unknownNativeTypeError t
     t is "float32" => nativeType "float"
     t is "float64" => nativeType "double"
     t is "pointer" =>
-      %hasFeature KEYWORD::GCL => "fixnum"
-      %hasFeature KEYWORD::ECL => KEYWORD::POINTER_-VOID
-      %hasFeature KEYWORD::SBCL => ["*",bfColonColon("SB-ALIEN","VOID")]
-      %hasFeature KEYWORD::CLISP => bfColonColon("FFI","C-POINTER")
-      %hasFeature KEYWORD::CLOZURE => KEYWORD::ADDRESS
+      %hasFeature bfInert '"GCL" => "fixnum"
+      %hasFeature bfInert '"ECL" => bfInert '"POINTER-VOID"
+      %hasFeature bfInert '"SBCL" => ["*",bfColonColon("SB-ALIEN","VOID")]
+      %hasFeature bfInert '"CLISP" => bfColonColon("FFI","C-POINTER")
+      %hasFeature bfInert '"CLOZURE" => bfInert '"ADDRESS"
       unknownNativeTypeError t
     unknownNativeTypeError t
   -- composite, reference type.
   first t is "buffer" =>
-    %hasFeature KEYWORD::GCL => "OBJECT"
-    %hasFeature KEYWORD::ECL => KEYWORD::OBJECT
-    %hasFeature KEYWORD::SBCL => ["*",nativeType second t]
-    %hasFeature KEYWORD::CLISP => bfColonColon("FFI","C-POINTER")
-    %hasFeature KEYWORD::CLOZURE => [KEYWORD::_*, nativeType second t]
+    %hasFeature bfInert '"GCL" => "OBJECT"
+    %hasFeature bfInert '"ECL" => bfInert '"OBJECT"
+    %hasFeature bfInert '"SBCL" => ["*",nativeType second t]
+    %hasFeature bfInert '"CLISP" => bfColonColon("FFI","C-POINTER")
+    %hasFeature bfInert '"CLOZURE" => [bfInert '"*", nativeType second t]
     unknownNativeTypeError t
   first t is "pointer" =>
     -- we don't bother looking at what the pointer points to.
@@ -1694,9 +1694,9 @@ needsStableReference? t ==
 ++ a call to a native functions.
 coerceToNativeType(a,t) ==
   -- GCL, ECL, CLISP, and CLOZURE don't do it this way.
-  %hasFeature KEYWORD::GCL or %hasFeature KEYWORD::ECL
-     or %hasFeature KEYWORD::CLISP or %hasFeature KEYWORD::CLOZURE => a
-  %hasFeature KEYWORD::SBCL =>
+  %hasFeature bfInert '"GCL" or %hasFeature bfInert '"ECL"
+     or %hasFeature bfInert '"CLISP" or %hasFeature bfInert '"CLOZURE" => a
+  %hasFeature bfInert '"SBCL" =>
     not needsStableReference? t => a
     [.,[c,y]] := t
     c is "buffer" => [bfColonColon("SB-SYS","VECTOR-SAP"),a]
@@ -1763,7 +1763,7 @@ genECLnativeTranslation(op,s,t,op') ==
   [["DEFUN",op, args,
     [bfColonColon("FFI","C-INLINE"),args, reverse! argtypes,
       rettype, callTemplate(op',#args,s), 
-        KEYWORD::ONE_-LINER, true]]] where
+        bfInert '"ONE-LINER", true]]] where
 	  callTemplate(op,n,s) ==
 	    "strconc"/[symbolName op,'"(",
 	      :[sharpArg(i,x) for i in 0..(n-1) for x in s],'")"]
@@ -1815,10 +1815,10 @@ genCLISPnativeTranslation(op,s,t,op') ==
   -- parameter of non-simple datatype are described as being pointers.
   foreignDecl := 
     [bfColonColon("FFI","DEF-CALL-OUT"),n,
-      [KEYWORD::NAME,symbolName op'],
-	[KEYWORD::ARGUMENTS,:[[a, x] for x in argtypes for a in parms]],
-	  [KEYWORD::RETURN_-TYPE, rettype],
-	      [KEYWORD::LANGUAGE,KEYWORD::STDC]]
+      [bfInert '"NAME",symbolName op'],
+	[bfInert '"ARGUMENTS",:[[a, x] for x in argtypes for a in parms]],
+	  [bfInert '"RETURN-TYPE", rettype],
+	      [bfInert '"LANGUAGE",bfInert '"STDC"]]
 
   -- The forwarding function.  We have to introduce local foreign
   -- variables to hold the address of converted Lisp objects.  Then
@@ -1905,7 +1905,7 @@ genCLOZUREnativeTranslation(op,s,t,op') ==
   -- Build the actual foreign function call.
   -- Note that Clozure CL does not mangle foreign function call for
   -- us, so we're left with more platform dependencies than needed.
-  if %hasFeature KEYWORD::DARWIN then
+  if %hasFeature bfInert '"DARWIN" then
     op' := strconc('"__",op')
   call := [bfColonColon("CCL","EXTERNAL-CALL"), STRING op', :args, rettype]
             where
@@ -1948,9 +1948,9 @@ genImportDeclaration(op, sig, dom) ==
   if dom is ["%LoadUnit",lib] and not symbolMember?(lib,$foreignLoadUnits) then
     $foreignLoadUnits := [lib,:$foreignLoadUnits]
 
-  %hasFeature KEYWORD::GCL => genGCLnativeTranslation(op,s,t,op')
-  %hasFeature KEYWORD::SBCL => genSBCLnativeTranslation(op,s,t,op')
-  %hasFeature KEYWORD::CLISP => genCLISPnativeTranslation(op,s,t,op')
-  %hasFeature KEYWORD::ECL => genECLnativeTranslation(op,s,t,op')
-  %hasFeature KEYWORD::CLOZURE => genCLOZUREnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"GCL" => genGCLnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"SBCL" => genSBCLnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"CLISP" => genCLISPnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"ECL" => genECLnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"CLOZURE" => genCLOZUREnativeTranslation(op,s,t,op')
   fatalError '"import declaration not implemented for this Lisp"

--- a/src/boot/includer.boot
+++ b/src/boot/includer.boot
@@ -165,8 +165,17 @@ bRgen s ==
  
 bRgen1 s ==
   a := readLine s
-  a ~= %nothing => [a,:bRgen s]
+  a ~= %nothing => [stripTrailingCR a,:bRgen s]
   $bStreamNil
+
+++ Strip any trailing carriage return from a line.
+++ Common Lisp's READ-LINE strips the newline but may leave a carriage
+++ return on Windows or when reading files with CRLF line endings.
+stripTrailingCR a ==
+  n := #a
+  n > 0 and stringChar(a,n - 1) = abstractChar 13 =>
+    subString(a,0,n - 1)
+  a
  
 bIgen n ==
   bDelay(function bIgen1,[n])

--- a/src/boot/strap/includer.clisp
+++ b/src/boot/strap/includer.clisp
@@ -115,8 +115,17 @@
   (LET* (|a|)
     (PROGN
      (SETQ |a| (|readLine| |s|))
-     (COND ((NOT (EQ |a| |%nothing|)) (CONS |a| (|bRgen| |s|)))
+     (COND ((NOT (EQ |a| |%nothing|))
+            (CONS (|stripTrailingCR| |a|) (|bRgen| |s|)))
            (T |$bStreamNil|)))))
+
+(DEFUN |stripTrailingCR| (|a|)
+  (LET* ((|n| (LENGTH |a|)))
+    (COND
+     ((AND (> |n| 0)
+           (CHAR= (SCHAR |a| (- |n| 1)) (CODE-CHAR 13)))
+      (SUBSEQ |a| 0 (- |n| 1)))
+     (T |a|))))
 
 (DEFUN |bIgen| (|n|) (|bDelay| #'|bIgen1| (LIST |n|)))
 

--- a/src/boot/translator.boot
+++ b/src/boot/translator.boot
@@ -66,7 +66,7 @@ genModuleFinalization(stream) ==
   setFFS := ["SETQ","$dynamicForeignFunctions",
               ["append!",quote $ffs,"$dynamicForeignFunctions"]]
   reallyPrettyPrint(atLoadOrExecutionTime setFFS,stream)
-  %hasFeature KEYWORD::CLISP =>
+  %hasFeature bfInert '"CLISP" =>
     $foreignsDefsForCLisp = nil => nil
     init := ["PROGN", :[["EVAL",quote d] for d in $foreignsDefsForCLisp]]
     reallyPrettyPrint(atLoadOrExecutionTime init,stream)
@@ -78,7 +78,7 @@ genOptimizeOptions stream ==
 
 AxiomCore::%sysInit() ==
   SETQ(_*LOAD_-VERBOSE_*,false)
-  if %hasFeature KEYWORD::GCL then
+  if %hasFeature bfInert '"GCL" then
     symbolValue(bfColonColon("COMPILER","*COMPILE-VERBOSE*")) := false
     symbolValue(bfColonColon("COMPILER","SUPPRESS-COMPILER-WARNINGS*")) := false
     symbolValue(bfColonColon("COMPILER","SUPPRESS-COMPILER-NOTES*")) := true
@@ -405,12 +405,12 @@ translateToplevelExpression expr ==
   first expr'
 
 inAllContexts x ==
-  ["EVAL-WHEN",[KEYWORD::COMPILE_-TOPLEVEL,
-                  KEYWORD::LOAD_-TOPLEVEL,
-                    KEYWORD::EXECUTE], x]
+  ["EVAL-WHEN",[bfInert '"COMPILE-TOPLEVEL",
+                  bfInert '"LOAD-TOPLEVEL",
+                    bfInert '"EXECUTE"], x]
 
 atLoadOrExecutionTime x ==
-  ["EVAL-WHEN",[KEYWORD::LOAD_-TOPLEVEL,KEYWORD::EXECUTE],x]
+  ["EVAL-WHEN",[bfInert '"LOAD-TOPLEVEL",bfInert '"EXECUTE"],x]
 
 exportNames ns ==
   ns = nil => nil
@@ -423,12 +423,12 @@ packageBody(x,p) ==
       [symbolName p]
     ns is 'System =>
       ['COND,
-        [['%hasFeature,KEYWORD::COMMON_-LISP],['USE_-PACKAGE,'"COMMON-LISP",:user]],
+        [['%hasFeature,bfInert '"COMMON-LISP"],['USE_-PACKAGE,'"COMMON-LISP",:user]],
            ['T,['USE_-PACKAGE,'"LISP",:user]]]
     z :=
       ns is ['DOT,'System,'Foreign] =>
-        %hasFeature KEYWORD::SBCL => 'SB_-ALIEN
-        %hasFeature KEYWORD::ECL => 'FFI
+        %hasFeature bfInert '"SBCL" => 'SB_-ALIEN
+        %hasFeature bfInert '"ECL" => 'FFI
         return nil
       ident? ns => ns
       bfSpecificErrorHere '"invalid namespace"
@@ -620,19 +620,19 @@ loadNativeModule(m,:dir) ==
   if dir ~= nil then
      [dir] := dir
      m := strconc(dir,m)
-  %hasFeature KEYWORD::SBCL =>
+  %hasFeature bfInert '"SBCL" =>
     apply(bfColonColon("SB-ALIEN","LOAD-SHARED-OBJECT"),
-          [m,KEYWORD::DONT_-SAVE,true])
-  %hasFeature KEYWORD::CLISP =>
+          [m,bfInert '"DONT-SAVE",true])
+  %hasFeature bfInert '"CLISP" =>
     EVAL [bfColonColon("FFI","DEFAULT-FOREIGN-LIBRARY"), m]
-  %hasFeature KEYWORD::ECL =>
+  %hasFeature bfInert '"ECL" =>
     EVAL [bfColonColon("FFI","LOAD-FOREIGN-LIBRARY"), m]
-  %hasFeature KEYWORD::CLOZURE =>
+  %hasFeature bfInert '"CLOZURE" =>
     EVAL [bfColonColon("CCL","OPEN-SHARED-LIBRARY"), m]
   coreError '"don't know how to load a dynamically linked module"
 
 loadSystemRuntimeCore() ==
-  %hasFeature KEYWORD::ECL or %hasFeature KEYWORD::GCL => nil
+  %hasFeature bfInert '"ECL" or %hasFeature bfInert '"GCL" => nil
   dir :=
      path := directoryFromCommandLine '"syslib" => path
      strconc(systemRootDirectory(),'"lib/")


### PR DESCRIPTION
- Add stripTrailingCR to Boot includer (and strap) to handle carriage returns that Common Lisp's READ-LINE may leave on Windows or when reading files with CRLF line endings.

- Replace all KEYWORD::X syntax with bfInert '"X"' calls in ast.boot and translator.boot.  The KEYWORD:: syntax relies on the Boot parser's qualified-name rule and Common Lisp reader internals; using bfInert makes the intent explicit and self-contained within the Boot AST layer.

- Mark .daase files as binary in .gitattributes.

- Add configure-time progress messages for algebra scanning.

- Make all-algebra part of the default ALL target so that a bare cmake --build includes the full algebra pipeline.

Assisted By: Claude Opus 4.6