### PR TITLE
Fix a latent command-line heap overflow and build the Windows CI under Release

### DIFF
--- a/.github/workflows/ci-windows-msvc-sbcl.yml
+++ b/.github/workflows/ci-windows-msvc-sbcl.yml
@@ -77,7 +77,7 @@ jobs:
           cmake -S . -B build -G Ninja `
             -DCMAKE_C_COMPILER=cl `
             -DCMAKE_CXX_COMPILER=cl `
-            -DCMAKE_BUILD_TYPE=Debug `
+            -DCMAKE_BUILD_TYPE=Release `
             -DOA_WITH_LISP=sbcl `
             -DCMAKE_INSTALL_PREFIX="${{ runner.temp }}/install"
 

--- a/src/lib/cfuns-c.cxx
+++ b/src/lib/cfuns-c.cxx
@@ -208,7 +208,7 @@ writeablep(const char* path)
       // -- The file does not exist, so check to see if the directory is writable.
       auto dir = oa_dirname(path);
       auto result = axiom_has_write_access(dir);
-      LocalFree(dir);
+      free(dir);
       return result ? 2 : -1;
    }
    return (attributes & FILE_ATTRIBUTE_READONLY) ? 0 : 1;

--- a/src/utils/command.cc
+++ b/src/utils/command.cc
@@ -483,8 +483,8 @@ execute_core(const Command* command, Driver driver)
       command_line_length += 1  /* blank char as separator */
 	 + 2			/* quotes around every argument.  */
          + strlen(command->rt_args[i]); /* room for each argument */
-   /* Don't forget room for the doubledash string.  */
-   command_line_length += sizeof("--") - 1;
+   /* Don't forget room for the separating blank and the doubledash string.  */
+   command_line_length += 1 + sizeof("--") - 1;
    /* And arguments to the actual command.  */
    for (i = 1; i < command->core.argc; ++i)
       command_line_length += 1 + 2 + strlen(command->core.argv[i]);


### PR DESCRIPTION
Switching the Windows MSVC + SBCL workflow to a Release configuration exposed a latent heap overflow that aborts the algebra bootstrap with `STATUS_HEAP_CORRUPTION` (0xC0000374) at the "Build initdb" step.

## The bug

`execute_core` sizes the child command-line buffer, then fills it. The sizing reserved `sizeof("--") - 1` == 2 bytes for the option separator, but the filling writes three bytes there: a separating blank followed by the two dashes. Every byte after the separator, including the terminating NUL, is written one position past the end of the `malloc`'d buffer.

The overrun is latent. A debug CRT heap leaves enough slack after a small allocation to absorb the stray NUL, but a Release heap packs allocations tightly and the write lands on the bookkeeping of the following block. Whether a given run trips depends on the total command-line length, e.g. the size of the `--output` path, which is why it surfaced only under the full-system Release build.

## The fix

Reserve room for the separating blank as well as the two dashes.

## A related allocator fix

The Windows `writeablep` released the `oa_dirname` result with `LocalFree`, but `oa_dirname` returns `strdup` storage (i.e. from `malloc`), which must be released with `free`. `LocalFree` pairs only with `LocalAlloc`, so the mismatch is undefined behavior on the MSVC runtime; the companion POSIX `writeablep` already uses `free`. Use `free` in the Windows branch as well.

## CI

With the overflow fixed, the full algebra strap completes cleanly under Release. Configure the workflow with `-DCMAKE_BUILD_TYPE=Release` so the native build, the interpsys image, and the algebra bootstrap are all exercised the way they ship.

Verified on Windows (MSVC, SBCL 2.6.3): `all-native`, `all-interpsys`, and `all-algstrap` all build green under Release, and the initdb step now succeeds across the full range of output-path lengths that previously crashed.

Assisted By: Claude Opus 4.8