### PR TITLE
Own, decode, and null-guard foreign string returns

### DIFF
--- a/.github/workflows/ci-linux-gcc-gcl.yml
+++ b/.github/workflows/ci-linux-gcc-gcl.yml
@@ -1,27 +1,55 @@
-# Linux: GCC 15 + GCL (GCL_ANSI=t workaround; binary is gcl27)
+# Linux: GCC 15 + GCL 2.6.x (Autotools, full-system build)
 #
-# Disabled: GCL 2.7 cannot compile the Boot translator's DECLAIM FTYPE
-# forms that use (FUNCTION ...) as a parameter type specifier.  The three
-# failing declarations in utility.clisp are:
-#   |every?|   : (FTYPE (FUNCTION ((FUNCTION (|%Thing|) |%Thing|) ...) ...) ...)
-#   |any?|     : same pattern
-#   |takeWhile|: same pattern
-# This is valid ANSI CL (CLHS 4.2.3) but GCL's PROCLAIM implementation
-# signals an error when (FUNCTION ...) appears nested inside an FTYPE
-# parameter list.  Re-enable once GCL is fixed or the Boot translator
-# emits a GCL-compatible workaround.
+# GCL is built with the traditional Autotools path (configure + make),
+# NOT the CMake migration -- the CMake GCL path is not ready yet.
 #
-# name: 'CI: Linux GCC+GCL'
-# on:
-#   push:
-#     branches: [master, cmake-migration-proposal]
-#   pull_request:
-#     branches: [master]
-# jobs:
-#   build:
-#     uses: ./.github/workflows/ci-linux-build.yml
-#     with:
-#       cc: gcc-15
-#       cxx: g++-15
-#       lisp: gcl
-#       lisp_executable: gcl27
+# GCL 2.7 (the 'gcl27' package) cannot compile the Boot translator's
+# DECLAIM FTYPE forms that nest (FUNCTION ...) inside a parameter type
+# specifier (|every?|, |any?|, |takeWhile|) -- valid ANSI CL (CLHS 4.2.3)
+# that GCL 2.7's PROCLAIM rejects.  The distro 'gcl' package (the 2.6.x
+# line) compiles them, so this job requires GCL 2.6.x.  GCL_ANSI=t selects
+# the ANSI image.
+name: 'CI: Linux GCC+GCL'
+on:
+  push:
+    branches: [master, cmake-migration-proposal]
+  pull_request:
+    branches: [master]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      GCL_ANSI: t
+      CC: gcc-15
+      CXX: g++-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC 15 and GCL 2.6.x
+        run: |
+          sudo apt-get update
+          # GCC 15 (Ubuntu 24.04 ships gcc-13 by default).
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-15 g++-15
+          # Build dependencies plus GCL 2.6.x.  The 'gcl' package is the
+          # 2.6.x line; 'gcl27' (2.7) cannot build the Boot translator.
+          # libreadline-dev links the GCL runtime image.
+          sudo apt-get install -y \
+            build-essential libxt-dev libxpm-dev texlive \
+            gcl libreadline-dev
+          # Require GCL 2.6.x specifically.
+          gcl_ver=$(dpkg-query -W -f='${Version}' gcl)
+          echo "Installed GCL version: $gcl_ver"
+          case "$gcl_ver" in
+            2.6.*|*:2.6.*) echo "OK: GCL 2.6.x" ;;
+            *) echo "::error::Expected GCL 2.6.x, got '$gcl_ver'"; exit 1 ;;
+          esac
+
+      - name: Configure, build, and test the full system
+        run: |
+          mkdir gcl-build && cd gcl-build
+          touch ../configure && sleep 1
+          ../configure --disable-maintainer-mode --with-lisp=gcl
+          make
+          make check

--- a/config/open-axiom.m4
+++ b/config/open-axiom.m4
@@ -496,6 +496,7 @@ case $oa_lisp_flavor in
     gaia)
        oa_quiet_flags=''
        oa_eval_flags='--eval'
+       ;;
     *) AC_MSG_ERROR([We do not know how to build OpenAxiom this $OA_LISP]) ;;
 esac
 ])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,7 +381,7 @@ configure_file(
 )
 
 # Guard: only emit the Lisp build rules when a supported runtime was found.
-if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$")
+if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure|gaia)$")
   # Common Lisp invocation prefix -- used by every custom command below.
   # Wraps the binary in `cmake -E env` for flavor-specific environment
   # variables (e.g. GCL_ANSI=t), followed by quiet/batch flags.
@@ -418,7 +418,13 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure)$
       COMMENT "Compile the OpenAxiom core Lisp runtime"
       VERBATIM
     )
-    set(oa_base_lisp_objects "nil")
+    if(OA_LISP_FLAVOR STREQUAL "gaia")
+      # Gaia links a standalone image from compiled FASLs, so the base
+      # image must include the core runtime FASL explicitly.
+      set(oa_base_lisp_objects "(\"core.${OA_LISP_FASL_EXT}\")")
+    else()
+      set(oa_base_lisp_objects "nil")
+    endif()
   endif()
 
   # -- Step 3: Link the FASL into a standalone executable image --
@@ -649,6 +655,13 @@ function(oa_boot_link_image stage fasl_list)
   # Use file(GENERATE ...) so that generator expressions (e.g. OA_DRIVER)
   # are resolved at generation time rather than configure time.
   set(cmdfile "${outdir}/link-bootsys.cmdfile")
+  # Gaia links a standalone image from FASLs and does not inherit the core
+  # runtime from a base image, so prepend the staged core FASL.  Other
+  # flavors obtain core from the base image or complete-fasl-list-for-link.
+  set(_link_fasls ${fasl_list})
+  if(OA_LISP_FLAVOR STREQUAL "gaia")
+    list(PREPEND _link_fasls "${OA_STAGE_ROOT}/lisp/core.${OA_LISP_FASL_EXT}")
+  endif()
   string(JOIN "\n" _cmd_content
     "${OA_DRIVER}"
     "--execpath=${OA_LISPSYS}"
@@ -658,7 +671,7 @@ function(oa_boot_link_image stage fasl_list)
     "--prologue=(pushnew :open-axiom-boot *features*)"
     "--output=${image}"
     "--load-directory=${outdir}"
-    ${fasl_list}
+    ${_link_fasls}
   )
   file(GENERATE OUTPUT "${cmdfile}" CONTENT "${_cmd_content}\n")
 

--- a/src/boot/ast.boot
+++ b/src/boot/ast.boot
@@ -1975,14 +1975,24 @@ genCLISPownedStringReturn(op,op',parms,argtypes,release,nullable) ==
       [bfInert '"LANGUAGE",bfInert '"STDC"]]
   $foreignsDefsForCLisp := [callDecl,releaseDecl,:$foreignsDefsForCLisp]
   p := gensym()
