### PR TITLE
Fix --build-initdb and --build-databases under GCL

### DIFF
--- a/src/interp/daase.lisp
+++ b/src/interp/daase.lisp
@@ -414,7 +414,9 @@
  (browseopen)
  (setq *category-stream-stamp* '(0 . 0))
  (categoryopen) ;note: this depends on constructorform in browse.daase
-#+:AKCL (gbc t)
+ ;; Reference GCL's garbage collector by its home package: in the BOOT
+ ;; package a bare GBC reads as an unbound BOOT::GBC under ANSI mode.
+#+:AKCL (system::gbc t)
 )
 
 
@@ -635,6 +637,11 @@
     (format t "getdatabase call: ~20a ~a~%" constructor key))
   (let (data table stream ignore struct)
     (declare (ignore ignore))
+    ;; Normalize the OBJECT key: under GCL ANSI it may reach us as BOOT::OBJECT
+    ;; while the CASE forms below dispatch on SYSTEM::OBJECT (the foreign C type).
+    #+(and :gcl :common-lisp)
+    (when (and (symbolp key) (string= (symbol-name key) "OBJECT"))
+      (setq key 'object))
     (when (or (symbolp constructor)
 	      (and (eq key 'hascategory) (consp constructor)))
       (let ((struct (and (symbolp constructor) (|constructorDB| constructor))))
@@ -901,6 +908,11 @@
 	      (concat root ".daase"))
   )
  (let ((ancestors-table (make-hash-table :test #'eq))
+       ;; GCL's top level leaves *print-level* and *print-length* bound to a
+       ;; small value in the saved image; bind them off so the databases are
+       ;; serialized in full rather than abbreviated with # and `...'.
+       (*print-level* nil)
+       (*print-length* nil)
        d)
   (declare (special |$constructorList|))
   (do-symbols (symbol)

--- a/src/interp/g-util.boot
+++ b/src/interp/g-util.boot
@@ -306,15 +306,10 @@ bufferToVector buf ==
   v
 
 
-++ Return the name of a relative path for a directory
-++ given by the string `s',  GCL does not implement
-++ Common Lisp semantics, so we have a special version for it.
+++ Return the Common Lisp directory list naming the relative directory
+++ given by the string `s', e.g. "foo.NRLIB" -> (:relative "foo.NRLIB").
 relativeDirname s ==
-)if %hasFeature &GCL and not %hasFeature &COMMON_-LISP
-  [s]
-)else
   [&RELATIVE,s]
-)endif
 
 --% Sub-domains information handlers
 

--- a/src/interp/lisplib.boot
+++ b/src/interp/lisplib.boot
@@ -768,15 +768,8 @@ getIndexPathname dir ==
 
 getAllIndexPathnames: %String -> %List %Thing
 getAllIndexPathnames dir ==
-  -- GCL's semantics of Common Lisp's `DIRECTORY *' differs from
-  -- everybody else's.  Namely, GCL would return a
-  -- a list of drirectories AND files.  Pretty much like `ls *'.
-  -- Everybody else strips out directories.
-)if %hasFeature KEYWORD::GCL
-  [getIndexPathname filePathString d for d in DIRECTORY strconc(dir,'"*.NRLIB")]
-)else
+  -- Return the index files of all NRLIBs in `dir'.
   DIRECTORY strconc(dir,'"*.NRLIB/",$IndexFilename)
-)endif
   
 
 getAllAldorObjectFiles: %String -> %List %Thing

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -327,7 +327,7 @@ static void print_usage(void) {
       { "--compile", Driver::compiler },
       { "--translate", Driver::compiler },
       { "--build-databases", Driver::compiler },
-      { "--build-initdb", Driver::core },
+      { "--build-initdb", Driver::compiler },
       { "--make", Driver::linker },
    };
 


### PR DESCRIPTION
The GCL Autotools build could not finalize the algebra: `--build-initdb`
hung, and once that was unblocked `--build-databases` failed in several
ways before it could produce a usable constructor database. This collects
the fixes for those steps.

- **`--build-initdb` dispatch** (`command.cc`): it was classified as a
  `core` driver and so was invoked without the run-time entry arguments,
  dropping interpsys into an interactive read loop that spun on a non-tty
  stdin. Classify it as a compiler driver, like `--build-databases`.

- **NRLIB relative directory** (`g-util.boot`): `relativeDirname` produced
  a bare directory list that GCL's `make-pathname` rejects; form it as a
  standard `(:relative ...)` list, as every other Lisp already receives.

- **NRLIB discovery** (`lisplib.boot`): the GCL branch of
  `getAllIndexPathnames` globbed `*.NRLIB` without a trailing slash; modern
  GCL's `DIRECTORY` returns nothing for that, so none of the compiled
  libraries were found and the database was built from the four special
  constructors alone. Glob the index files directly.

- **Database contents** (`daase.lisp`): under ANSI GCL the `OBJECT`
  database key and the bare `GBC` collector call resolved to the wrong
  package, and the saved image's small `*print-level*`/`*print-length*`
  truncated the serialized databases. Recognize the key regardless of its
  home package, call the collector through `SYSTEM`, and bind the print
  limits off while the databases are written.

With these, `--build-databases` runs to completion under ANSI GCL and
writes complete, unabbreviated `interp`/`browse`/`category`/`operation`
databases (full signatures, no `#`/`...` markers).

A separate change supplies GCL's C compiler with `-Wno-int-conversion` so
the run-time C it generates compiles under modern GCC; the algebra has to
build before this database step is reached.

Assisted By: Claude Opus 4.8