### PR TITLE
Complete the GCL CMake build under GCC 15

### DIFF
--- a/cmake/OpenAxiomLispRuntime.cmake
+++ b/cmake/OpenAxiomLispRuntime.cmake
@@ -17,6 +17,11 @@
 #   oa_query_lisp(OUTPUT_VAR EXPRESSION <expr>)
 #   oa_set_ffi_type_table(flavor precision)
 
+# CheckCCompilerFlag provides check_c_compiler_flag(), used by
+# oa_configure_lisp_runtime to probe host C-compiler support for the GCL
+# runtime cc-flags.
+include(CheckCCompilerFlag)
+
 
 # ---------------------------------------------------------------------------
 # oa_parse_lisp_flavor -- classify a Lisp implementation from free-form text
@@ -347,6 +352,24 @@ function(oa_configure_lisp_runtime)
   oa_list_to_string(_eval_flags  ${_batch_args} ${_eval_flag})
 
   # -------------------------------------------------------------------
+  # 6b. GCL runtime C-compiler flags.
+  #     GCL compiles the algebra to C and invokes the host C compiler at
+  #     image runtime.  Modern GCC (>= 15) promotes -Wint-conversion to an
+  #     error by default, which aborts that on-the-fly compilation.  When the
+  #     C compiler accepts -Wno-int-conversion, thread it into the GCL image
+  #     (via @oa_gcl_cc_flags@ in core.lisp.in, appended to COMPILER::*CC*)
+  #     so the algebra keeps building.  Mirrors the Autotools
+  #     OPENAXIOM_SATISFY_GCL_NEEDS probe.
+  # -------------------------------------------------------------------
+  set(_gcl_cc_flags "")
+  if(_detected_flavor STREQUAL "gcl")
+    check_c_compiler_flag("-Wno-int-conversion" OA_C_ACCEPTS_WNO_INT_CONVERSION)
+    if(OA_C_ACCEPTS_WNO_INT_CONVERSION)
+      set(_gcl_cc_flags "-Wno-int-conversion")
+    endif()
+  endif()
+
+  # -------------------------------------------------------------------
   # 7. Export everything into the parent scope.
   # -------------------------------------------------------------------
 
@@ -372,6 +395,7 @@ function(oa_configure_lisp_runtime)
   set(oa_quiet_flags       "${_quiet_flags}"      PARENT_SCOPE)
   set(oa_eval_flags        "${_eval_flags}"       PARENT_SCOPE)
   set(oa_optimize_options  "${_optimize_options}"  PARENT_SCOPE)
+  set(oa_gcl_cc_flags      "${_gcl_cc_flags}"      PARENT_SCOPE)
 
   # FFI type names (substituted into core.lisp.in).
   set(void_type    "${_void_type}"    PARENT_SCOPE)

--- a/cmake/RunCommand.cmake
+++ b/cmake/RunCommand.cmake
@@ -19,11 +19,23 @@ file(STRINGS "${CMDFILE}" _lines)
 list(GET _lines 0 _prog)
 list(REMOVE_AT _lines 0)
 