-  decode := [bfColonColon("FFI","MEMORY-AS"), p,
-              [bfColonColon("FFI","PARSE-C-TYPE"),
-                ["QUOTE", bfColonColon("FFI","C-STRING")]]]
+  cell := gensym()
+  -- Decode the returned `char*' into a fresh Lisp string.  `p' already
+  -- points at the characters, so we must not read it directly as a
+  -- `c-string': CLISP's `c-string' is itself a pointer type, so
+  -- `memory-as' would misread the leading bytes of the text as a pointer
+  -- and follow it into oblivion.  Instead we hold `p' in a `c-pointer'
+  -- cell and read that cell as a `c-string', which follows the pointer
+  -- and copies its characters.
+  decode := [bfColonColon("FFI","WITH-C-VAR"),
+              [cell, ["QUOTE", bfColonColon("FFI","C-POINTER")], p],
+                [bfColonColon("FFI","CAST"), cell,
+                  [bfColonColon("FFI","PARSE-C-TYPE"),
+                    ["QUOTE", bfColonColon("FFI","C-STRING")]]]]
   body := ["UNWIND-PROTECT", decode, [releaseHack, p]]
+  -- A null result decodes as NIL.  CLISP maps a NULL `c-pointer' to NIL,
+  -- so the guard is a plain null test and there is nothing to release.
   if nullable then
-    body := ["IF",
-              ["ZEROP", [bfColonColon("FFI","FOREIGN-ADDRESS-UNSIGNED"), p]],
-                nil, body]
+    body := ["IF", ["NULL", p], nil, body]
   [["DEFUN",op,parms, ["LET",[[p,[callHack,:parms]]], body]]]
 
 

--- a/src/boot/ast.boot
+++ b/src/boot/ast.boot
@@ -63,7 +63,7 @@ structure %Ast ==
   %Namespace(%Symbol)                   -- namespace AxiomCore
   %Import(%Ast)                         -- import module; import namespace foo
   %LoadUnit(%Symbol)                    -- System.LoadUnit lib
-  %ImportSignature(%Symbol,%Signature,%Domain)  -- import function declaration
+  %ImportSignature(%Symbol,%Signature,%List)  -- import op(s): t with props == cname
   %Record(%List,%List)                  -- Record(num: %Short, den: %Short)
   %AccessorDef(%Symbol,%Ast)            -- numerator == (.num)
   %TypeAlias(%Head, %List)              -- type alias definition
@@ -1662,9 +1662,28 @@ nativeType t ==
     nativeType "pointer"
   unknownNativeTypeError t
 
