### PR TITLE
Support Gaia as a base Lisp for the Boot bootstrap

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,7 +381,7 @@ configure_file(
 )
 
 # Guard: only emit the Lisp build rules when a supported runtime was found.
-if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$")
+if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure|gaia)$")
   # Common Lisp invocation prefix -- used by every custom command below.
   # Wraps the binary in `cmake -E env` for flavor-specific environment
   # variables (e.g. GCL_ANSI=t), followed by quiet/batch flags.
@@ -418,7 +418,13 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$
       COMMENT "Compile the OpenAxiom core Lisp runtime"
       VERBATIM
     )
-    set(oa_base_lisp_objects "nil")
+    if(OA_LISP_FLAVOR STREQUAL "gaia")
+      # Gaia links a standalone image from compiled FASLs, so the base
+      # image must include the core runtime FASL explicitly.
+      set(oa_base_lisp_objects "(\"core.${OA_LISP_FASL_EXT}\")")
+    else()
+      set(oa_base_lisp_objects "nil")
+    endif()
   endif()
 
   # -- Step 3: Link the FASL into a standalone executable image --
@@ -649,6 +655,13 @@ function(oa_boot_link_image stage fasl_list)
   # Use file(GENERATE ...) so that generator expressions (e.g. OA_DRIVER)
   # are resolved at generation time rather than configure time.
   set(cmdfile "${outdir}/link-bootsys.cmdfile")
+  # Gaia links a standalone image from FASLs and does not inherit the core
+  # runtime from a base image, so prepend the staged core FASL.  Other
+  # flavors obtain core from the base image or complete-fasl-list-for-link.
+  set(_link_fasls ${fasl_list})
+  if(OA_LISP_FLAVOR STREQUAL "gaia")
+    list(PREPEND _link_fasls "${OA_STAGE_ROOT}/lisp/core.${OA_LISP_FASL_EXT}")
+  endif()
   string(JOIN "\n" _cmd_content
     "${OA_DRIVER}"
     "--execpath=${OA_LISPSYS}"
@@ -658,7 +671,7 @@ function(oa_boot_link_image stage fasl_list)
     "--prologue=(pushnew :open-axiom-boot *features*)"
     "--output=${image}"
     "--load-directory=${outdir}"
-    ${fasl_list}
+    ${_link_fasls}
   )
   file(GENERATE OUTPUT "${cmdfile}" CONTENT "${_cmd_content}\n")
 

--- a/src/lisp/core.lisp.in
+++ b/src/lisp/core.lisp.in
@@ -1054,14 +1054,15 @@
 ;; Command line arguments: equivalent of traditional `argv[]' from
 ;;  systems programming world.
 (defun |getCommandLineArguments| nil
-  #-(or :gcl :sbcl :clisp :ecl :clozure) 
+  #-(or :gcl :sbcl :clisp :ecl :clozure :gaia) 
   (|fatalError| "don't know how to get command line args")
   (let* ((all-args  
 	  #+:clozure ccl:*command-line-argument-list*
           #+:ecl (ext:command-args)
           #+:gcl si::*command-args*
           #+:sbcl sb-ext::*posix-argv*
-          #+:clisp (coerce (ext::argv) 'list))
+          #+:clisp (coerce (ext::argv) 'list)
+          #+:gaia (gaia:command-line-arguments))
          (args (member "--" all-args :test #'equal)))
     (cons (car all-args) (if args (cdr args) args))))
 
@@ -1081,11 +1082,21 @@
 			  &optional (entry-point nil) (prologue nil))
   (if (and entry-point (stringp entry-point))
       (setq entry-point `(read-from-string ,entry-point)))
-  #-:ecl 
+  #-(or :ecl :gaia) 
   (progn
     (mapcar #'(lambda (p) (|loadOrElse| p)) lisp-files)
     (eval prologue)
     (|saveCore| core-image entry-point))
+  #+:gaia
+  (progn
+    ;; Gaia links a fresh executable from the supplied FASLs, so resolve
+    ;; the entry-point suspension before handing it to the builder.
+    (when (consp entry-point)
+      (setq entry-point (apply (car entry-point) (cdr entry-point))))
+    (gaia:build-program core-image
+                        :fasls lisp-files
+                        :entry-point entry-point)
+    (|coreQuit|))
   #+:ecl 
   (let* ((compiler::*ld* oa-cxx)
 	 (compiler::*ld-flags* (concatenate 'string 

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -239,6 +239,12 @@ build_rts_options(Command* command, Driver driver)
          command->rt_args[1] = (char*) "-norc";
          break;
 
+      case Runtime::gaia:
+         // Gaia images embed their entry point and read every argument
+         // following the doubledash separator, so they need no runtime
+         // options of their own.
+         break;
+
       default:
          abort();
       }


### PR DESCRIPTION
Teach the generic Boot build pipeline to use Gaia as the underlying Lisp, alongside the existing Common Lisp flavors. Every change is gated on the `gaia` flavor, so the other flavors are unaffected.

## Changes

**`src/lisp/core.lisp.in`**
- `getCommandLineArguments` returns Gaia's process arguments via `gaia:command-line-arguments`, and `gaia` joins the guard for flavors that know how to read the command line. The existing `--` separator handling is unchanged.
- `link` gains a `gaia` arm that builds a standalone executable from the compiled FASLs with `gaia:build-program` and then quits, mirroring the ECL `build-program` path rather than the `saveCore` image dump. The entry-point suspension is resolved before it is handed to the builder, so a case-sensitive entry such as `|AxiomCore|::|topLevel|` survives intact.

**`src/utils/command.cc`**
- The C++ driver supplies no runtime options for a `gaia` image: it embeds its entry point and reads every argument after the doubledash separator.

**`src/CMakeLists.txt`**
- The boot rules emit for the `gaia` flavor. Because a Gaia image is linked from FASLs rather than inheriting a dumped core, the base image lists `core.fasl` explicitly and the bootsys link prepends the staged core FASL.

## Validation

The full three-stage Boot bootstrap (strap → stage1 → stage2) builds end to end with Gaia and reaches a byte-identical `stage1` vs `stage2` `.clisp` fixpoint for all eight modules (utility, tokens, includer, scanner, pile, ast, parser, translator), producing a native `bootsys` image. The existing Common Lisp flavors are untouched.

Assisted By: Claude Opus 4.8