### PR TITLE
Abstract KEYWORD package as %Inert constant

### DIFF
--- a/src/boot/ast.boot
+++ b/src/boot/ast.boot
@@ -174,6 +174,8 @@ bfColon x==
 
 bfColonColon: (%Symbol,%Symbol) -> %Symbol
 bfColonColon(package, name) == 
+  if readOnly? package then
+    package := symbolValue package
   %hasFeature bfInert '"CLISP" and package in '(EXT FFI) =>
     symbolBinding(symbolName name,package)
   makeSymbol(symbolName name, package)
@@ -802,7 +804,7 @@ bfKeyArg(k,x) ==
   ['%Key,k,x]
 
 bfInert x ==
-  makeSymbol(x,'"KEYWORD")
+  makeSymbol(x,%Inert)
 
 lispKey k ==
   bfInert stringUpcase symbolName k
@@ -1376,11 +1378,11 @@ bfRecordDef(tu,s,fields,accessors) ==
   fun := makeSymbol strconc('"mk",symbolName s)
   ctor := makeSymbol strconc('"MAKE-",symbolName s)
   recDef := ["DEFSTRUCT",
-               [s,[bfColonColon("KEYWORD","COPIER"),
+               [s,[bfInert '"COPIER",
                     makeSymbol strconc('"copy",symbolName s)]],
                       :[x for ['%Signature,x,.] in fields]]
   ctorDef :=
-    args := [:[bfColonColon("KEYWORD",p),p] for p in parms]
+    args := [:[bfInert(symbolName p),p] for p in parms]
     ["DEFMACRO",fun,parms,["LIST",quote ctor,:args]]
   accDefs :=
     accessors = nil => nil

--- a/src/boot/strap/ast.clisp
+++ b/src/boot/strap/ast.clisp
@@ -221,6 +221,7 @@
 (DECLAIM (FTYPE (FUNCTION (|%Symbol| |%Symbol|) |%Symbol|) |bfColonColon|))
 
 (DEFUN |bfColonColon| (|package| |name|)
+  (COND ((CONSTANTP |package|) (SETQ |package| (SYMBOL-VALUE |package|))))
   (COND
    ((AND (|%hasFeature| :CLISP) (|symbolMember?| |package| '(EXT FFI)))
     (FIND-SYMBOL (SYMBOL-NAME |name|) |package|))
@@ -1218,7 +1219,7 @@
 
 (DEFUN |bfKeyArg| (|k| |x|) (LIST '|%Key| |k| |x|))
 
-(DEFUN |bfInert| (|x|) (INTERN |x| "KEYWORD"))
+(DEFUN |bfInert| (|x|) (INTERN |x| |%Inert|))
 
 (DEFUN |lispKey| (|k|) (|bfInert| (STRING-UPCASE (SYMBOL-NAME |k|))))
 
@@ -2580,7 +2581,7 @@
              (CONS 'DEFSTRUCT
                    (CONS
                     (LIST |s|
-                          (LIST (|bfColonColon| 'KEYWORD 'COPIER)
+                          (LIST (|bfInert| "COPIER")
                                 (INTERN (CONCAT "copy" (SYMBOL-NAME |s|)))))
                     (LET ((|bfVar#6| NIL)
                           (|bfVar#7| NIL)
@@ -2623,7 +2624,7 @@
                            (RETURN |bfVar#9|))
                           (T
                            (LET ((|bfVar#11|
-                                  (LIST (|bfColonColon| 'KEYWORD |p|) |p|)))
+                                  (LIST (|bfInert| (SYMBOL-NAME |p|)) |p|)))
                              (COND ((NULL |bfVar#11|) NIL)
                                    ((NULL |bfVar#9|)
                                     (SETQ |bfVar#9| |bfVar#11|)

--- a/src/boot/strap/utility.clisp
+++ b/src/boot/strap/utility.clisp
@@ -15,7 +15,7 @@
 
 (EVAL-WHEN (:COMPILE-TOPLEVEL :LOAD-TOPLEVEL :EXECUTE)
   (EXPORT
-   '(|objectMember?| |symbolMember?| |stringMember?| |charMember?|
+   '(|%Inert| |objectMember?| |symbolMember?| |stringMember?| |charMember?|
                      |scalarMember?| |listMember?| |reverse| |reverse!|
                      |lastNode| |append| |append!| |copyList| |substitute|
                      |substitute!| |listMap| |listMap!| |butLast| |butLast!|
@@ -25,6 +25,8 @@
                      |remove| |removeSymbol| |atomic?| |every?| |any?| |take|
                      |takeWhile| |drop| |copyTree| |finishLine| |stringPrefix?|
                      |stringSuffix?| |findChar| |charPosition|)))
+
+(DEFCONSTANT |%Inert| "KEYWORD")
 
 (DECLAIM (FTYPE (FUNCTION (|%Thing| |%Thing| |%Thing|) |%Thing|) |substitute|))
 

--- a/src/boot/utility.boot
+++ b/src/boot/utility.boot
@@ -43,7 +43,7 @@ namespace BOOTTRAN ==
 
 namespace BOOTTRAN
 
-module utility (objectMember?, symbolMember?, stringMember?,
+module utility (%Inert, objectMember?, symbolMember?, stringMember?,
   charMember?, scalarMember?, listMember?, reverse, reverse!,
   lastNode, append, append!, copyList, substitute, substitute!,
   listMap, listMap!, butLast, butLast!, last,
@@ -84,6 +84,9 @@ module utility (objectMember?, symbolMember?, stringMember?,
     stringPrefix?: (%String,%String) -> %Maybe %Short
 
 %defaultReadAndLoadSettings()
+
+++ The package for inert (self-evaluating) symbols.
+%Inert == '"KEYWORD"
 
 --%
 

--- a/src/interp/c-util.boot
+++ b/src/interp/c-util.boot
@@ -301,7 +301,7 @@ ivExportBytecodes iv ==
 
 ++ Token to indicate that a function body should be ignored.
 $ClearBodyToken ==
-  KEYWORD::OpenAxiomClearBodyToken
+  %Inert::OpenAxiomClearBodyToken
 
 ++
 $ConstructorCache := hashTable 'EQ

--- a/src/interp/sys-os.boot
+++ b/src/interp/sys-os.boot
@@ -205,11 +205,11 @@ import oa__system: string -> int for runCommand
 
 ++ run a program with specified arguments
 runProgram(prog,args) ==
-)if %hasFeature KEYWORD::GCL
+)if %hasFeature %Inert::GCL
   SYSTEM::SYSTEM(strconc/[prog,:[:['" ",a] for a in args]])
-)elseif %hasFeature KEYWORD::CLISP
+)elseif %hasFeature %Inert::CLISP
   EXT::RUN_-PROGRAM(prog,arguments <- args)
-)elseif %hasFeature KEYWORD::SBCL
+)elseif %hasFeature %Inert::SBCL
   SB_-EXT::RUN_-PROGRAM(prog,args)
 )else
   systemError '"don't how to execute external program with this Lisp"
@@ -220,7 +220,7 @@ runProgram(prog,args) ==
 
 import quiet__double__NaN: () -> double for quietDoubleNaN
 
-)if %hasFeature KEYWORD::GCL
+)if %hasFeature %Inert::GCL
 import plus__infinity: () -> double for plusInfinity
 
 import minus__infinity: () -> double for minusInfinity
@@ -228,7 +228,7 @@ import minus__infinity: () -> double for minusInfinity
 $plusInfinity := plusInfinity()
 $minusInfinity := minusInfinity()
 
-)elseif %hasFeature KEYWORD::SBCL
+)elseif %hasFeature %Inert::SBCL
 $plusInfinity == SB_-EXT::DOUBLE_-FLOAT_-POSITIVE_-INFINITY
 
 $minusInfinity == SB_-EXT::DOUBLE_-FLOAT_-NEGATIVE_-INFINITY
@@ -240,7 +240,7 @@ $plusInfinity == $DoubleFloatMaximum
 $minusInfinity == -$plusInfinity
 )endif
 
-)if not %hasFeature KEYWORD::GCL
+)if not %hasFeature %Inert::GCL
 plusInfinity() ==
   $plusInfinity
 


### PR DESCRIPTION
- Define `%Inert` as an exported constant with value `"KEYWORD"` in
  `utility.boot`, hiding the Common Lisp package name from Boot source.

- Update `bfInert` in `ast.boot` to use `%Inert` instead of the hardcoded
  string literal.

- Update `bfRecordDef` to use `bfInert` calls instead of
  `bfColonColon("KEYWORD",...)`.

- Fix `bfColonColon` to resolve constant symbols (via `readOnly?` /
  `symbolValue`) before using them as package designators.  This
  enables the `%Inert::X` syntax in source files outside the `BOOTTRAN`
  namespace.

- Replace `KEYWORD::` with `%Inert::` in `src/interp/c-util.boot` and
  `src/interp/sys-os.boot`.

Assisted By: Claude Opus 4.6