+++ True if `t' is a nullable native return type, i.e. `%Maybe T'.
+maybeType? t ==
+  t is [h,.] and symbol? h and symbolName h = '"%Maybe"
+
+++ The underlying type of a possibly-nullable native type `t': the `T' of
+++ a `%Maybe T', otherwise `t' itself.
+maybeBaseType t ==
+  maybeType? t => second t
+  t
+
+++ True if the native return type `t' is a `string' whose storage the
+++ caller must manage explicitly -- decoding the raw pointer, then freeing
+++ it (when `release' is non-nil) and/or guarding a null pointer (when `t'
+++ is a `%Maybe').
+managedStringReturn?(t,release) ==
+  maybeBaseType t = "string" and (release ~= nil or maybeType? t)
+
 ++ Check that `t' is a valid return type for a native function, and
-++ returns its translation
+++ returns its translation.  A `%Maybe T' return decodes a possibly-null
+++ result; the underlying native type is that of `T'.
 nativeReturnType t ==
+  maybeType? t => nativeReturnType second t
   objectMember?(t,$NativeSimpleReturnTypes) => nativeType t
   coreError strconc('"invalid return type for native function: ", 
               PNAME t)
@@ -1672,6 +1691,7 @@ nativeReturnType t ==
 ++ Check that `t' is a valid parameter type for a native function,
 ++ and returns its translation.
 nativeArgumentType t ==
+  maybeType? t => nativeArgumentType second t
   objectMember?(t,$NativeSimpleDataTypes) => nativeType t
   -- Allow 'string'  for `pass-by-value'
   t is "string" => nativeType t
@@ -1713,15 +1733,24 @@ coerceToNativeType(a,t) ==
 ++ Generate GCL native translation for import op: s -> t for op'
 ++ `argtypes' is the list of GCL FFI names for types in `s'.
 ++ `rettype' is the GCL FFI name for `t'.
-genGCLnativeTranslation(op,s,t,op') ==
+genGCLnativeTranslation(op,s,t,op',release) ==
   argtypes := [nativeArgumentType x for x in s]
   rettype := nativeReturnType t
-  -- If a simpel DEFENTRY will do, go for it
+  -- An owned (carries a release) or nullable (%Maybe) `string' return
+  -- cannot use a plain DEFENTRY: GCL would copy the C string but leak the
+  -- original (owned), or crash on a null pointer (nullable).  Such returns
+  -- go through the C-stub path below, which copies into a Lisp string,
+  -- guards a null pointer, and frees the original.
+  -- An owned or nullable string return needs a C stub (copy + free/guard).
+  managedStringReturn?(t,release) =>
+    genGCLownedStringReturn(op,s,t,op',release,maybeType? t)
+  -- If a simple DEFENTRY will do, go for it.
   and/[isSimpleNativeType x for x in [t,:s]] =>
     [["DEFENTRY", op, argtypes, [rettype, symbolName op']]]
   -- Otherwise, do it the hard way.
   [["CLINES",ccode], ["DEFENTRY", op, argtypes, [rettype, cop]]] where
     cop := strconc(symbolName op','"__stub")
+    cargs := [mkCArgName i for i in 0..(#s - 1)]
     ccode := 
       "strconc"/[gclTypeInC t, '" ", cop, '"(",
 	 :[cparm(x,a) for x in tails s for a in tails cargs],
@@ -1729,7 +1758,6 @@ genGCLnativeTranslation(op,s,t,op') ==
 	     symbolName op', '"(",
 	       :[gclArgsInC(x,a) for x in tails s for a in tails cargs],
 		  '"); }" ]
-                where cargs := [mkCArgName i for i in 0..(#s - 1)]
     mkCArgName i == strconc('"x",toString i)
     cparm(x,a) ==
       strconc(gclTypeInC first x, '" ", first a,
@@ -1755,18 +1783,79 @@ genGCLnativeTranslation(op,s,t,op') ==
       strconc(gclArgInC(first x, first a),
 	(rest x => '", "; '""))  
 
-genECLnativeTranslation(op,s,t,op') ==
+++ Generate a GCL `string'-returning import that owns its result (when
+++ `release' is non-nil) and/or may be null (when `nullable').  A plain
+++ DEFENTRY would let GCL copy the C string but leak the original, or
+++ crash on a null pointer.  We route through a C stub that copies into a
+++ Lisp string with make_simple_string, returns NIL for a null pointer,
+++ and frees the original through the named release function.
+genGCLownedStringReturn(op,s,t,op',release,nullable) ==
+  argtypes := [nativeArgumentType x for x in s]
+  [["CLINES",ccode], ["DEFENTRY", op, argtypes, ["OBJECT", cop]]] where
+    cop := strconc(symbolName op','"__stub")
+    cargs := [mkCArgName i for i in 0..(#s - 1)]
+    ccode :=
+      "strconc"/['"object ", cop, '"(",
+        :[cparm(x,a) for x in tails s for a in tails cargs],
+        '") { char *p = ", symbolName op', '"(",
+        :[gclArgsInC(x,a) for x in tails s for a in tails cargs],
+        '"); ",
+        (nullable => '"if (p == 0) return Cnil; "; '""),
+        '"{ object r = make__simple__string(p); ",
+        (release ~= nil => strconc(symbolName release,'"(p); "); '""),
+        '"return r; } }" ]
+    mkCArgName i == strconc('"x",toString i)
+    cparm(x,a) ==
+      strconc(gclCType first x, '" ", first a,
+        (rest x => '", "; '""))
+    gclCType x ==
+      objectMember?(x,$NativeSimpleDataTypes) => symbolName x
+      x is "void" => '"void"
+      x is "string" => '"char*"
+      x is [.,["pointer",.]] => "fixnum"
+      '"object"
+    gclArgInCall(x,a) ==
+      objectMember?(x,$NativeSimpleDataTypes) => a
+      x is "string" => a
+      [.,[c,y]] := x
+      c is "pointer" => a
+      y is "char" => strconc(a,'"->st.st__self")
+      y is "byte" => strconc(a,'"->ust.ust__self")
+      y is "int" => strconc(a,'"->fixa.fixa__self")
+      y is "float" => strconc(a,'"->sfa.sfa__self")
+      y is "double" => strconc(a,'"->lfa.lfa__self")
+      coreError '"unknown argument type"
+    gclArgsInC(x,a) ==
+      strconc(gclArgInCall(first x, first a),
+        (rest x => '", "; '""))
+
+genECLnativeTranslation(op,s,t,op',release) ==
   args := nil
   argtypes := nil
   for x in s repeat
      argtypes := [nativeArgumentType x,:argtypes]
      args := [gensym(),:args]
   args := reverse args
-  rettype := nativeReturnType t
-  [["DEFUN",op, args,
-    [bfColonColon("FFI","C-INLINE"),args, reverse! argtypes,
-      rettype, callTemplate(op',#args,s), 
-        bfInert '"ONE-LINER", true]]] where
+  buildECLImport(op,args,argtypes,op',s,t,release) where
+	  buildECLImport(op,args,argtypes,op',s,t,release) ==
+	    nullable := maybeType? t
+	    managed := managedStringReturn?(t,release)
+	    rettype := nativeReturnType t
+	    if managed then rettype := bfInert '"POINTER-VOID"
+	    callForm := [bfColonColon("FFI","C-INLINE"),args, reverse! argtypes,
+	                   rettype, callTemplate(op',#args,s), bfInert '"ONE-LINER", true]
+	    not managed => [["DEFUN",op, args, callForm]]
+	    p := gensym()
+	    decode := [bfColonColon("FFI","CONVERT-FROM-FOREIGN-STRING"), p]
+	    body := decode
+	    if release ~= nil then
+	      body := ["UNWIND-PROTECT", decode,
+	                 [bfColonColon("FFI","C-INLINE"), [p], [bfInert '"POINTER-VOID"],
+	                   bfInert '"VOID", strconc(symbolName release,'"((char*)(#0))"),
+	                     bfInert '"ONE-LINER", true]]
+	    if nullable then
+	      body := ["IF", [bfColonColon("FFI","NULL-POINTER-P"), p], nil, body]
+	    [["DEFUN",op, args, ["LET",[[p,callForm]], body]]]
 	  callTemplate(op,n,s) ==
 	    "strconc"/[symbolName op,'"(",
 	      :[sharpArg(i,x) for i in 0..(n-1) for x in s],'")"]
@@ -1788,7 +1877,7 @@ genECLnativeTranslation(op,s,t,op') ==
             c is "pointer" => '""
             coreError '"unknown type constructor"
 
-genCLISPnativeTranslation(op,s,t,op') ==
+genCLISPnativeTranslation(op,s,t,op',release) ==
   -- check parameter types and return types.
   rettype := nativeReturnType t
   argtypes := [nativeArgumentType x for x in s]
@@ -1806,6 +1895,13 @@ genCLISPnativeTranslation(op,s,t,op') ==
   -- them back.  Ugh.  
   n := makeSymbol strconc(symbolName op, '"%clisp-hack")
   parms := [gensym '"parm" for x in s]  -- parameters of the forward decl.
+
+  -- An owned `string' return is decoded from a raw pointer which is then
+  -- handed to the named release function.  (CLISP's own `ffi:c-string'
+  -- already maps a null pointer to NIL, so a nullable non-owned return
+  -- needs no special handling here.)
+  maybeBaseType t = "string" and release ~= nil =>
+    genCLISPownedStringReturn(op,op',parms,argtypes,release,maybeType? t)
 
   -- Now, separate non-simple data from the rest.  This is a triple-list
   -- of the form ((parameter boot-type . ffi-type) ...)
@@ -1858,8 +1954,39 @@ genCLISPnativeTranslation(op,s,t,op') ==
 getCLISPType a ==
   [bfColonColon("FFI","C-ARRAY"), #a]
 
+++ Generate the CLISP translation of an owned (and possibly nullable)
+++ `string'-returning foreign call.  The foreign call yields a raw pointer
+++ whose pointed-to storage we decode into a fresh Lisp string before
+++ handing the pointer to the named release function.
+genCLISPownedStringReturn(op,op',parms,argtypes,release,nullable) ==
+  callHack := makeSymbol strconc(symbolName op, '"%clisp-call")
+  releaseHack := makeSymbol strconc(symbolName op, '"%clisp-release")
+  callDecl :=
+    [bfColonColon("FFI","DEF-CALL-OUT"),callHack,
+      [bfInert '"NAME",symbolName op'],
+      [bfInert '"ARGUMENTS",:[[a, x] for x in argtypes for a in parms]],
+      [bfInert '"RETURN-TYPE", bfColonColon("FFI","C-POINTER")],
+      [bfInert '"LANGUAGE",bfInert '"STDC"]]
+  releaseDecl :=
+    [bfColonColon("FFI","DEF-CALL-OUT"),releaseHack,
+      [bfInert '"NAME",symbolName release],
+      [bfInert '"ARGUMENTS",[gensym '"loc", bfColonColon("FFI","C-POINTER")]],
+      [bfInert '"RETURN-TYPE", nil],
+      [bfInert '"LANGUAGE",bfInert '"STDC"]]
+  $foreignsDefsForCLisp := [callDecl,releaseDecl,:$foreignsDefsForCLisp]
+  p := gensym()
+  decode := [bfColonColon("FFI","MEMORY-AS"), p,
+              [bfColonColon("FFI","PARSE-C-TYPE"),
+                ["QUOTE", bfColonColon("FFI","C-STRING")]]]
+  body := ["UNWIND-PROTECT", decode, [releaseHack, p]]
+  if nullable then
+    body := ["IF",
+              ["ZEROP", [bfColonColon("FFI","FOREIGN-ADDRESS-UNSIGNED"), p]],
+                nil, body]
+  [["DEFUN",op,parms, ["LET",[[p,[callHack,:parms]]], body]]]
 
-genSBCLnativeTranslation(op,s,t,op') ==    
+
+genSBCLnativeTranslation(op,s,t,op',release) ==    
   -- check return type and argument types.
   rettype := nativeReturnType t
   argtypes := [nativeArgumentType x for x in s]
@@ -1873,7 +2000,13 @@ genSBCLnativeTranslation(op,s,t,op') ==
       unstableArgs := [a,:unstableArgs]
   
   op' := symbolName op'
-    
+
+  -- A `string' return that is owned (carries a release) or nullable
+  -- (%Maybe) is decoded from a raw pointer, so it can be freed and/or
+  -- guarded against a NULL result.
+  managedStringReturn?(t,release) =>
+    genSBCLownedStringReturn(op,args,newArgs,unstableArgs,argtypes,op',release,maybeType? t)
+
   unstableArgs = nil =>
     [["DEFUN",op,args,
       [makeSymbol('"ALIEN-FUNCALL",'"SB-ALIEN"),
@@ -1887,8 +2020,40 @@ genSBCLnativeTranslation(op,s,t,op') ==
 
 
 
+++ Generate an SBCL `string'-returning foreign call that owns its result
+++ (when `release' is non-nil) and/or may return a null pointer (when
+++ `nullable').  The raw pointer is decoded into a fresh Lisp string; an
+++ owned result is freed with an UNWIND-PROTECT cleanup, and a nullable
+++ result yields NIL for a NULL pointer.
+genSBCLownedStringReturn(op,args,newArgs,unstableArgs,argtypes,cname,release,nullable) ==
+  sap := bfColonColon("SB-SYS","SYSTEM-AREA-POINTER")
+  call :=
+    unstableArgs = nil =>
+      [makeSymbol('"ALIEN-FUNCALL",'"SB-ALIEN"),
+        [makeSymbol('"EXTERN-ALIEN",'"SB-ALIEN"), cname,
+          ["FUNCTION",sap,:argtypes]], :args]
+    [bfColonColon("SB-SYS","WITH-PINNED-OBJECTS"), reverse! unstableArgs,
+      [makeSymbol('"ALIEN-FUNCALL",'"SB-ALIEN"),
+        [makeSymbol('"EXTERN-ALIEN",'"SB-ALIEN"), cname,
+          ["FUNCTION",sap,:argtypes]], :reverse! newArgs]]
+  p := gensym()
+  decode := [makeSymbol('"C-STRING-TO-STRING",'"SB-ALIEN"), p,
+              [makeSymbol('"DEFAULT-EXTERNAL-FORMAT",'"SB-IMPL")],
+                ["QUOTE","CHARACTER"]]
+  body := decode
+  if release ~= nil then
+    body := ["UNWIND-PROTECT", decode,
+              [makeSymbol('"ALIEN-FUNCALL",'"SB-ALIEN"),
+                [makeSymbol('"EXTERN-ALIEN",'"SB-ALIEN"), symbolName release,
+                  ["FUNCTION",bfColonColon("SB-ALIEN","VOID"),sap]], p]]
+  if nullable then
+    body := ["IF",
+              [bfColonColon("SB-SYS","SAP="), p, [bfColonColon("SB-SYS","INT-SAP"), 0]],
+                nil, body]
+  [["DEFUN",op,args, ["LET",[[p,call]], body]]]
+
 ++ Generate Clozure CL's equivalent of import declaration
-genCLOZUREnativeTranslation(op,s,t,op') ==
+genCLOZUREnativeTranslation(op,s,t,op',release) ==
   -- check parameter types and return types.
   rettype := nativeReturnType t
   argtypes := [nativeArgumentType x for x in s]
@@ -1918,10 +2083,27 @@ genCLOZUREnativeTranslation(op,s,t,op') ==
                     p' := objectAssoc(p, aryPairs) => rest p'
                     p
 
-  -- If the foreign call returns a C-string, turn it into a Lisp string.
-  -- Note that if the C-string was malloc-ed, this will leak storage.
-  if t is "string" then
-    call := [bfColonColon("CCL","%GET-CSTRING"), call]
+  -- Decode a C-string result into a fresh Lisp string.  An owned result
+  -- (`release' is non-nil) is handed to the named release function under
+  -- an UNWIND-PROTECT cleanup; a nullable result (a `%Maybe' return)
+  -- decodes a null pointer as NIL.
+  nullable := maybeType? t
+  if maybeBaseType t = "string" then
+    if release ~= nil or nullable then
+      ptr := gensym()
+      body := [bfColonColon("CCL","%GET-CSTRING"), ptr]
+      if release ~= nil then
+        relName := symbolName release
+        if %hasFeature bfInert '"DARWIN" then
+          relName := strconc('"__", relName)
+        body := ["UNWIND-PROTECT", body,
+                  [bfColonColon("CCL","EXTERNAL-CALL"), relName,
+                    bfInert '"ADDRESS", ptr, bfInert '"VOID"]]
+      if nullable then
+        body := ["IF", [bfColonColon("CCL","%NULL-PTR-P"), ptr], nil, body]
+      call := ["LET", [[ptr, call]], body]
+    else
+      call := [bfColonColon("CCL","%GET-CSTRING"), call]
 
   -- If we have array arguments from Boot, bind pointers to initial data.
   for arg in aryPairs repeat
@@ -1943,17 +2125,27 @@ $ffs := nil
 ++ Generate an import declaration for `op' as equivalent of the
 ++ foreign signature `sig'.  Here, `foreign' operationally means that
 ++ the entity is from the C language world. 
-genImportDeclaration(op, sig, dom) ==
+++ Look up the value of foreign import property `name' (a string) in the
+++ property association list `props', or nil if the property is absent.
+foreignProperty(name,props) ==
+  props = nil => nil
+  [k,v] := first props
+  symbolName k = name => v
+  foreignProperty(name,rest props)
+
+genImportDeclaration(op, sig, props) ==
   sig isnt ["%Signature", op', m] => coreError '"invalid signature"
   m isnt ["%Mapping", t, s] => coreError '"invalid function type"
   if s ~= nil and symbol? s then s := [s]
   $ffs := [op,:$ffs]
-  if dom is ["%LoadUnit",lib] and not symbolMember?(lib,$foreignLoadUnits) then
+  lib := foreignProperty('"library",props)
+  if lib ~= nil and not symbolMember?(lib,$foreignLoadUnits) then
     $foreignLoadUnits := [lib,:$foreignLoadUnits]
+  release := foreignProperty('"release",props)
 
-  %hasFeature bfInert '"GCL" => genGCLnativeTranslation(op,s,t,op')
-  %hasFeature bfInert '"SBCL" => genSBCLnativeTranslation(op,s,t,op')
-  %hasFeature bfInert '"CLISP" => genCLISPnativeTranslation(op,s,t,op')
-  %hasFeature bfInert '"ECL" => genECLnativeTranslation(op,s,t,op')
-  %hasFeature bfInert '"CLOZURE" => genCLOZUREnativeTranslation(op,s,t,op')
+  %hasFeature bfInert '"GCL" => genGCLnativeTranslation(op,s,t,op',release)
+  %hasFeature bfInert '"SBCL" => genSBCLnativeTranslation(op,s,t,op',release)
+  %hasFeature bfInert '"CLISP" => genCLISPnativeTranslation(op,s,t,op',release)
+  %hasFeature bfInert '"ECL" => genECLnativeTranslation(op,s,t,op',release)
+  %hasFeature bfInert '"CLOZURE" => genCLOZUREnativeTranslation(op,s,t,op',release)
   fatalError '"import declaration not implemented for this Lisp"

--- a/src/boot/ast.boot
+++ b/src/boot/ast.boot
@@ -1752,7 +1752,8 @@ genGCLnativeTranslation(op,s,t,op',release) ==
     cop := strconc(symbolName op','"__stub")
     cargs := [mkCArgName i for i in 0..(#s - 1)]
     ccode := 
-      "strconc"/[gclTypeInC t, '" ", cop, '"(",
+      "strconc"/['"extern ", gclTypeInC t, '" ", symbolName op', '"(); ",
+         gclTypeInC t, '" ", cop, '"(",
 	 :[cparm(x,a) for x in tails s for a in tails cargs],
 	   '") { ", (t isnt "void" => '"return "; ""),
 	     symbolName op', '"(",
@@ -1795,7 +1796,9 @@ genGCLownedStringReturn(op,s,t,op',release,nullable) ==
     cop := strconc(symbolName op','"__stub")
     cargs := [mkCArgName i for i in 0..(#s - 1)]
     ccode :=
-      "strconc"/['"object ", cop, '"(",
+      "strconc"/['"extern char* ", symbolName op', '"(); ",
+        (release ~= nil => strconc('"extern void ", symbolName release, '"(); "); '""),
+        '"object ", cop, '"(",
         :[cparm(x,a) for x in tails s for a in tails cargs],
         '") { char *p = ", symbolName op', '"(",
         :[gclArgsInC(x,a) for x in tails s for a in tails cargs],

--- a/src/boot/parser.boot
+++ b/src/boot/parser.boot
@@ -530,29 +530,74 @@ bpProvenance ps ==
     bpPush(ps,%LoadUnit lib)
   bpPush(ps,nil)
 
-++ Parse a module import, or a import declaration for a foreign entity.
+++ Parse a module import, or an import declaration for a foreign entity.
 ++ Import:
-++    IMPORT Signature FOR Name
-++    IMPORT Signature IN Application FOR Name
+++    IMPORT Name ( ArgtypeList ) : Type [ WITH PropertyList ] == Name
 ++    IMPORT Name
 ++    IMPORT NAMESPACE LongName
+++ A foreign function import binds the logical Boot name on the left of
+++ `==' to the foreign entity named on its right.  Optional properties
+++ express the ownership contract of the binding, e.g. `with release: c_free'.
 bpImport ps ==
   bpEqKey(ps,"IMPORT") =>
     bpEqKey(ps,"NAMESPACE") =>
       bpLeftAssoc(ps,'(DOT),function bpName) and
         bpPush(ps,%Import bfNamespace bpPop1 ps)
           or bpTrap ps
-    a := bpState ps
     bpRequire(ps,function bpName)
-    bpEqPeek(ps,"COLON") =>
-      bpRestore(ps,a)
-      bpRequire(ps,function bpSignature)
-      bpProvenance ps
-      bpEqKey(ps,"FOR") or bpTrap ps
-      bpRequire(ps,function bpName)
-      bpPush(ps,%ImportSignature(bpPop1 ps, bpPop2 ps, bpPop1 ps))
+    bpEqPeek(ps,"OPAREN") =>
+      bpForeignImport ps
     bpPush(ps,%Import bpPop1 ps)
   false
+
+++ Parse the tail of a foreign function import, after the logical name:
+++    ( ArgtypeList ) : Type [ WITH PropertyList ] == Name
+++ The logical name has already been pushed onto the parser stack.
+bpForeignImport ps ==
+  (bpParenthesized(ps,function bpArgtypeList) or bpTrap ps) and
+    (bpEqKey(ps,"COLON") or bpTrap ps) and
+      bpRequire(ps,function bpApplication) and
+        bpForeignProperties ps and
+          (bpEqKey(ps,"DEF") or bpTrap ps) and
+            bpRequire(ps,function bpName) and
+              bpPushForeignImport ps
+
+++ Assemble a %ImportSignature node from the foreign import components left
+++ on the parser stack: name, argtypes, result, properties, cname.
+bpPushForeignImport ps ==
+  cname := bpPop1 ps
+  properties := bpPop1 ps
+  result := bpPop1 ps
+  argtypes := bpPop1 ps
+  name := bpPop1 ps
+  bpPush(ps,%ImportSignature(name,
+            %Signature(cname,%Mapping(result,bfUntuple argtypes)),
+            properties))
+
+++ Parse an optional foreign import property clause:
+++    WITH PropertyList
+++ Always leaves a (possibly empty) property association list on the stack.
+bpForeignProperties ps ==
+  bpEqKey(ps,"WITH") => bpRequire(ps,function bpForeignPropertyList)
+  bpPush(ps,nil)
+
+++ PropertyList:
+++    Property
+++    Property , PropertyList
+bpForeignPropertyList ps ==
+  bpForeignProperty ps =>
+    bpEqKey(ps,"COMMA") =>
+      bpRequire(ps,function bpForeignPropertyList) and
+        bpPush(ps,[bpPop2 ps,:bpPop1 ps])
+    bpPush(ps,[bpPop1 ps])
+  false
+
+++ Property:
+++    Name : Name
+bpForeignProperty ps ==
+  bpName ps and (bpEqKey(ps,"COLON") or bpTrap ps) and
+    bpRequire(ps,function bpName) and
+      bpPush(ps,[bpPop2 ps,bpPop1 ps])
 
 ++
 ++ Namespace:

--- a/src/boot/translator.boot
+++ b/src/boot/translator.boot
@@ -457,8 +457,8 @@ translateToplevel(ps,b,export?) ==
         bootImport symbolName m
       [["IMPORT-MODULE", symbolName m]]
 
-    %ImportSignature(x, sig, dom) =>
-      genImportDeclaration(x, sig, dom)
+    %ImportSignature(x, sig, props) =>
+      genImportDeclaration(x, sig, props)
 
     %TypeAlias(lhs, rhs) => [genTypeAlias(lhs,rhs)]
 

--- a/src/include/cfuns.h
+++ b/src/include/cfuns.h
@@ -52,6 +52,7 @@ OPENAXIOM_C_EXPORT int oa_unlink(const char*);
 OPENAXIOM_C_EXPORT int oa_rename(const char*, const char*);
 OPENAXIOM_C_EXPORT const char* oa_acquire_temporary_pathname();
 OPENAXIOM_C_EXPORT void oa_release_temporary_pathname(const char*);
+OPENAXIOM_C_EXPORT void oa_release_storage(const char*);
 OPENAXIOM_C_EXPORT int oa_mkdir(const char*);
 OPENAXIOM_C_EXPORT int oa_system(const char*);
 OPENAXIOM_C_EXPORT char* oa_getenv(const char*);

--- a/src/interp/boot-pkg.lisp
+++ b/src/interp/boot-pkg.lisp
@@ -36,6 +36,11 @@
   #+:common-lisp (:use "COMMON-LISP")
   #-:common-lisp (:use "LISP")
   #+:SBCL (:use "SB-ALIEN")
+  ;; In ANSI mode, GCL's CLINES/DEFENTRY (emitted by the foreign function
+  ;; code generators) are not present in COMMON-LISP; they live in the
+  ;; CLTL1-COMPAT extension package.  In traditional mode they come from
+  ;; the LISP package used above.
+  #+(and :gcl :common-lisp) (:use "CLTL1-COMPAT")
   (:use "AxiomCore" "BOOTTRAN"))
 
 (in-package "BOOT")

--- a/src/interp/hash.lisp
+++ b/src/interp/hash.lisp
@@ -59,21 +59,6 @@
         #'(lambda (key val) (declare (ignore val)) (push key keys)) table)
         keys))
 
-#+AKCL
-(clines "int mem_value(x ,i)object x;int i; { return ((short *)x)[i];}")
-#+AKCL
-(defentry memory-value-short(object int) (int "mem_value"))
-
-;(memory-value-short  (make-hash-table :test 'equal) 12) is 0,1,or 2
-;depending on whether the test is eq,eql or equal.
-#+AKCL
-(defun HASHTABLE-CLASS (table)
-  (case (memory-value-short table 12)
-        (0 'EQ)
-        (1 'EQL)
-        (2 'EQUAL)
-        (t "error unknown hash table class")))
-
 ;17.4 Searching and Updating
 
 (defun HPUT (table key value) (setf (gethash key table) value))

--- a/src/interp/sys-os.boot
+++ b/src/interp/sys-os.boot
@@ -50,17 +50,16 @@ loadSystemRuntimeCore()
 --% File System Support
 
 ++ Get a temporary pathname
-import oa__acquire__temporary__pathname: () -> string for
-  acquireTemporaryPathname
+import acquireTemporaryPathname(): string with release: oa__release__temporary__pathname == oa__acquire__temporary__pathname
 
 ++ Current working directory
-import oa__getcwd: () -> string for doGetWorkingDirectory
+import doGetWorkingDirectory(): string with release: oa__release__storage == oa__getcwd
 
 getWorkingDirectory() ==
   ensureTrailingSlash doGetWorkingDirectory()
 
 ++ Copy a file.
-import oa__copy__file: (string,string) -> int for doCopyFile
+import doCopyFile(string, string): int == oa__copy__file
        -- 0: success
        -- otherwise: error.
 
@@ -69,60 +68,57 @@ copyFile(src,dst) ==
   systemError ['"Could not copy file",:bright src,'"to",:bright dst]
 
 ++ change current working directory.
-import oa__chdir: string -> int for changeDirectory
+import changeDirectory(string): int == oa__chdir
        -- 0: success, -1: failure
   
 ++ remove file or directory tree.
-import oa__unlink: string -> int for removeFile
+import removeFile(string): int == oa__unlink
        -- 0: sucess, -1: failure
 
 ++ rename file or directory
-import oa__rename: (string,string) -> int for renameFile
+import renameFile(string, string): int == oa__rename
        -- 0: success, -1 failure
 
 ++ create a directory
-import oa__mkdir: string -> int for mkdir
+import mkdir(string): int == oa__mkdir
        -- 0: sucess, -1: failure.
 
 ++ Test whether a path names a directory.
-import directoryp: string -> int for directoryp
+import directoryp(string): int == directoryp
        -- -1: path does not exist or access denied
        --  0: path exists but is not directory
        --  1: path designates directory
 
 ++ Test whether a file exists and is accessible for read.
-import readablep: string -> int for readablep
+import readablep(string): int == readablep
        -- -1: inexistent.
        --  0: exist but read access denied.
        --  1: exist and read accress granted.
   
 ++ Test whether a file exists and is accessible for write.
-import writeablep: string -> int for writeablep
+import writeablep(string): int == writeablep
        -- -1: inexistent.
        --  0: exists but write access denied
        --  1: exists and write access granted
        --  2: inexistent but write access to parent directory granted.
 
-import oa__filedesc__read: (int,writeonly buffer byte,int) -> int 
-  for readFromFileHandle
+import readFromFileHandle(int, writeonly buffer byte, int): int == oa__filedesc__read
        -- -1: failure; otherwise
        -- actual read bytes count
 
-import oa__filedesc__write: (int,readonly buffer byte,int) -> int 
-  for writeToFileHandle
+import writeToFileHandle(int, readonly buffer byte, int): int == oa__filedesc__write
        -- -1: failure; otherwise
        -- actual written bytes count
 
-import oa__filedesc__close: int -> int for closeFileHandle
+import closeFileHandle(int): int == oa__filedesc__close
        -- -1: failure; otherwise 0.
 
-import oa__getenv: string -> string for getEnv
+import getEnv(string): %Maybe string == oa__getenv
   
 
 --% Local IPC socket support
 
-import oa__open__local__client__stream__socket: string -> int 
-  for openLocalClientStreamSocket
+import openLocalClientStreamSocket(string): int == oa__open__local__client__stream__socket
        -- -1: failure
 
 --% INET socket stream support
@@ -133,75 +129,67 @@ import oa__open__local__client__stream__socket: string -> int
 ++    -1: failure
 ++     0: success
 ++ Note that at the moment, only IP4 is supported.
-import oa__inet__pton: (string, int, writeonly buffer byte) -> int
-  for presentationToNumeric
+import presentationToNumeric(string, int, writeonly buffer byte): int == oa__inet__pton
 
 ++ Try to resolve a network hostname to its IP address.  On success,
 ++ return 0, otherwise -1.  The IP address is written into the 
 ++ third argument.
-import oa__get__host__address: (string, int, writeonly buffer byte) -> int
-  for hostnameToNumeric
+import hostnameToNumeric(string, int, writeonly buffer byte): int == oa__get__host__address
 
 ++ Try to establish a client TCP/IP socket connection.  The IP numeric
 ++ address is specified by the first argument; second argument is the
 ++ version of IP used (4 or 6); third argument is the desired port.
 ++ Return -1 on failure, otherwise the file descriptor corresponding
 ++ to the obtained client socket.
-import oa__connect__ip__port__stream: (readonly buffer byte,int,int) -> int
-  for doConnectToHostAndPort
+import doConnectToHostAndPort(readonly buffer byte, int, int): int == oa__connect__ip__port__stream
 
 ++ Try to read bytes of data from socket.  
 ++    Return -1 for failure; number of read bytes, otherwise.
-import oa__socket__read: (int,writeonly buffer byte,int) -> int 
-  for readFromStreamSocket
+import readFromStreamSocket(int, writeonly buffer byte, int): int == oa__socket__read
 
 ++ Try read a byte socket from a socket.  
 ++ Return -1 on failure; byte read, otherwise.
-import oa__socket__read__byte: int -> int
-  for doReadByteFromStreamSocket
+import doReadByteFromStreamSocket(int): int == oa__socket__read__byte
   
 ++ Try to write bytes of data to socket.
 ++    Return -1 on failure; actual bytes written, otherwise.
-import oa__socket__write: (int,readonly buffer byte,int) -> int 
-  for writeToStreamSocket
+import writeToStreamSocket(int, readonly buffer byte, int): int == oa__socket__write
 
 ++ Try to write a byte to socket.
 ++   Return -1 on failure; the written byte, otherwise.
-import oa__socket__write__byte: (int,int) -> int
-  for doWriteByteToStreamSocket
+import doWriteByteToStreamSocket(int, int): int == oa__socket__write__byte
 
-import oa__close__socket: int -> int for closeSocket
+import closeSocket(int): int == oa__close__socket
 
 --% OpenAxiom subsystem socket support
 
 ++ socket interface
-import open__server: string -> int for openServer
+import openServer(string): int == open__server
 
-import sock__get__int: int -> int for sockGetInt
+import sockGetInt(int): int == sock__get__int
 
-import sock__send__int: (int,int) -> int for sockSendInt
+import sockSendInt(int, int): int == sock__send__int
 
-import sock__get__string: int -> string for sockGetString
+import sockGetString(int): string == sock__get__string
 
-import sock__send__string__len: (int, string, int) -> int
-  for doSendString
+import doSendString(int, string, int): int == sock__send__string__len
 
 sockSendString(type,str) ==
   doSendString(type, str, # str)
 
-import sock__get__float: int -> double for sockGetFloat
+import sockGetFloat(int): double == sock__get__float
 
-import sock__send__float: (int,double) -> int for sockSendFloat
+import sockSendFloat(int, double): int == sock__send__float
 
-import sock__send__wakeup: (int,int) -> int for sockSendWakeup
+import sockSendWakeup(int, int): int == sock__send__wakeup
 
-import server__switch: () -> int for serverSwitch
+import serverSwitch(): int == server__switch
 
-import sock__send__signal: (int,int) -> int for sockSendSignal
+import sockSendSignal(int, int): int == sock__send__signal
 
 --%
 
-import oa__system: string -> int for runCommand
+import runCommand(string): int == oa__system
 
 ++ run a program with specified arguments
 runProgram(prog,args) ==
@@ -218,12 +206,12 @@ runProgram(prog,args) ==
   
 ++ numeric limits
 
-import quiet__double__NaN: () -> double for quietDoubleNaN
+import quietDoubleNaN(): double == quiet__double__NaN
 
 )if %hasFeature %Inert::GCL
-import plus__infinity: () -> double for plusInfinity
+import plusInfinity(): double == plus__infinity
 
-import minus__infinity: () -> double for minusInfinity
+import minusInfinity(): double == minus__infinity
 
 $plusInfinity := plusInfinity()
 $minusInfinity := minusInfinity()
@@ -251,7 +239,7 @@ minusInfinity() ==
 ++ stdStreamIsTerminal:
 ++   returns 1 if the standard stream is attached to a terminal;
 ++   otherwise 0.
-import  std__stream__is__terminal: int -> int for stdStreamIsTerminal
+import stdStreamIsTerminal(int): int == std__stream__is__terminal
 
 --% Data layout
 
@@ -260,4 +248,4 @@ import  std__stream__is__terminal: int -> int for stdStreamIsTerminal
 ++   0: unknown
 ++   1: little endian
 ++   2: big endian
-import oa__get__host__byteorder: () -> int for getHostByteOrder
+import getHostByteOrder(): int == oa__get__host__byteorder

--- a/src/lib/cfuns-c.cxx
+++ b/src/lib/cfuns-c.cxx
@@ -549,6 +549,14 @@ oa_release_temporary_pathname(const char* s)
    free(const_cast<char*>(s));  // yuck!
 }
 
+/* Release storage returned by an OpenAxiom runtime function that
+   transfers ownership to the caller, e.g. the string from oa_getcwd.  */
+OPENAXIOM_C_EXPORT void
+oa_release_storage(const char* s)
+{
+   free(const_cast<char*>(s));
+}
+
 /* Rename a file or directory.  */
 OPENAXIOM_C_EXPORT int
 oa_rename(const char* old_path, const char* new_path)

--- a/src/lisp/core.lisp.in
+++ b/src/lisp/core.lisp.in
@@ -1240,13 +1240,6 @@
   #-:ecl (compile-file-pathname file)
   #+:ecl (compile-file-pathname file :type :object))
 
-(defun |currentDirectoryName| nil
-  (let* ((dir (namestring (truename "")))
-         (n (1- (length dir))))
-    (if (char= (char dir n) #\/)
-        (subseq dir 0 n)
-      dir)))    
-
 ;; Compile Lisp source files to target object code.  Most of the time
 ;; this function is called externally to accomplish just that: compile
 ;; a Lisp file.  So, by default, we exit the read-eval-print loop after
@@ -1277,7 +1270,7 @@
           (setq out-file 
                 (make-pathname :name (pathname-name out-file)
                                :type (pathname-type out-file)
-                               :directory (list (|currentDirectoryName|)))))
+                               :directory (pathname-directory (truename "")))))
   (unwind-protect
       (progn
 	(|startCompileDuration|)

--- a/src/lisp/core.lisp.in
+++ b/src/lisp/core.lisp.in
@@ -55,6 +55,12 @@
   ;; image obtained from compiler link will not work.  The root cause
   ;; is a non-ANSI compliant organization of GCL's implementation.
   #+:gcl (:use "DEFPACKAGE")
+  ;; In ANSI mode, GCL's native-interface vocabulary -- in particular the
+  ;; C type designators INT, DOUBLE, VOID used by $NativeTypeTable and the
+  ;; foreign function code generators -- is not present in COMMON-LISP; it
+  ;; lives in the CLTL1-COMPAT extension package.  In traditional mode it
+  ;; comes from the LISP package used above.
+  #+(and :gcl :common-lisp) (:use "CLTL1-COMPAT")
   ;; Clozure CL sequesters most of its useful extensions, in particular
   ;; threads, in the CCL package.
   ;; #+:clozure (:use "CCL")

--- a/src/lisp/core.lisp.in
+++ b/src/lisp/core.lisp.in
@@ -1054,14 +1054,15 @@
 ;; Command line arguments: equivalent of traditional `argv[]' from
 ;;  systems programming world.
 (defun |getCommandLineArguments| nil
-  #-(or :gcl :sbcl :clisp :ecl :clozure) 
+  #-(or :gcl :sbcl :clisp :ecl :clozure :gaia) 
   (|fatalError| "don't know how to get command line args")
   (let* ((all-args  
 	  #+:clozure ccl:*command-line-argument-list*
           #+:ecl (ext:command-args)
           #+:gcl si::*command-args*
           #+:sbcl sb-ext::*posix-argv*
-          #+:clisp (coerce (ext::argv) 'list))
+          #+:clisp (coerce (ext::argv) 'list)
+          #+:gaia (gaia:command-line-arguments))
          (args (member "--" all-args :test #'equal)))
     (cons (car all-args) (if args (cdr args) args))))
 
@@ -1081,11 +1082,21 @@
 			  &optional (entry-point nil) (prologue nil))
   (if (and entry-point (stringp entry-point))
       (setq entry-point `(read-from-string ,entry-point)))
-  #-:ecl 
+  #-(or :ecl :gaia) 
   (progn
     (mapcar #'(lambda (p) (|loadOrElse| p)) lisp-files)
     (eval prologue)
     (|saveCore| core-image entry-point))
+  #+:gaia
+  (progn
+    ;; Gaia links a fresh executable from the supplied FASLs, so resolve
+    ;; the entry-point suspension before handing it to the builder.
+    (when (consp entry-point)
+      (setq entry-point (apply (car entry-point) (cdr entry-point))))
+    (gaia:build-program core-image
+                        :fasls lisp-files
+                        :entry-point entry-point)
+    (|coreQuit|))
   #+:ecl 
   (let* ((compiler::*ld* oa-cxx)
 	 (compiler::*ld-flags* (concatenate 'string 

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -239,6 +239,12 @@ build_rts_options(Command* command, Driver driver)
          command->rt_args[1] = (char*) "-norc";
          break;
 
+      case Runtime::gaia:
+         // Gaia images embed their entry point and read every argument
+         // following the doubledash separator, so they need no runtime
+         // options of their own.
+         break;
+
       default:
          abort();
       }


### PR DESCRIPTION
## Foreign string return ownership and nullability

A foreign function returning a C string can now declare that the callee owns the result (`with release: <fn>`) and/or that it is nullable (a `%Maybe` return). The result is decoded into a fresh Lisp string; an owned result is freed through the named release function under an `unwind-protect`, and a nullable result yields `NIL` for a null pointer.

The parser accepts the new signature, the translator dispatches on it, and the code generators for all five Boot back ends emit the matching form:

- **SBCL** — `extern-alien` SAP + `unwind-protect` `c-string-to-string`; `sap=`/`int-sap` guard
- **CLISP** — `def-call-out` returning `c-pointer` + `ffi:memory-as`; separate release `def-call-out`
- **ECL** — `c-inline :pointer-void` + `convert-from-foreign-string`; `si:null-pointer-p` guard
- **Clozure** — `external-call :address` + `%get-cstring`; `%null-ptr-p` guard
- **GCL** — a `CLINES` C stub that copies with `make_simple_string`; `if (p == 0) return Cnil`

`src/interp/sys-os.boot` is migrated to the new syntax, and `src/lib/cfuns-c.cxx` gains `oa_release_storage` for the owning `getcwd` path.

## Also included

- **config/open-axiom.m4**: add the missing `;;` to the `gaia)` arm of the `$oa_lisp_flavor` case (without it the regenerated `configure` case is a syntax error for every flavor). The generated `configure` is intentionally left untouched to avoid autotools-version churn.
- **CI**: a GCL job that builds the full system via Autotools with GCL **2.6.x** (version asserted). GCL 2.7 cannot compile the Boot translator's nested-`(FUNCTION ...)` `DECLAIM FTYPE` forms, and the CMake migration does not yet build under GCL.

This branch builds on the "Support Gaia as a base Lisp" commit, which is part of the diff.

Verified by translating `sys-os.boot` under each host and compiling (and, where possible, running) the generated stubs on SBCL, CLISP, ECL 24.5, Clozure 1.13, and GCL 2.6.14.

Assisted By: Claude Opus 4.8