-execute_process(
-  COMMAND "${_prog}" ${_lines}
-  WORKING_DIRECTORY "${WORKDIR}"
-  RESULT_VARIABLE _rc
-)
+# STDINFILE (optional) is fed to the command as standard input.  GCL's
+# compiler::link image build reads its link form this way (mirroring the
+# Autotools `| ./base-lisp`).
+if(STDINFILE)
+  execute_process(
+    COMMAND "${_prog}" ${_lines}
+    WORKING_DIRECTORY "${WORKDIR}"
+    INPUT_FILE "${STDINFILE}"
+    RESULT_VARIABLE _rc
+  )
+else()
+  execute_process(
+    COMMAND "${_prog}" ${_lines}
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE _rc
+  )
+endif()
 if(NOT _rc EQUAL 0)
   message(FATAL_ERROR "Command failed with exit code ${_rc}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,27 +427,109 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure|g
     endif()
   endif()
 
-  # -- Step 3: Link the FASL into a standalone executable image --
+  # -- Step 3: Link the base Lisp image --
   # The Lisp |..| bar-escape syntax contains pipe characters that cmd.exe
-  # interprets as shell pipes, so we write the link form to a file and
-  # --load it instead of passing it via --eval.
-  set(oa_lisp_link_script "${oa_lisp_build_dir}/link-base-lisp.lisp")
-  file(WRITE "${oa_lisp_link_script}"
-    "(load \"core\")\n(|AxiomCore|::|link| \"base-lisp${CMAKE_EXECUTABLE_SUFFIX}\" (quote ${oa_base_lisp_objects}) \"|AxiomCore|::|topLevel|\")\n")
+  # interprets as shell pipes, so link forms go through files run via
+  # cmake/RunCommand.cmake rather than a shell.
+  if(OA_LISP_FLAVOR STREQUAL "gcl")
+    # GCL resolves FASL symbol references against the running image's symbol
+    # table (sfaslelf.c relocation), not against shared libraries, so the
+    # OpenAxiom C runtime (oa_get_host_byteorder, ...) must be STATICALLY
+    # linked into the base image.  |AxiomCore|::|link| only does save-system
+    # (no C linking), so -- exactly as the Autotools src/lisp/Makefile does --
+    # build an intermediate save-system image, then use it to compiler::link
+    # core plus the C-runtime objects into the real base image.
+    #
+    # oa-gcl-c-runtime holds just the three C-runtime translation units (NOT
+    # the whole open-axiom-core, which also bundles the C++ boot translator);
+    # it is compiled with open-axiom-core's include directories and flags.
+    add_library(oa-gcl-c-runtime OBJECT
+      lib/bsdsignal.cxx
+      lib/cfuns-c.cxx
+      lib/sockio-c.cxx
+    )
+    target_include_directories(oa-gcl-c-runtime PRIVATE
+      $<TARGET_PROPERTY:open-axiom-core,INCLUDE_DIRECTORIES>)
+    target_compile_features(oa-gcl-c-runtime PRIVATE cxx_std_20)
+    oa_apply_build_flags(oa-gcl-c-runtime)
 
-  add_custom_command(
-    OUTPUT "${oa_lisp_generated_image}"
-    COMMAND ${OA_LISP_CMD}
-            ${OA_LISP_EVAL_FLAG} "(load \"link-base-lisp.lisp\")"
-    WORKING_DIRECTORY "${oa_lisp_build_dir}"
-    DEPENDS "${oa_lisp_generated_fasl}"
-    COMMENT "Link the OpenAxiom base Lisp image"
-    VERBATIM
-  )
+    set(oa_lisp_stage1_image
+      "${oa_lisp_build_dir}/base-lisp-stage1${CMAKE_EXECUTABLE_SUFFIX}")
+
+    # Stage 1: save-system intermediate image (no C runtime yet).
+    set(oa_lisp_link_script "${oa_lisp_build_dir}/link-base-lisp.lisp")
+    file(WRITE "${oa_lisp_link_script}"
+      "(load \"core\")\n(|AxiomCore|::|link| \"base-lisp-stage1${CMAKE_EXECUTABLE_SUFFIX}\" (quote nil) \"|AxiomCore|::|topLevel|\")\n")
+
+    # Stage 2: compiler::link form.  $<TARGET_OBJECTS:oa-gcl-c-runtime>
+    # resolves to the three C-runtime objects; -lstdc++/-lm satisfy the C++
+    # runtime they reference.  file(GENERATE) expands the generator
+    # expression; the stage-1 image runs this form on stdin.
+    set(oa_gcl_link_form "${oa_lisp_build_dir}/link-gcl-image.lisp")
+    file(GENERATE OUTPUT "${oa_gcl_link_form}" CONTENT
+"(compiler::link
+  '(\"core.${OA_LISP_LNK_EXT}\")
+  \"base-lisp${CMAKE_EXECUTABLE_SUFFIX}\"
+  \"(progn (when (fboundp 'si::sgc-on) (si::sgc-on nil)) (setq si::*top-level-hook* (read-from-string \\\"|AxiomCore|::|topLevel|\\\")))\"
+  \"$<JOIN:$<TARGET_OBJECTS:oa-gcl-c-runtime>, > -lstdc++ -lm\")
+(bye)
+")
+    set(oa_gcl_link_cmdfile "${oa_lisp_build_dir}/link-gcl-image.cmdfile")
+    file(GENERATE OUTPUT "${oa_gcl_link_cmdfile}"
+      CONTENT "${oa_lisp_stage1_image}\n")
+
+    add_custom_command(
+      OUTPUT "${oa_lisp_generated_image}"
+      COMMAND ${OA_LISP_CMD}
+              ${OA_LISP_EVAL_FLAG} "(load \"link-base-lisp.lisp\")"
+      COMMAND ${CMAKE_COMMAND} -E env ${OA_LISP_ENV_VARS}
+              ${CMAKE_COMMAND}
+              -DCMDFILE=${oa_gcl_link_cmdfile}
+              -DSTDINFILE=${oa_gcl_link_form}
+              -DWORKDIR=${oa_lisp_build_dir}
+              -P ${PROJECT_SOURCE_DIR}/cmake/RunCommand.cmake
+      WORKING_DIRECTORY "${oa_lisp_build_dir}"
+      DEPENDS "${oa_lisp_generated_fasl}"
+              oa-gcl-c-runtime
+      COMMENT "Link the OpenAxiom base GCL image (static C runtime)"
+      VERBATIM
+    )
+  else()
+    set(oa_lisp_link_script "${oa_lisp_build_dir}/link-base-lisp.lisp")
+    file(WRITE "${oa_lisp_link_script}"
+      "(load \"core\")\n(|AxiomCore|::|link| \"base-lisp${CMAKE_EXECUTABLE_SUFFIX}\" (quote ${oa_base_lisp_objects}) \"|AxiomCore|::|topLevel|\")\n")
+
+    add_custom_command(
+      OUTPUT "${oa_lisp_generated_image}"
+      COMMAND ${OA_LISP_CMD}
+              ${OA_LISP_EVAL_FLAG} "(load \"link-base-lisp.lisp\")"
+      WORKING_DIRECTORY "${oa_lisp_build_dir}"
+      DEPENDS "${oa_lisp_generated_fasl}"
+      COMMENT "Link the OpenAxiom base Lisp image"
+      VERBATIM
+    )
+  endif()
 
   # -- Step 4: Place Lisp artifacts into the runtime layout --
   # Only artifacts consumed by later build steps belong here.
   # Install-only files (cmake settings) are handled by install() rules.
+  #
+  # Stage the base Lisp image with add_custom_command(OUTPUT ...) -- the same
+  # pattern used for the staged bootsys below -- so the rule that produces it
+  # is resolvable in the dependency graph.  The boot and interpreter steps run
+  # it via --execpath (OA_LISPSYS) and must rebuild when its content changes
+  # (e.g. when the GCL C runtime is relinked into it); a copy hidden inside the
+  # phony stage-lisp-runtime target would not trigger that rebuild.
+  add_custom_command(
+    OUTPUT "${OA_STAGE_ROOT}/bin/lisp${CMAKE_EXECUTABLE_SUFFIX}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${oa_lisp_generated_image}"
+      "${OA_STAGE_ROOT}/bin/lisp${CMAKE_EXECUTABLE_SUFFIX}"
+    DEPENDS "${oa_lisp_generated_image}" stage-native-layout
+    COMMENT "Stage the base Lisp image"
+    VERBATIM
+  )
+
   set(oa_stage_lisp_commands
     COMMAND ${CMAKE_COMMAND} -E make_directory
       "${OA_STAGE_ROOT}/lisp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -539,9 +539,6 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure|g
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
       "${oa_lisp_generated_fasl}"
       "${OA_STAGE_ROOT}/lisp/"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      "${oa_lisp_generated_image}"
-      "${OA_STAGE_ROOT}/bin/lisp${CMAKE_EXECUTABLE_SUFFIX}"
   )
 
   # ECL needs a linkset file and the linkable object in the build layout.
@@ -562,6 +559,7 @@ if(OA_LISP_EXECUTABLE AND OA_LISP_FLAVOR MATCHES "^(gcl|ecl|sbcl|clisp|clozure|g
   add_custom_target(stage-lisp-runtime
     ${oa_stage_lisp_commands}
     DEPENDS stage-native-layout "${oa_lisp_generated_image}"
+            "${OA_STAGE_ROOT}/bin/lisp${CMAKE_EXECUTABLE_SUFFIX}"
     COMMENT "Place Lisp runtime artifacts into the build layout"
   )
 
@@ -683,7 +681,7 @@ function(oa_boot_compile_module stage module clisp_file deps)
       --load-directory=${outdir}
       "${clisp_file}"
     WORKING_DIRECTORY "${outdir}"
-    DEPENDS ${clisp_file} ${deps}
+    DEPENDS ${clisp_file} ${deps} ${OA_LISPSYS}
     COMMENT "[boot/${stage}] Compile ${module}.clisp"
     VERBATIM
   )
@@ -764,7 +762,7 @@ function(oa_boot_link_image stage fasl_list)
       -DWORKDIR=${outdir}
       -P ${PROJECT_SOURCE_DIR}/cmake/RunCommand.cmake
     WORKING_DIRECTORY "${outdir}"
-    DEPENDS ${fasl_list} stage-lisp-runtime
+    DEPENDS ${fasl_list} ${OA_LISPSYS} stage-lisp-runtime
     COMMENT "[boot/${stage}] Link bootsys image"
     VERBATIM
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1297,6 +1297,14 @@ set(oa_spad_compile_prefix
 
 set(oa_all_spadfiles "")
 
+# Ensure the destination exists before extraction.  hammer and the plain
+# copy below write whole .spad files into oa_algebra_outsrc, but nothing
+# else creates that directory (the per-constructor extraction below creates
+# its own oa_algebra_builddir).  hammer exits 0 even when it cannot open its
+# output file in a missing directory, so without this the extracts silently
+# produce nothing and initdb later fails on an empty scan directory.
+file(MAKE_DIRECTORY "${oa_algebra_outsrc}")
+
 # -- Pamphlets: extract whole file via hammer --
 foreach(spad ${OA_ALGEBRA_PAMPHLET_BASES})
   set(_pam "${oa_algebra_srcdir}/${spad}.spad.pamphlet")


### PR DESCRIPTION
Brings the CMake build to a working GCL-based OpenAxiom under GCC 15, following up #94 (the Autotools side). Four changes, one per commit.

**1. Pass GCL the GCC 15 C-compiler flag** (mirror of #94)

#94 added an Autotools probe (`OPENAXIOM_SATISFY_GCL_NEEDS`) that tests whether the C compiler accepts `-Wno-int-conversion` and threads it into GCL's `COMPILER::*CC*` through `core.lisp`, so GCL's runtime C compilation of the algebra survives GCC 15 (which promotes `-Wint-conversion` to an error). The CMake build generates `core.lisp` from the same template but had no matching variable, so `@oa_gcl_cc_flags@` expanded to the empty string. This adds the mirror in `oa_configure_lisp_runtime`: when the flavor is GCL and the C compiler accepts `-Wno-int-conversion` (probed with `check_c_compiler_flag`), `oa_gcl_cc_flags` is set and substituted into `core.lisp`. Non-GCL flavors and compilers that reject the flag leave it empty, exactly as before.

**2. Statically link the GCL C runtime into the base Lisp image**

GCL resolves a FASL's external symbol references against the running image's symbol table (`sfaslelf.c` relocation), not against shared libraries, so the OpenAxiom C runtime (`oa_get_host_byteorder` and the other functions the FFI imports) must be statically linked into the image. `|AxiomCore|::|link|` only does `save-system`, which is why linking interpsys failed with `Unrelocated non-local symbol: oa_get_host_byteorder`. As the Autotools `src/lisp/Makefile` does, the build now produces an intermediate save-system image and uses it to `compiler::link` core plus the three C-runtime objects (bsdsignal, cfuns-c, sockio-c) into the real base image. `RunCommand.cmake` gains an optional `STDINFILE` so the link form can be fed to the image on standard input.

**3. Make the staged Lisp image a tracked output so bootsys rebuilds**

The boot and interpreter steps run the base image via `--execpath`, but it was copied into the build layout inside a phony target. A file produced by a custom target is not a tracked `OUTPUT`, so a change that alters only the image's content (such as relinking the C runtime into it) did not rebuild bootsys/interpsys on an incremental build. The image is now staged with `add_custom_command(OUTPUT ...)` -- the pattern already used for the staged bootsys -- and the boot compile/link steps depend on it.

**4. Create the whole-file `.spad` output directory before extraction**

The whole-file `.spad` extraction writes into a directory that nothing created (the per-constructor extraction creates its own). `hammer` exits successfully even when it cannot open its output file in a missing directory, so the extracts silently produced nothing and initdb later failed scanning an empty directory. The directory is now created first, mirroring the per-constructor path.

**Verified end-to-end.** A full `-DOA_WITH_LISP=gcl` build (GCC 15, CMake 3.31.6) configures and builds to completion: native tools, the GCL base image (with the static C runtime), bootsys, interpsys (links cleanly, the symbol resolved), initdb, all algebra layers, the databases, and AXIOMsys (which starts and prints its banner). The `core.lisp` cc-flag substitution was checked for both gcl (`-Wno-int-conversion`) and sbcl (empty), and the incremental rebuild cascade was confirmed in both directions. The algebra layers are memory-sensitive under high parallelism; `-j4` builds reliably.

Assisted By: Claude Opus 4.8